### PR TITLE
chore: upload file checksum once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,4 +67,3 @@ jobs:
           draft: true
           files: |
             sqruff-*
-            *.sha256


### PR DESCRIPTION
it seems due to this the workflow is failing
<img width="631" alt="image" src="https://github.com/quarylabs/sqruff/assets/131762131/1982395c-3044-4706-8cb4-212740aa5496">
