### PR TITLE
fix: add ability to parse returning in sqlite delete update

### DIFF
--- a/crates/lib-dialects/src/sqlite.rs
+++ b/crates/lib-dialects/src/sqlite.rs
@@ -449,6 +449,41 @@ pub fn raw_dialect() -> Dialect {
             .to_matchable()
             .into(),
         ),
+        (
+            "DeleteStatementSegment".into(),
+            NodeMatcher::new(
+                SyntaxKind::DeleteStatement,
+                Sequence::new(vec_of_erased![
+                    Ref::keyword("DELETE"),
+                    Ref::new("FromClauseSegment"),
+                    Ref::new("WhereClauseSegment").optional(),
+                    Ref::new("ReturningClauseSegment").optional()
+                ])
+                .to_matchable(),
+            )
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "UpdateStatementSegment".into(),
+            NodeMatcher::new(
+                SyntaxKind::UpdateStatement,
+                Sequence::new(vec_of_erased![
+                    Ref::keyword("UPDATE"),
+                    Ref::new("TableReferenceSegment"),
+                    Ref::new("AliasExpressionSegment")
+                        .exclude(Ref::keyword("SET"))
+                        .optional(),
+                    Ref::new("SetClauseListSegment"),
+                    Ref::new("FromClauseSegment").optional(),
+                    Ref::new("WhereClauseSegment").optional(),
+                    Ref::new("ReturningClauseSegment").optional()
+                ])
+                .to_matchable(),
+            )
+            .to_matchable()
+            .into(),
+        ),
     ]);
 
     let column_constraint = sqlite_dialect

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/delete.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/delete.sql
@@ -1,0 +1,14 @@
+DELETE FROM table_name
+WHERE a > 0;
+
+DELETE FROM table_name
+WHERE a > 0
+RETURNING *;
+
+DELETE FROM table_name
+WHERE a > 0
+RETURNING a;
+
+DELETE FROM table_name
+WHERE a > 0
+RETURNING a, b AS bee;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/delete.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/delete.yml
@@ -1,0 +1,94 @@
+file:
+- statement:
+  - delete_statement:
+    - keyword: DELETE
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table_name
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+  - delete_statement:
+    - keyword: DELETE
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table_name
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+    - keyword: RETURNING
+    - star: '*'
+- statement_terminator: ;
+- statement:
+  - delete_statement:
+    - keyword: DELETE
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table_name
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+    - keyword: RETURNING
+    - expression:
+      - column_reference:
+        - naked_identifier: a
+- statement_terminator: ;
+- statement:
+  - delete_statement:
+    - keyword: DELETE
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table_name
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+    - keyword: RETURNING
+    - expression:
+      - column_reference:
+        - naked_identifier: a
+    - comma: ','
+    - expression:
+      - column_reference:
+        - naked_identifier: b
+    - alias_expression:
+      - keyword: AS
+      - naked_identifier: bee
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/update.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/update.sql
@@ -1,0 +1,7 @@
+UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1;
+
+UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1 RETURNING *;
+
+UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1 RETURNING column1;
+
+UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1 RETURNING column1 AS c1, column2;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/update.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/update.yml
@@ -1,0 +1,142 @@
+file:
+- statement:
+  - update_statement:
+    - keyword: UPDATE
+    - table_reference:
+      - naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column2
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value2
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - update_statement:
+    - keyword: UPDATE
+    - table_reference:
+      - naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column2
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value2
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - keyword: RETURNING
+    - star: '*'
+- statement_terminator: ;
+- statement:
+  - update_statement:
+    - keyword: UPDATE
+    - table_reference:
+      - naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column2
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value2
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - keyword: RETURNING
+    - expression:
+      - column_reference:
+        - naked_identifier: column1
+- statement_terminator: ;
+- statement:
+  - update_statement:
+    - keyword: UPDATE
+    - table_reference:
+      - naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+          - naked_identifier: column2
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: value2
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - keyword: RETURNING
+    - expression:
+      - column_reference:
+        - naked_identifier: column1
+    - alias_expression:
+      - keyword: AS
+      - naked_identifier: c1
+    - comma: ','
+    - expression:
+      - column_reference:
+        - naked_identifier: column2
+- statement_terminator: ;


### PR DESCRIPTION
Queries including the `RETURNING` clause in `DELETE` and `UPDATE` statements and what comes after them were not being properly parsed in the sqlite dialect. 

I am not sure if this is the best way to go about fixing this but this patch got both the `DELETE` and `UPDATE` queries with a `RETURNING` clause formatting properly. 

Sqlite supports [DELETE](https://sqlite.org/lang_delete.html), [INSERT](https://sqlite.org/lang_insert.html), and [UPDATE](https://sqlite.org/lang_update.html) statements. https://sqlite.org/lang_returning.html

Related to https://github.com/quarylabs/sqruff/issues/1028