### PR TITLE
fix:working dir for python wheel publish.

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -400,6 +400,5 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
-          working-directory: crates/cli
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
fix:working dir for python wheel publish.

 I tested and you can see that [the files are now being picked up](https://github.com/quarylabs/sqruff/actions/run