### PR TITLE
fix: index out-of-bounds issue in the LT05 rule when trying to remove elements from a sequence

### DIFF
--- a/crates/lib/src/rules/layout/lt05.rs
+++ b/crates/lib/src/rules/layout/lt05.rs
@@ -163,7 +163,15 @@ FROM my_table"#
         }
 
         for idx in to_remove {
-            results.remove(idx);
+            if idx < results.len() {
+                results.remove(idx);
+            } else {
+                println!(
+                    "Attempted to remove index {} from results with length {}",
+                    idx,
+                    results.len()
+                );
+            }
         }
 
         results

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -713,3 +713,32 @@ test_pass_window_function:
             order by d desc
         ) as rnk
     from foo
+
+test_long_line_with_jinja_template:
+  # Test handling of long lines with Jinja templates to avoid index out of bounds
+  pass_str: |
+    {{ config(
+        materialized = 'table',
+        tags = ["tag1", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8", "tag9", "tag10"]
+    ) }}
+
+    WITH date_series AS (
+        SELECT DATE(DATEADD(month,
+            ROW_NUMBER() OVER (
+                PARTITION BY cm.customer_external_id,
+                cm.subscription_external_id,
+                cm.uuid
+                ORDER BY cm.date
+            ) - 1,
+            cm.date
+        ) AS calendar_date
+    FROM {{ source("some_schema", "some_table") }} AS cm
+    )
+    SELECT * FROM date_series
+  configs:
+    core:
+      max_line_length: 80
+    templater:
+      jinja:
+        context:
+          source: my_source


### PR DESCRIPTION
When running `sqruff` on a DBT model in Snowflake dialect, the `LT05` rule was panicking. This only removes the indexes when they exist, otherwise prints.

**Error:**
```sh
thread 'main' panicked at crates/lib/src/rules/layout/lt05.rs:166:21:
removal index (is 14) should be < len (is 10)
```