### PR TITLE
fix: github actions detection not working properly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo r -F codegen-docs
+      - run: env GITHUB_ACTIONS=false cargo r -F codegen-docs
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           push_options: "--force"
@@ -22,5 +22,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo r --bin sqruff -F codegen-docs
+      - run: env GITHUB_ACTIONS=false cargo r --bin sqruff -F codegen-docs
       - run: git diff --quiet || exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,7 @@ dependencies = [
  "serde",
  "sqruff-lib",
  "sqruff-lsp",
+ "strum_macros",
  "tempfile",
  "tikv-jemallocator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ sqruff-lib-core = { version = "0.21.6", path = "crates/lib-core" }
 sqruff-lib-dialects = { version = "0.21.6", path = "crates/lib-dialects"}
 wasm-bindgen = "0.2"
 wasm-pack = "0.13.0"
+
+strum = "0.26.3"
+strum_macros = "0.26.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ codegen-docs = ["clap-markdown", "minijinja", "serde", "python"]
 [dependencies]
 sqruff-lib.workspace = true
 sqruff-lsp.workspace = true
+strum_macros.workspace = true
 
 clap = { version = "4", features = ["derive"] }
 console = "0.15.8"

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,7 +1,5 @@
-use std::{
-    fmt::{write, Display},
-    path::PathBuf,
-};
+use std::path::PathBuf;
+use strum_macros::Display;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -48,7 +46,8 @@ pub(crate) struct FixArgs {
     pub format: Format,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[strum(serialize_all = "kebab-case")]
 pub(crate) enum Format {
     Human,
     GithubAnnotationNative,
@@ -60,15 +59,6 @@ impl Default for Format {
             Format::GithubAnnotationNative
         } else {
             Format::Human
-        }
-    }
-}
-
-impl Display for Format {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Format::Human => f.write_str("human"),
-            Format::GithubAnnotationNative => f.write_str("github-annotation-native"),
         }
     }
 }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    fmt::{write, Display},
+    path::PathBuf,
+};
 
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -30,7 +33,7 @@ pub(crate) enum Commands {
 pub(crate) struct LintArgs {
     /// Files or directories to fix. Use `-` to read from stdin.
     pub paths: Vec<PathBuf>,
-    #[arg(default_value = "human", short, long)]
+    #[arg(default_value_t, short, long)]
     pub format: Format,
 }
 
@@ -41,7 +44,7 @@ pub(crate) struct FixArgs {
     /// Skip the confirmation prompt and go straight to applying fixes.
     #[arg(long)]
     pub force: bool,
-    #[arg(default_value = "human", short, long)]
+    #[arg(default_value_t, short, long)]
     pub format: Format,
 }
 
@@ -57,6 +60,15 @@ impl Default for Format {
             Format::GithubAnnotationNative
         } else {
             Format::Human
+        }
+    }
+}
+
+impl Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Format::Human => f.write_str("human"),
+            Format::GithubAnnotationNative => f.write_str("github-annotation-native"),
         }
     }
 }

--- a/crates/cli/src/github_action.rs
+++ b/crates/cli/src/github_action.rs
@@ -1,5 +1,7 @@
 use std::env;
 
 pub(crate) fn is_in_github_action() -> bool {
-    env::var("GITHUB_ACTIONS").is_ok()
+    env::var("GITHUB_ACTIONS")
+        .map(|s| s == "true")
+        .unwrap_or(false)
 }

--- a/crates/lib-core/Cargo.toml
+++ b/crates/lib-core/Cargo.toml
@@ -19,9 +19,9 @@ stringify = ["dep:serde_yaml", "serde"]
 [dependencies]
 smol_str = "0.3.1"
 ahash = { version = "0.8.11", features = ["compile-time-rng", "serde"] }
-strum = "0.26.3"
+strum.workspace = true
+strum_macros.workspace = true
 indexmap = "2.5.0"
-strum_macros = "0.26.4"
 nohash-hasher = "0.2.0"
 itertools = "0.13.0"
 fancy-regex = "0.14.0"

--- a/crates/lib-dialects/Cargo.toml
+++ b/crates/lib-dialects/Cargo.toml
@@ -44,9 +44,9 @@ trino = []
 
 [dependencies]
 sqruff-lib-core.workspace = true
+strum.workspace = true
 itertools = "0.13.0"
 ahash = "0.8.11"
-strum = "0.26.3"
 serde_yaml = "0.9.34+deprecated"
 
 [dev-dependencies]


### PR DESCRIPTION
I noticed that specifying `default_value = "human"` in `#[arg]` directive does not rely on Default trait for Format enum which results in always defaults to human even on GitHub Actions.
So I replaced it to `default_value_t` which calls `Default::default` and sets default value depends on GitHub Actions or not properly.
I also implemented Display for Format enum since `default_value_t` requires `impl ToString`, but clippy suggests `impl Display` instead of `impl ToString`.