### PR TITLE
chore: specify `resolver = "2"` in the workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
 [workspace]
-members = [
-    "crates/lib",
-]
+members = ["crates/lib"]
+resolver = "2"


### PR DESCRIPTION
Fixes the below warning:

> warning: virtual workspace defaulting to resolver = "1" despite one or more workspace members being on edition 2021 > which implies resolver = "2"
> note: to keep the current resolver, specify workspace.resolver = "1" in the workspace root's manifest
> note: to use the edition 2021 resolver, specify workspace.resolver = "2" in the workspace root's manifest
