### PR TITLE
feat: accept sqlc style placeholders

### DIFF
--- a/crates/lib/src/templaters/placeholder.rs
+++ b/crates/lib/src/templaters/placeholder.rs
@@ -191,6 +191,9 @@ A few common styles are supported:
 
  -- apache_camel
  WHERE bla = :#${qwe}
+
+ -- at
+ WHERE bla = @my_name
 ```
 
 The can be configured by setting `param_style` in the config file. For example:

--- a/docs/templaters.md
+++ b/docs/templaters.md
@@ -90,6 +90,9 @@ A few common styles are supported:
 
  -- apache_camel
  WHERE bla = :#${qwe}
+
+ -- at
+ WHERE bla = @my_name
 ```
 
 The can be configured by setting `param_style` in the config file. For example:


### PR DESCRIPTION
I'm not a Rust expert, but opening this as a conversation starter. Not sure if this is all it is needed.

So, I've been using sqlc in a golang project and I tried to use named variables as described [here](https://docs.sqlc.dev/en/latest/howto/named_parameters.html) and it caused problems with sqruff formatting.

This is my attempt at supporting that.

EDIT: Tested with the following config in my project and it worked perfectly

```
[sqruff]
templater = placeholder

[sqruff:templater:placeholder]
param_style = at
```