### PR TITLE
Fix typo in templater source

### DIFF
--- a/crates/lib/src/templaters/raw.rs
+++ b/crates/lib/src/templaters/raw.rs
@@ -20,7 +20,7 @@ impl Templater for RawTemplater {
     }
 
     fn description(&self) -> &'static str {
-        r"The raw templater simply returns the input string as the output string. It passes through the input string unchanged and is useful if you need no templating. It is the defualt templater."
+        r"The raw templater simply returns the input string as the output string. It passes through the input string unchanged and is useful if you need no templating. It is the default templater."
     }
 
     fn process(

--- a/docs/templaters.md
+++ b/docs/templaters.md
@@ -31,7 +31,7 @@ Sqruff comes with the following templaters out of the box:
 
 ### raw
 
-The raw templater simply returns the input string as the output string. It passes through the input string unchanged and is useful if you need no templating. It is the defualt templater.
+The raw templater simply returns the input string as the output string. It passes through the input string unchanged and is useful if you need no templating. It is the default templater.
 
 ### placeholder
 


### PR DESCRIPTION
## Summary
- correct misspelling in `RawTemplater` description

## Testing
- `cargo test --manifest-path ./crates/cli/Cargo.toml` *(fails: could not download Rust toolchain)*
- `cargo test --all --all-features --exclude sqruff` *(fails: could not download Rust toolchain)*