### PR TITLE
chore: fixes

### DIFF
--- a/crates/lib/src/core/linter/linter.rs
+++ b/crates/lib/src/core/linter/linter.rs
@@ -278,7 +278,7 @@ impl Linter {
                     }
 
                     let (linting_errors, fixes) =
-                        rule.crawl(&dialect, fix, tree.clone(), self.config.clone());
+                        rule.crawl(&dialect, fix, tree.clone(), &self.config);
                     let anchor_info = compute_anchor_edit_info(fixes.clone());
 
                     if is_first_linter_pass {

--- a/crates/lib/src/core/parser/lexer.rs
+++ b/crates/lib/src/core/parser/lexer.rs
@@ -622,7 +622,7 @@ fn iter_segments(
     let tfs_idx = 0;
     // We keep a map of previous block locations in case they re-occur.
     // let block_stack = BlockTracker()
-    let templated_file_slices = templated_file.clone().sliced_file;
+    let templated_file_slices = &templated_file.clone().sliced_file;
 
     // Now work out source slices, and add in template placeholders.
     for (_idx, element) in lexed_elements.into_iter().enumerate() {

--- a/crates/lib/src/core/rules/base.rs
+++ b/crates/lib/src/core/rules/base.rs
@@ -11,7 +11,7 @@ use crate::core::config::{FluffConfig, Value};
 use crate::core::dialects::base::Dialect;
 use crate::core::errors::SQLLintError;
 use crate::core::parser::segments::base::ErasedSegment;
-use crate::helpers::Config;
+use crate::helpers::{Config, IndexMap};
 
 #[derive(Clone)]
 pub struct LintResult {
@@ -270,12 +270,12 @@ pub trait Rule: CloneRule + dyn_clone::DynClone + Debug + 'static {
         dialect: &Dialect,
         fix: bool,
         tree: ErasedSegment,
-        config: FluffConfig,
+        config: &FluffConfig,
     ) -> (Vec<SQLLintError>, Vec<LintFix>) {
         let root_context = RuleContext {
             dialect,
             fix,
-            config: config.into(),
+            config: Some(config),
             segment: tree,
             templated_file: <_>::default(),
             path: <_>::default(),
@@ -379,7 +379,7 @@ pub struct RulePack {
 pub struct RuleSet {
     pub(crate) name: String,
     pub(crate) config_info: AHashMap<String, String>,
-    pub(crate) register: AHashMap<&'static str, RuleManifest>,
+    pub(crate) register: IndexMap<&'static str, RuleManifest>,
 }
 
 impl RuleSet {

--- a/crates/lib/src/core/rules/context.rs
+++ b/crates/lib/src/core/rules/context.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use ahash::AHashMap;
 
 use crate::core::config::FluffConfig;

--- a/crates/lib/src/core/rules/context.rs
+++ b/crates/lib/src/core/rules/context.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use ahash::AHashMap;
 
 use crate::core::config::FluffConfig;
@@ -13,7 +15,7 @@ pub struct RuleContext<'a> {
     pub fix: bool,
     pub templated_file: Option<TemplatedFile>,
     pub path: Option<String>,
-    pub config: Option<FluffConfig>,
+    pub config: Option<&'a FluffConfig>,
 
     // These change within a file.
     /// segment: The segment in question

--- a/crates/lib/src/core/templaters/base.rs
+++ b/crates/lib/src/core/templaters/base.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::ops::{Deref, Range};
 
 use crate::cli::formatters::OutputStreamFormatter;
 use crate::core::config::FluffConfig;
@@ -30,6 +30,46 @@ impl TemplatedFileSlice {
 /// the capability to split up that file when lexing.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct TemplatedFile {
+    inner: TemplatedFileInner,
+}
+
+impl TemplatedFile {
+    pub fn new(
+        source_str: String,
+        f_name: String,
+        input_templated_str: Option<String>,
+        sliced_file: Option<Vec<TemplatedFileSlice>>,
+        input_raw_sliced: Option<Vec<RawFileSlice>>,
+    ) -> Result<TemplatedFile, SQLFluffSkipFile> {
+        Ok(TemplatedFile {
+            inner: TemplatedFileInner::new(
+                source_str,
+                f_name,
+                input_templated_str,
+                sliced_file,
+                input_raw_sliced,
+            )?,
+        })
+    }
+
+    pub fn from_string(raw: String) -> TemplatedFile {
+        TemplatedFile {
+            inner: TemplatedFileInner::new(raw.clone(), "<string>".to_string(), None, None, None)
+                .unwrap(),
+        }
+    }
+}
+
+impl Deref for TemplatedFile {
+    type Target = TemplatedFileInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct TemplatedFileInner {
     pub source_str: String,
     f_name: String,
     pub templated_str: Option<String>,
@@ -39,7 +79,7 @@ pub struct TemplatedFile {
     pub sliced_file: Vec<TemplatedFileSlice>,
 }
 
-impl TemplatedFile {
+impl TemplatedFileInner {
     /// Initialise the TemplatedFile.
     /// If no templated_str is provided then we assume that
     /// the file is NOT templated and that the templated view
@@ -50,7 +90,7 @@ impl TemplatedFile {
         input_templated_str: Option<String>,
         sliced_file: Option<Vec<TemplatedFileSlice>>,
         input_raw_sliced: Option<Vec<RawFileSlice>>,
-    ) -> Result<TemplatedFile, SQLFluffSkipFile> {
+    ) -> Result<TemplatedFileInner, SQLFluffSkipFile> {
         // Assume that no sliced_file, means the file is not templated.
         // TODO Will this not always be Some and so type can avoid Option?
         let templated_str = input_templated_str.clone().unwrap_or(source_str.clone());
@@ -157,7 +197,7 @@ impl TemplatedFile {
             }
         }
 
-        Ok(TemplatedFile {
+        Ok(TemplatedFileInner {
             raw_sliced,
             source_newlines,
             templated_newlines,

--- a/crates/lib/src/helpers.rs
+++ b/crates/lib/src/helpers.rs
@@ -1,10 +1,14 @@
 use std::cell::RefCell;
+use std::hash::BuildHasherDefault;
 use std::panic;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Once;
 
 use crate::core::parser::matchable::Matchable;
 use crate::core::parser::segments::base::{ErasedSegment, Segment};
+
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<ahash::AHasher>>;
+pub type IndexSet<V> = indexmap::IndexSet<V, BuildHasherDefault<ahash::AHasher>>;
 
 pub trait ToMatchable: Matchable + Sized {
     fn to_matchable(self) -> Box<dyn Matchable> {

--- a/crates/lib/src/rules.rs
+++ b/crates/lib/src/rules.rs
@@ -1,6 +1,5 @@
-use ahash::AHashMap;
-
 use crate::core::rules::base::{RuleManifest, RuleSet};
+use crate::helpers::IndexMap;
 
 pub mod aliasing;
 pub mod convention;
@@ -9,7 +8,7 @@ pub mod layout;
 pub mod structure;
 
 pub fn get_ruleset() -> RuleSet {
-    let mut register = AHashMap::default();
+    let mut register = IndexMap::default();
 
     let rules = layout::get_rules();
     register.reserve(rules.len());

--- a/crates/lib/src/rules/aliasing/AL01.rs
+++ b/crates/lib/src/rules/aliasing/AL01.rs
@@ -82,6 +82,7 @@ impl Rule for RuleAL01 {
                         &as_keyword,
                         rule_cx.parent_stack[0].clone(),
                         "both",
+                        rule_cx.config.unwrap(),
                     )
                     .without(&as_keyword)
                     .respace(false, Filter::All)
@@ -105,6 +106,7 @@ impl Rule for RuleAL01 {
                         &identifier,
                         rule_cx.parent_stack[0].clone(),
                         "before",
+                        rule_cx.config.unwrap(),
                     )
                     .insert(
                         KeywordSegment::new("AS".into(), None).to_erased_segment(),

--- a/crates/lib/src/rules/aliasing/AL04.rs
+++ b/crates/lib/src/rules/aliasing/AL04.rs
@@ -1,11 +1,11 @@
 use ahash::{AHashMap, AHashSet};
-use indexmap::IndexSet;
 
 use crate::core::config::Value;
 use crate::core::dialects::common::AliasInfo;
 use crate::core::rules::base::{ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
+use crate::helpers::IndexSet;
 use crate::utils::analysis::select::get_select_statement_info;
 
 #[derive(Debug, Clone, Default)]
@@ -47,7 +47,7 @@ impl RuleAL04 {
         &self,
         table_aliases: Vec<AliasInfo>,
     ) -> Option<Vec<LintResult>> {
-        let mut duplicates = IndexSet::new();
+        let mut duplicates = IndexSet::default();
         let mut seen: AHashSet<String> = AHashSet::new();
 
         for alias in table_aliases.iter() {

--- a/crates/lib/src/rules/layout/LT03.rs
+++ b/crates/lib/src/rules/layout/LT03.rs
@@ -47,6 +47,7 @@ impl Rule for RuleLT03 {
             &context.segment,
             context.parent_stack.first().unwrap().clone_box(),
             "both",
+            context.config.unwrap(),
         )
         .rebreak()
         .results()

--- a/crates/lib/src/rules/layout/LT04.rs
+++ b/crates/lib/src/rules/layout/LT04.rs
@@ -44,6 +44,7 @@ impl Rule for RuleLT04 {
             &context.segment,
             context.parent_stack.first().unwrap().clone(),
             "both",
+            context.config.unwrap(),
         )
         .rebreak()
         .results()

--- a/crates/lib/src/rules/layout/LT08.rs
+++ b/crates/lib/src/rules/layout/LT08.rs
@@ -1,7 +1,6 @@
 use std::iter::repeat;
 
 use ahash::AHashMap;
-use indexmap::IndexMap;
 use itertools::Itertools;
 
 use crate::core::config::Value;
@@ -9,6 +8,7 @@ use crate::core::parser::segments::base::NewlineSegment;
 use crate::core::rules::base::{EditType, Erased, ErasedRule, LintFix, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
+use crate::helpers::IndexMap;
 
 #[derive(Debug, Default, Clone)]
 pub struct RuleLT08 {}
@@ -49,7 +49,7 @@ impl Rule for RuleLT08 {
             let mut blank_lines = 0;
             let mut comma_line_idx = None;
             let mut line_blank = false;
-            let mut line_starts = IndexMap::new();
+            let mut line_starts = IndexMap::default();
             let mut comment_lines = Vec::new();
 
             while forward_slice[seg_idx].is_type("comma") || !forward_slice[seg_idx].is_code() {

--- a/crates/lib/src/rules/layout/LT11.rs
+++ b/crates/lib/src/rules/layout/LT11.rs
@@ -31,6 +31,7 @@ impl Rule for RuleLT11 {
             &context.segment,
             context.parent_stack.first().unwrap().clone_box(),
             "both",
+            context.config.unwrap(),
         )
         .rebreak()
         .results()

--- a/crates/lib/src/rules/structure/ST03.rs
+++ b/crates/lib/src/rules/structure/ST03.rs
@@ -1,10 +1,10 @@
 use ahash::AHashMap;
-use indexmap::IndexMap;
 
 use crate::core::config::Value;
 use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
+use crate::helpers::IndexMap;
 use crate::utils::analysis::query::Query;
 
 #[derive(Debug, Default, Clone)]

--- a/crates/lib/src/utils/reflow/config.rs
+++ b/crates/lib/src/utils/reflow/config.rs
@@ -152,7 +152,7 @@ impl ReflowConfig {
         block_config
     }
 
-    pub fn from_fluff_config(config: FluffConfig) -> ReflowConfig {
+    pub fn from_fluff_config(config: &FluffConfig) -> ReflowConfig {
         let configs = config.raw["layout"]["type"].as_map().unwrap().clone();
         let config_types: AHashSet<_> = configs.keys().cloned().collect();
 

--- a/crates/lib/src/utils/reflow/rebreak.rs
+++ b/crates/lib/src/utils/reflow/rebreak.rs
@@ -449,7 +449,7 @@ mod tests {
             let _panic = enter_panic(format!("{raw_sql_in:?}"));
 
             let root = parse_ansi_string(raw_sql_in);
-            let seq = ReflowSequence::from_root(root, <_>::default());
+            let seq = ReflowSequence::from_root(root, &<_>::default());
             let new_seq = seq.rebreak();
 
             assert_eq!(new_seq.raw(), raw_sql_out);
@@ -472,7 +472,7 @@ mod tests {
         for (raw_sql_in, target_idx, seq_sql_in, seq_sql_out) in cases {
             let root = parse_ansi_string(raw_sql_in);
             let target = &root.get_raw_segments()[target_idx];
-            let seq = ReflowSequence::from_around_target(target, root, "both");
+            let seq = ReflowSequence::from_around_target(target, root, "both", &<_>::default());
 
             assert_eq!(seq.raw(), seq_sql_in);
 

--- a/crates/lib/src/utils/reflow/reindent.rs
+++ b/crates/lib/src/utils/reflow/reindent.rs
@@ -596,7 +596,7 @@ mod tests {
 
         for (raw_sql_in, elem_idx, indent_out) in cases {
             let root = parse_ansi_string(raw_sql_in);
-            let seq = ReflowSequence::from_root(root, <_>::default());
+            let seq = ReflowSequence::from_root(root, &<_>::default());
             let elem = seq.elements()[elem_idx].as_point().unwrap();
 
             assert_eq!(indent_out, elem.get_indent().as_deref());

--- a/crates/lib/src/utils/reflow/respace.rs
+++ b/crates/lib/src/utils/reflow/respace.rs
@@ -416,7 +416,7 @@ mod tests {
 
         for (raw_sql_in, (strip_newlines, filter), raw_sql_out) in cases {
             let root = parse_ansi_string(raw_sql_in);
-            let seq = ReflowSequence::from_root(root, <_>::default());
+            let seq = ReflowSequence::from_root(root, &<_>::default());
 
             let new_seq = seq.respace(strip_newlines, filter);
             assert_eq!(new_seq.raw(), raw_sql_out);
@@ -463,7 +463,7 @@ mod tests {
             let _panic = enter_panic(format!("{raw_sql_in:?}"));
 
             let root = parse_ansi_string(raw_sql_in);
-            let seq = ReflowSequence::from_root(root, <_>::default());
+            let seq = ReflowSequence::from_root(root, &<_>::default());
             let pnt = seq.elements()[point_idx].as_point().unwrap();
 
             let (results, new_pnt) = pnt.respace_point(

--- a/crates/lib/src/utils/reflow/sequence.rs
+++ b/crates/lib/src/utils/reflow/sequence.rs
@@ -32,7 +32,7 @@ impl ReflowSequence {
         self.results().into_iter().flat_map(|result| result.fixes).collect()
     }
 
-    pub fn from_root(root_segment: ErasedSegment, config: FluffConfig) -> Self {
+    pub fn from_root(root_segment: ErasedSegment, config: &FluffConfig) -> Self {
         let depth_map = DepthMap::from_parent(&*root_segment).into();
 
         Self::from_raw_segments(root_segment.get_raw_segments(), root_segment, config, depth_map)
@@ -41,7 +41,7 @@ impl ReflowSequence {
     pub fn from_raw_segments(
         segments: Vec<ErasedSegment>,
         root_segment: ErasedSegment,
-        config: FluffConfig,
+        config: &FluffConfig,
         depth_map: Option<DepthMap>,
     ) -> Self {
         let reflow_config = ReflowConfig::from_fluff_config(config);
@@ -100,6 +100,7 @@ impl ReflowSequence {
         target_segment: &ErasedSegment,
         root_segment: ErasedSegment,
         sides: &str,
+        config: &FluffConfig,
     ) -> ReflowSequence {
         let all_raws = root_segment.get_raw_segments();
         let target_raws = target_segment.get_raw_segments();
@@ -138,7 +139,7 @@ impl ReflowSequence {
             segments.to_vec(),
             root_segment,
             // FIXME:
-            FluffConfig::default(),
+            config,
             None,
         )
     }


### PR DESCRIPTION
This PR resolves an issue with non-deterministic retrieval of rule lists, ensuring consistent results every time the function is called. Additionally, it includes performance improvements as demonstrated by the measurements below:
```powershell
PS> Measure-Command { python.exe -m sqlfluff lint --dialect ansi . *> $null }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 7
Milliseconds      : 371
Ticks             : 73714833
TotalDays         : 8.531809375E-05
TotalHours        : 0.00204763425
TotalMinutes      : 0.122858055
TotalSeconds      : 7.3714833
TotalMilliseconds : 7371.4833



PS> Measure-Command { sqruff.exe lint SqlFolder *> $null }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 6
Milliseconds      : 505
Ticks             : 65058890
TotalDays         : 7.52996412037037E-05
TotalHours        : 0.00180719138888889
TotalMinutes      : 0.108431483333333
TotalSeconds      : 6.505889
TotalMilliseconds : 6505.889
```