### PR TITLE
chore: Disable benchmarking in CLI and library crates

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 license = "Apache-2.0"
 default-run = "sqruff"
 
+[[bin]]
+name = "bench"
+path = "src/bin/bench.rs"
+bench = false
+
 [[test]]
 name = "ui"
 harness = false

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+bench = false
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
To address the issue described on the FAQ page (https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options):

