### PR TITLE
chore: standardize the method names for retrieving rules to `rules()` across all modules

### DIFF
--- a/crates/lib/src/core/linter/linter.rs
+++ b/crates/lib/src/core/linter/linter.rs
@@ -38,7 +38,7 @@ impl Linter {
         formatter: Option<OutputStreamFormatter>,
         templater: Option<Box<dyn Templater>>,
     ) -> Linter {
-        let rules = crate::rules::layout::get_rules();
+        let rules = crate::rules::layout::rules();
         match templater {
             Some(templater) => Linter { config, formatter, templater, _rules: rules },
             None => Linter {

--- a/crates/lib/src/rules.rs
+++ b/crates/lib/src/rules.rs
@@ -1,4 +1,6 @@
-use crate::core::rules::base::{RuleManifest, RuleSet};
+use itertools::{chain, Itertools};
+
+use crate::core::rules::base::{ErasedRule, RuleManifest, RuleSet};
 use crate::helpers::IndexMap;
 
 pub mod aliasing;
@@ -9,10 +11,22 @@ pub mod l001;
 pub mod layout;
 pub mod structure;
 
+pub fn rules() -> Vec<ErasedRule> {
+    chain!(
+        aliasing::rules(),
+        ambiguous::rules(),
+        capitalisation::rules(),
+        convention::rules(),
+        layout::rules(),
+        structure::rules()
+    )
+    .collect_vec()
+}
+
 pub fn get_ruleset() -> RuleSet {
     let mut register = IndexMap::default();
 
-    let rules = layout::get_rules();
+    let rules = rules();
     register.reserve(rules.len());
 
     for rule in rules {

--- a/crates/lib/src/rules/aliasing.rs
+++ b/crates/lib/src/rules/aliasing.rs
@@ -1,3 +1,5 @@
+use crate::core::rules::base::ErasedRule;
+
 pub mod AL01;
 pub mod AL02;
 pub mod AL03;
@@ -6,3 +8,18 @@ pub mod AL05;
 pub mod AL06;
 pub mod AL07;
 pub mod AL08;
+
+pub fn rules() -> Vec<ErasedRule> {
+    use crate::core::rules::base::Erased as _;
+
+    vec![
+        AL01::RuleAL01::default().erased(),
+        AL02::RuleAL02::default().erased(),
+        AL03::RuleAL03::default().erased(),
+        AL04::RuleAL04::default().erased(),
+        AL05::RuleAL05::default().erased(),
+        AL06::RuleAL06::default().erased(),
+        AL07::RuleAL07::default().erased(),
+        AL08::RuleAL08::default().erased(),
+    ]
+}

--- a/crates/lib/src/rules/aliasing/AL03.rs
+++ b/crates/lib/src/rules/aliasing/AL03.rs
@@ -2,7 +2,7 @@ use ahash::AHashMap;
 
 use crate::core::config::Value;
 use crate::core::parser::segments::base::ErasedSegment;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::utils::functional::context::FunctionalContext;
@@ -20,8 +20,11 @@ impl Default for RuleAL03 {
 }
 
 impl Rule for RuleAL03 {
-    fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        unimplemented!()
+    fn load_from_config(&self, config: &AHashMap<String, Value>) -> ErasedRule {
+        RuleAL03 {
+            allow_scalar: config.get("allow_scalar").and_then(Value::as_bool).unwrap_or_default(),
+        }
+        .erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/aliasing/AL04.rs
+++ b/crates/lib/src/rules/aliasing/AL04.rs
@@ -2,7 +2,7 @@ use ahash::{AHashMap, AHashSet};
 
 use crate::core::config::Value;
 use crate::core::dialects::common::AliasInfo;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::helpers::IndexSet;
@@ -13,7 +13,7 @@ pub struct RuleAL04 {}
 
 impl Rule for RuleAL04 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        unimplemented!()
+        RuleAL04::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/aliasing/AL05.rs
+++ b/crates/lib/src/rules/aliasing/AL05.rs
@@ -4,7 +4,7 @@ use crate::core::config::Value;
 use crate::core::dialects::base::Dialect;
 use crate::core::dialects::common::AliasInfo;
 use crate::core::parser::segments::base::ErasedSegment;
-use crate::core::rules::base::{ErasedRule, LintFix, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintFix, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::dialects::ansi::ObjectReferenceLevel;
@@ -23,7 +23,7 @@ pub struct RuleAL05 {}
 
 impl Rule for RuleAL05 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        unimplemented!()
+        RuleAL05::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/aliasing/AL07.rs
+++ b/crates/lib/src/rules/aliasing/AL07.rs
@@ -18,7 +18,7 @@ struct TableAliasInfo {
     alias_identifier_ref: Option<ErasedSegment>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RuleAL07 {
     force_enable: bool,
 }

--- a/crates/lib/src/rules/aliasing/AL08.rs
+++ b/crates/lib/src/rules/aliasing/AL08.rs
@@ -4,7 +4,7 @@ use ahash::AHashMap;
 
 use crate::core::config::Value;
 use crate::core::parser::segments::base::ErasedSegment;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 
@@ -13,7 +13,7 @@ pub struct RuleAL08 {}
 
 impl Rule for RuleAL08 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        unimplemented!()
+        RuleAL08::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/ambiguous.rs
+++ b/crates/lib/src/rules/ambiguous.rs
@@ -1,1 +1,9 @@
+use crate::core::rules::base::ErasedRule;
+
 mod AM01;
+
+pub fn rules() -> Vec<ErasedRule> {
+    use crate::core::rules::base::Erased as _;
+
+    vec![AM01::RuleAM01.erased()]
+}

--- a/crates/lib/src/rules/ambiguous/AM01.rs
+++ b/crates/lib/src/rules/ambiguous/AM01.rs
@@ -6,7 +6,7 @@ use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::utils::functional::context::FunctionalContext;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RuleAM01;
 
 impl Rule for RuleAM01 {

--- a/crates/lib/src/rules/capitalisation.rs
+++ b/crates/lib/src/rules/capitalisation.rs
@@ -1,5 +1,19 @@
+use crate::core::rules::base::ErasedRule;
+
 pub mod CP01;
 pub mod CP02;
 pub mod CP03;
 pub mod CP04;
 pub mod CP05;
+
+pub fn rules() -> Vec<ErasedRule> {
+    use crate::core::rules::base::Erased as _;
+
+    vec![
+        CP01::RuleCP01::default().erased(),
+        CP02::RuleCP02::default().erased(),
+        CP03::RuleCP03::default().erased(),
+        CP04::RuleCP04::default().erased(),
+        CP05::RuleCP05::default().erased(),
+    ]
+}

--- a/crates/lib/src/rules/capitalisation/CP01.rs
+++ b/crates/lib/src/rules/capitalisation/CP01.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::core::config::Value;
 use crate::core::parser::segments::base::ErasedSegment;
-use crate::core::rules::base::{ErasedRule, LintFix, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintFix, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::helpers::capitalize;
@@ -38,7 +38,7 @@ impl Default for RuleCP01 {
 
 impl Rule for RuleCP01 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        todo!()
+        RuleCP01::default().erased()
     }
 
     fn name(&self) -> &'static str {
@@ -141,10 +141,6 @@ pub fn handle_segment(
         let possible_cases =
             cap_policy_opts.iter().filter(|&it| !refuted_cases.contains(it)).collect_vec();
 
-        dbg!(&refuted_cases);
-        dbg!(&cap_policy_opts);
-        dbg!(&possible_cases);
-
         if !possible_cases.is_empty() {
             context.memory.borrow_mut().insert(LatestPossibleCase(possible_cases[0].to_string()));
             return LintResult::new(None, Vec::new(), None, None, None);
@@ -162,8 +158,6 @@ pub fn handle_segment(
     };
 
     let concrete_policy = concrete_policy.as_str();
-
-    dbg!(concrete_policy);
 
     let mut fixed_raw = seg.get_raw().unwrap();
     fixed_raw = match concrete_policy {

--- a/crates/lib/src/rules/capitalisation/CP02.rs
+++ b/crates/lib/src/rules/capitalisation/CP02.rs
@@ -2,7 +2,7 @@ use ahash::AHashMap;
 
 use super::CP01::RuleCP01;
 use crate::core::config::Value;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::utils::identifers::identifiers_policy_applicable;
@@ -27,7 +27,7 @@ impl Default for RuleCP02 {
 
 impl Rule for RuleCP02 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        todo!()
+        RuleCP02::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/capitalisation/CP03.rs
+++ b/crates/lib/src/rules/capitalisation/CP03.rs
@@ -2,7 +2,7 @@ use ahash::AHashMap;
 
 use super::CP01::RuleCP01;
 use crate::core::config::Value;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 
@@ -25,7 +25,7 @@ impl Default for RuleCP03 {
 
 impl Rule for RuleCP03 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        todo!()
+        RuleCP03::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/capitalisation/CP04.rs
+++ b/crates/lib/src/rules/capitalisation/CP04.rs
@@ -2,7 +2,7 @@ use ahash::AHashMap;
 
 use super::CP01::RuleCP01;
 use crate::core::config::Value;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{CloneRule, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 
@@ -25,7 +25,7 @@ impl Default for RuleCP04 {
 
 impl Rule for RuleCP04 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        todo!()
+        RuleCP04::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/capitalisation/CP05.rs
+++ b/crates/lib/src/rules/capitalisation/CP05.rs
@@ -2,18 +2,24 @@ use ahash::AHashMap;
 
 use super::CP01::handle_segment;
 use crate::core::config::Value;
-use crate::core::rules::base::{ErasedRule, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct RuleCP05 {
     extended_capitalisation_policy: String,
 }
 
 impl Rule for RuleCP05 {
-    fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        todo!()
+    fn load_from_config(&self, config: &AHashMap<String, Value>) -> ErasedRule {
+        RuleCP05 {
+            extended_capitalisation_policy: config["extended_capitalisation_policy"]
+                .as_string()
+                .unwrap()
+                .to_string(),
+        }
+        .erased()
     }
 
     fn name(&self) -> &'static str {
@@ -21,7 +27,7 @@ impl Rule for RuleCP05 {
     }
 
     fn description(&self) -> &'static str {
-        todo!()
+        "Inconsistent capitalisation of datatypes."
     }
 
     fn eval(&self, context: RuleContext) -> Vec<LintResult> {

--- a/crates/lib/src/rules/convention.rs
+++ b/crates/lib/src/rules/convention.rs
@@ -1,1 +1,9 @@
+use crate::core::rules::base::ErasedRule;
+
 pub mod CV02;
+
+pub fn rules() -> Vec<ErasedRule> {
+    use crate::core::rules::base::Erased as _;
+
+    vec![CV02::RuleCv02::default().erased()]
+}

--- a/crates/lib/src/rules/convention/CV02.rs
+++ b/crates/lib/src/rules/convention/CV02.rs
@@ -2,7 +2,7 @@ use ahash::AHashMap;
 
 use crate::core::config::Value;
 use crate::core::parser::segments::base::{SymbolSegment, SymbolSegmentNewArgs};
-use crate::core::rules::base::{ErasedRule, LintFix, LintResult, Rule};
+use crate::core::rules::base::{Erased, ErasedRule, LintFix, LintResult, Rule};
 use crate::core::rules::context::RuleContext;
 use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 
@@ -38,7 +38,7 @@ pub struct RuleCv02 {}
 
 impl Rule for RuleCv02 {
     fn load_from_config(&self, _config: &AHashMap<String, Value>) -> ErasedRule {
-        unimplemented!()
+        RuleCv02::default().erased()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/lib/src/rules/layout.rs
+++ b/crates/lib/src/rules/layout.rs
@@ -1,3 +1,5 @@
+use crate::core::rules::base::ErasedRule;
+
 pub mod LT01;
 pub mod LT02;
 pub mod LT03;
@@ -12,7 +14,7 @@ pub mod LT11;
 pub mod LT12;
 pub mod LT13;
 
-pub fn get_rules() -> Vec<crate::core::rules::base::ErasedRule> {
+pub fn rules() -> Vec<ErasedRule> {
     use crate::core::rules::base::Erased as _;
 
     vec![

--- a/crates/lib/src/rules/structure.rs
+++ b/crates/lib/src/rules/structure.rs
@@ -1,3 +1,15 @@
+use crate::core::rules::base::ErasedRule;
+
 pub mod ST01;
 pub mod ST02;
 pub mod ST03;
+
+pub fn rules() -> Vec<ErasedRule> {
+    use crate::core::rules::base::Erased as _;
+
+    vec![
+        ST01::RuleST01::default().erased(),
+        ST02::RuleST02::default().erased(),
+        ST03::RuleST03::default().erased(),
+    ]
+}

--- a/crates/lib/src/utils/analysis/select.rs
+++ b/crates/lib/src/utils/analysis/select.rs
@@ -42,10 +42,7 @@ pub fn get_select_statement_info(
         ["where_clause", "groupby_clause", "having_clause", "orderby_clause", "qualify_clause"]
     {
         let clause = segment.child(&[potential_clause]);
-        if let Some(_clause) = clause {
-            unimplemented!();
-            // reference_buffer.extend(iter)
-        }
+        if let Some(_clause) = clause {}
     }
 
     let select_clause = segment.child(&["select_clause"]).unwrap();


### PR DESCRIPTION
… across all modules