### PR TITLE
fix: add sqlite window function grammar spec

### DIFF
--- a/crates/lib-dialects/src/sqlite.rs
+++ b/crates/lib-dialects/src/sqlite.rs
@@ -187,7 +187,12 @@ pub fn raw_dialect() -> Dialect {
         ),
         (
             "PostFunctionGrammar".into(),
-            Ref::new("FilterClauseGrammar").to_matchable().into(),
+            Sequence::new(vec_of_erased![
+                Ref::new("FilterClauseGrammar").optional(),
+                Ref::new("OverClauseSegment"),
+            ])
+            .to_matchable()
+            .into(),
         ),
         (
             "IgnoreRespectNullsGrammar".into(),

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/select.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/select.yml
@@ -100,18 +100,17 @@ file:
                           - column_reference:
                             - naked_identifier: time
                         - end_bracket: )
-                  - expression:
-                    - function:
-                      - function_name:
-                        - function_name_identifier: OVER
-                      - bracketed:
-                        - start_bracket: (
-                        - orderby_clause:
-                          - keyword: ORDER
-                          - keyword: BY
-                          - column_reference:
-                            - naked_identifier: time
-                        - end_bracket: )
+                      - over_clause:
+                        - keyword: OVER
+                        - bracketed:
+                          - start_bracket: (
+                          - window_specification:
+                            - orderby_clause:
+                              - keyword: ORDER
+                              - keyword: BY
+                              - column_reference:
+                                - naked_identifier: time
+                          - end_bracket: )
                   - keyword: as
                   - data_type:
                     - data_type_identifier: real

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/window.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/window.sql
@@ -1,0 +1,10 @@
+SELECT
+  name,
+  ROW_NUMBER() OVER(PARTITION BY dept),
+  salary as sal
+FROM employees;
+
+SELECT c, a, b, group_concat(b, '.') FILTER (WHERE c!='two') OVER (
+  ORDER BY a
+) AS group_concat
+FROM t1 ORDER BY a;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/window.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/window.yml
@@ -1,0 +1,111 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - bracketed:
+            - start_bracket: (
+            - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: dept
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: salary
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: sal
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: employees
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: c
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: group_concat
+          - bracketed:
+            - start_bracket: (
+            - expression:
+              - column_reference:
+                - naked_identifier: b
+            - comma: ','
+            - expression:
+              - quoted_literal: '''.'''
+            - end_bracket: )
+          - keyword: FILTER
+          - bracketed:
+            - start_bracket: (
+            - keyword: WHERE
+            - expression:
+              - column_reference:
+                - naked_identifier: c
+              - comparison_operator:
+                - raw_comparison_operator: '!'
+                - raw_comparison_operator: =
+              - quoted_literal: '''two'''
+            - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                    - naked_identifier: a
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: group_concat
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t1
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+- statement_terminator: ;


### PR DESCRIPTION
Was having an issue where this query wasn't being parsed properly in the sqlite dialect:

```
SELECT
    some_val AS sv,
    ROW_NUMBER() OVER (PARTITION BY name),
    other_val AS ov
FROM tablename;
``` 

I think this patch reflects what the diagram here represents: https://sqlite.org/windowfunctions.html

The previous query gets properly formatted with this patch.