### PR TITLE
feat: add publish to cargo step on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
       - name: Publish sqruff-lib to Cargo
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch: 
 
 jobs:
   check-versions-match:
@@ -84,7 +85,6 @@ jobs:
           draft: true
           files: |
             sqruff-*
-
   update-homebrew-formula:
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
@@ -145,3 +145,24 @@ jobs:
           
           gh auth login --with-token < token.txt
           gh pr create --title "Update Sqruff to version ${STRIPPED_VERSION}" --body "Automated PR to update Sqruff to version ${STRIPPED_VERSION}" --base main
+  publish-to-cargo:
+    name: Publish to Cargo
+    runs-on: ubuntu-latest
+    needs: [release, check-versions-match]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Publish sqruff-lib to Cargo
+        uses: actions-rs/cargo@v1
+        with:
+         command: publish
+         args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-lib
+
+      - name: Publish sqruff to Cargo
+        uses: actions-rs/cargo@v1
+        with:
+         command: publish
+         args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff


### PR DESCRIPTION
- added workflow_dispatch so that we can manually trigger the publish step
- Secrets stored.