### PR TITLE
fix: respect specified config filename

### DIFF
--- a/crates/lib/src/core/config.rs
+++ b/crates/lib/src/core/config.rs
@@ -352,19 +352,18 @@ impl ConfigLoader {
             ".sqruff", /* "pyproject.toml" */
         ];
 
-        let path = if path.is_dir() {
-            path
-        } else {
-            path.parent().unwrap()
-        };
         let mut configs = AHashMap::new();
 
-        for fname in filename_options {
-            let path = path.join(fname);
-            if path.exists() {
-                self.load_config_file(path, &mut configs);
+        if path.is_dir() {
+            for fname in filename_options {
+                let path = path.join(fname);
+                if path.exists() {
+                    self.load_config_file(path, &mut configs);
+                }
             }
-        }
+        } else if path.is_file() {
+            self.load_config_file(path, &mut configs);
+        };
 
         configs
     }


### PR DESCRIPTION
Previously, the `load_config_at_path` function removed the base filename and searched for filenames listed in `filename_options`, such as .sqruff and .sqlfluff. This fix changes the logic so that the filename_options list is only used if the file path is an existing directory. If instead the file path is an existing file, then simply load the config from the file.

fixes #1131. I recognize the presenting issue was already worked around by commit c69a0c81252f71ea1 but it still seems this should be fixed in `load_config_at_path`, yes?
