### PR TITLE
refactor: add start-of-string anchor to regex patterns in lexer

### DIFF
--- a/crates/lib-core/src/parser/lexer.rs
+++ b/crates/lib-core/src/parser/lexer.rs
@@ -255,10 +255,12 @@ impl Pattern {
     }
 
     pub fn regex(name: &'static str, regex: &'static str, syntax_kind: SyntaxKind) -> Self {
+        let regex = format!("^{regex}");
+
         Self {
             name,
             syntax_kind,
-            kind: SearchPatternKind::Regex(Regex::new(regex).unwrap()),
+            kind: SearchPatternKind::Regex(Regex::new(&regex).unwrap()),
         }
     }
 


### PR DESCRIPTION
fix #939 