### PR TITLE
ci: add --no-fail-fast to cargo test commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ rust_lint: ## Lint rust code
 .PHONY: rust_test
 rust_test: ## Run rust tests
 	cd crates/cli-python && maturin develop
-	cargo test --manifest-path ./crates/cli/Cargo.toml
-	cargo test --all --all-features --exclude sqruff
+	cargo test --no-fail-fast --manifest-path ./crates/cli/Cargo.toml
+	cargo test --no-fail-fast --all --all-features --exclude sqruff
 
 .PHONY: ci
 ci: ratchet_check python_ci rust_test ## Run all CI checks


### PR DESCRIPTION
## Summary
- Added `--no-fail-fast` flag to all cargo test commands in the Makefile
- This ensures all tests run even if some fail, providing complete test results

## Motivation
The `--no-fail-fast` flag is crucial for debugging CI issues. Without it, cargo test stops at the first failing test, which can hide additional failures that might be related to the same root cause. By running all tests regardless of failures, developers get a complete picture of what's broken, making it easier to:

1. Identify patterns in failures
2. Fix multiple related issues at once
3. Understand the full scope of a breaking change
4. Debug flaky tests by seeing all occurrences

This change applies to both test commands in the Makefile:
- `cargo test --no-fail-fast --manifest-path ./crates/cli/Cargo.toml`
- `cargo test --no-fail-fast --all --all-features --exclude sqruff`

## Test plan
- [x] Updated Makefile with --no-fail-fast flags
- [ ] CI runs will now show all test failures instead of stopping at the first one
- [ ] No functional changes to the tests themselves

🤖 Generated with [Claude Code](https://claude.ai/code)