### PR TITLE
Add attestation for GitHub release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
       - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: cd editors/code && pnpm run build
       - run: cd editors/code && pnpm run package
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # ratchet:actions/attest-build-provenance@v2
+        with:
+          subject-path: "editors/code/*.vsix"
       - name: Publish GitHub release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # ratchet:ncipollo/release-action@v1
         with:
@@ -131,6 +135,11 @@ jobs:
 
       - name: Generate SHA-256 and Save to File
         run: shasum -a 256 ${{ matrix.platform.name }} > ${{ matrix.platform.name }}.sha256
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # ratchet:actions/attest-build-provenance@v2
+        with:
+          subject-path: "sqruff-*"
 
       - name: Publish GitHub release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # ratchet:ncipollo/release-action@v1


### PR DESCRIPTION
Related to #1348

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/quarylabs/sqruff/pull/1392?shareId=5f0b03e3-f482-4c02-9936-1c053852da59).