### PR TITLE
chore: workflow for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+    release:
+      name: Release ${{ matrix.target }}
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - target: x86_64-pc-windows-gnu
+              archive: zip
+            - target: x86_64-unknown-linux-musl
+              archive: tar.gz
+            # - target: x86_64-apple-darwin
+            #   archive: zip
+      steps:
+        - uses: actions/checkout@master
+        - name: Compile and release
+          uses: rust-build/rust-build.action@v1.4.4
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            SRC_DIR: crates/cli
+            RUSTTARGET: ${{ matrix.target }}
+            ARCHIVE_TYPES: ${{ matrix.archive }}


### PR DESCRIPTION
Fix: #168 

The x86_64-apple-darwin target is disabled due to an error:
<img width="901" alt="image" src="https://github.com/quarylabs/sqruff/assets/131762131/2dd275cf-e353-4b9c-b083-a9ec7e42dde5">
