### PR TITLE
Fix windows release shasum step

### DIFF
--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -44,8 +44,13 @@ runs:
         cd -
     - name: Generate SHA-256 and Save to File
       if: inputs.package == 'true'
-      run: shasum -a 256 ${{ matrix.platform.name }} > ${{ matrix.platform.name }}.sha256
       shell: bash
+      run: |
+        if command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 "${{ matrix.platform.name }}" > "${{ matrix.platform.name }}.sha256"
+        else
+          sha256sum "${{ matrix.platform.name }}" > "${{ matrix.platform.name }}.sha256"
+        fi
     - name: Generate artifact attestation
       if: inputs.publish == 'true'
       uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # ratchet:actions/attest-build-provenance@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
 jobs:
   convert-release-as-draft:
+    if: startsWith(github.ref, 'refs/tags/')
     name: Convert release to draft
     runs-on: ubuntu-latest
     steps:
@@ -18,8 +19,6 @@ jobs:
   check-versions-match:
     name: Check versions match
     runs-on: ubuntu-latest
-    needs:
-      - convert-release-as-draft
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Install jq
@@ -28,9 +27,13 @@ jobs:
         run: chmod +x ./.hacking/scripts/check_versions_match.sh
       - name: Check release version matches code
         run: |
-          RELEASE_VERSION=${{ github.event.release.tag_name }}
-          STRIPPED_VERSION=${RELEASE_VERSION#v}
-          ./.hacking/scripts/check_versions_match.sh $STRIPPED_VERSION
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            RELEASE_VERSION=${{ github.event.release.tag_name }}
+            STRIPPED_VERSION=${RELEASE_VERSION#v}
+            ./.hacking/scripts/check_versions_match.sh "$STRIPPED_VERSION"
+          else
+            ./.hacking/scripts/check_versions_match.sh
+          fi
   release-vsix:
     name: Release VSIX
     runs-on: ubuntu-latest
@@ -64,6 +67,7 @@ jobs:
         with:
           subject-path: "editors/code/*.vsix"
       - name: Publish GitHub release
+        if: github.event_name != 'workflow_dispatch'
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # ratchet:ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -115,6 +119,7 @@ jobs:
           package: true
           publish: true
       - name: Publish GitHub release
+        if: github.event_name != 'workflow_dispatch'
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # ratchet:ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -126,6 +131,7 @@ jobs:
           artifacts: |
             sqruff-*
   build-and-push-docker:
+    if: github.event_name != 'workflow_dispatch'
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs:
@@ -152,6 +158,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sqruff:latest
           platforms: linux/amd64,linux/arm64
   convert_release_to_not_draft:
+    if: github.event_name != 'workflow_dispatch'
     name: Convert release to not draft
     runs-on: ubuntu-latest
     permissions: write-all
@@ -165,6 +172,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   update-homebrew-formula:
+    if: github.event_name != 'workflow_dispatch'
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
     needs: [convert_release_to_not_draft]
@@ -175,6 +183,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - run: ./.hacking/scripts/update_homebrew_pr.sh $HOMEBREW_ACCESS_TOKEN
   publish-to-cargo:
+    if: github.event_name != 'workflow_dispatch'
     name: Publish to Cargo
     runs-on: ubuntu-latest
     needs: [convert_release_to_not_draft]
@@ -210,6 +219,7 @@ jobs:
           command: publish
           args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff
   publish-to-marketplace:
+    if: github.event_name != 'workflow_dispatch'
     name: Publish VSIX to VSCode Marketplace
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Summary
- update `shasum` step in the `build-binaries` composite action to fall back to `sha256sum` if `shasum` isn't available
- allow running the release workflow manually on any branch

## Testing
- `cargo test --manifest-path ./crates/cli/Cargo.toml -- --list` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6841a5a5e85c8330b0044c3e81894574