### PR TITLE
chore: Add optional jemalloc support via feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "clap",
  "glob",
  "sqruff-lib",
+ "tikv-jemallocator",
  "ui_test",
 ]
 
@@ -965,6 +966,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,10 +9,16 @@ license = "MIT"
 name = "ui"
 harness = false
 
+[features]
+jemalloc = ["jemallocator"]
+
 [dependencies]
 sqruff-lib = { version = "0.1.4", path = "../lib" }
 clap = { version = "4", features = ["derive"] }
 glob = "0.3.1"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { version = "0.5", package = "tikv-jemallocator", optional = true }
 
 [dev-dependencies]
 ui_test = "0.22"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,6 +10,10 @@ use crate::commands::Cli;
 
 mod commands;
 
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 fn main() {
     match main_wrapper() {
         Ok(msg) => {


### PR DESCRIPTION
Jemalloc is valuable because of its introspection API, which enables the acquisition of swift and precise memory usage data, overcoming the constraints faced by mallinfo.