### PR TITLE
ci: fix maturin rust toolchain

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -6,7 +6,9 @@
 name: CI
 
 on:
-  pull_request:
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -142,18 +144,18 @@ jobs:
           name: wheels-sdist
           path: crates/cli/dist
 
-  #release:
-  #  name: Release
-  #  runs-on: ubuntu-latest
-  #  environment: production
-  #  #if: "startsWith(github.ref, 'refs/tags/')"
-  #  needs: [linux, musllinux, windows, macos, sdist]
-  #  steps:
-  #    - uses: actions/download-artifact@v4
-  #    - name: Publish to PyPI
-  #      uses: PyO3/maturin-action@v1
-  #      env:
-  #        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  #      with:
-  #        command: upload
-  #        args: --non-interactive --skip-existing wheels-*/*
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    environment: production
+    #if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [linux, musllinux, windows, macos, sdist]
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -6,9 +6,7 @@
 name: CI
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -38,7 +36,7 @@ jobs:
           args: --release --out dist
           sccache: "true"
           manylinux: auto
-          rust-toolchain: nightly
+          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -68,7 +66,7 @@ jobs:
           args: --release --out dist
           sccache: "true"
           manylinux: musllinux_1_2
-          rust-toolchain: nightly
+          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -93,7 +91,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
-          rust-toolchain: nightly
+          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -117,7 +115,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
-          rust-toolchain: nightly
+          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -137,25 +135,25 @@ jobs:
           target: x86_64
           command: sdist
           args: --out dist
-          rust-toolchain: nightly
+          rust-toolchain: 1.81.0
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
           name: wheels-sdist
           path: crates/cli/dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    environment: production
-    #if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, musllinux, windows, macos, sdist]
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+  # release:
+  #   name: Release
+  #   runs-on: ubuntu-latest
+  #   environment: production
+  #   #if: "startsWith(github.ref, 'refs/tags/')"
+  #   needs: [linux, musllinux, windows, macos, sdist]
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #     - name: Publish to PyPI
+  #       uses: PyO3/maturin-action@v1
+  #       env:
+  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  #       with:
+  #         command: upload
+  #         args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -65,7 +65,6 @@ jobs:
           args: --release --out dist
           sccache: "true"
           manylinux: musllinux_1_2
-          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -90,7 +89,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
-          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -133,7 +131,6 @@ jobs:
           target: x86_64
           command: sdist
           args: --out dist
-          rust-toolchain: 1.81.0
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -6,9 +6,7 @@
 name: CI
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -38,6 +36,7 @@ jobs:
           args: --release --out dist
           sccache: "true"
           manylinux: auto
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -67,6 +66,7 @@ jobs:
           args: --release --out dist
           sccache: "true"
           manylinux: musllinux_1_2
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -91,6 +91,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -114,6 +115,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -133,24 +135,25 @@ jobs:
           target: x86_64
           command: sdist
           args: --out dist
+          rust-toolchain: nightly
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
           name: wheels-sdist
           path: crates/cli/dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    environment: production
-    #if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, musllinux, windows, macos, sdist]
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+  #release:
+  #  name: Release
+  #  runs-on: ubuntu-latest
+  #  environment: production
+  #  #if: "startsWith(github.ref, 'refs/tags/')"
+  #  needs: [linux, musllinux, windows, macos, sdist]
+  #  steps:
+  #    - uses: actions/download-artifact@v4
+  #    - name: Publish to PyPI
+  #      uses: PyO3/maturin-action@v1
+  #      env:
+  #        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  #      with:
+  #        command: upload
+  #        args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -6,7 +6,9 @@
 name: CI
 
 on:
-  pull_request:
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -137,18 +139,18 @@ jobs:
           name: wheels-sdist
           path: crates/cli/dist
 
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   environment: production
-  #   #if: "startsWith(github.ref, 'refs/tags/')"
-  #   needs: [linux, musllinux, windows, macos, sdist]
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #     - name: Publish to PyPI
-  #       uses: PyO3/maturin-action@v1
-  #       env:
-  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  #       with:
-  #         command: upload
-  #         args: --non-interactive --skip-existing wheels-*/*
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    environment: production
+    #if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [linux, musllinux, windows, macos, sdist]
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -36,7 +36,6 @@ jobs:
           args: --release --out dist
           sccache: "true"
           manylinux: auto
-          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -115,7 +114,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
-          rust-toolchain: 1.81.0
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.81.0"


### PR DESCRIPTION
It looks like the python deployments have been failing because the rust-toolchain wasn't set and has been using `stable` by default when I think we want to use `nightly`.

This PR should fix that. I have tested in a previoud commit by changing the actions trigger to be 'pull request' and it built the artifacts fine for all the jobs: https://github.com/quarylabs/sqruff/actions/runs/11627091156

