### PR TITLE
fix:python release

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -402,4 +402,4 @@ jobs:
         with:
           working-directory: crates/cli
           command: upload
-          args: --non-interactive --skip-existing artifacts-*/
+          args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
@benfdking 

It looks like the release didn't work properly/find any files and there is no new release on pypi. I think this might be because of changing line 404 in `python-ci.yml` from:
```yaml
    args: --non-interactive --skip-existing wheels-*/*
```
to:
```yaml          
    args: --non-interactive --skip-existing artifacts-*/
```

**We are using an artifacts-*/ prefix for the binaries however I believe we are still using the 'wheels-' prefix for the wheels** we are uploading as artifacts so we still want to use the `wheels` prefix in the release args on line 404.

Hopefully this PR will fix the python release. 