### PR TITLE
feat: Add verbosity config to OutputStreamFormatter

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -110,6 +110,7 @@ pub(crate) fn linter(config: FluffConfig, format: Format, collect_parse_errors: 
             let formatter = OutputStreamFormatter::new(
                 output_stream,
                 config.get("nocolor", "core").as_bool().unwrap_or_default(),
+                config.get("verbose", "core").as_int().unwrap_or_default(),
             );
             Arc::new(formatter)
         }

--- a/crates/lib/src/cli/formatters.rs
+++ b/crates/lib/src/cli/formatters.rs
@@ -113,12 +113,12 @@ impl Formatter for OutputStreamFormatter {
 }
 
 impl OutputStreamFormatter {
-    pub fn new(output_stream: Option<Stderr>, nocolor: bool) -> Self {
+    pub fn new(output_stream: Option<Stderr>, nocolor: bool, verbosity: i32) -> Self {
         Self {
             output_stream,
             plain_output: Self::should_produce_plain_output(nocolor),
             filter_empty: true,
-            verbosity: 0,
+            verbosity,
             output_line_length: 80,
             has_fail: false.into(),
             files_dispatched: 0.into(),
@@ -347,7 +347,7 @@ mod tests {
     }
 
     fn mk_formatter() -> OutputStreamFormatter {
-        OutputStreamFormatter::new(None, false)
+        OutputStreamFormatter::new(None, false, 0)
     }
 
     #[test]


### PR DESCRIPTION
The original implementation initialises the OutputStreamFormatter with the 'verbosity = 0`. However, the parameter `verbose = (0 - 2)` from the config does not override this value.

How similar to the original SQLFluff implementation do you want to keep scruff? There are a few additional parameters not yet set, which I would be happy to implement.