### PR TITLE
chore: pin Rust version that we are building with

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-04-27"


### PR DESCRIPTION
fix: #242 