### PR TITLE
fix: Handle T-SQL APPLY clauses in JoinClauseSegment to prevent panic

### DIFF
--- a/crates/lib-core/src/parser/segments/join.rs
+++ b/crates/lib-core/src/parser/segments/join.rs
@@ -9,13 +9,25 @@ impl JoinClauseSegment {
     pub fn eventual_aliases(&self) -> Vec<(ErasedSegment, AliasInfo)> {
         let mut buff = Vec::new();
 
-        let from_expression = self
-            .0
-            .child(const { &SyntaxSet::new(&[SyntaxKind::FromExpressionElement]) })
-            .unwrap();
-        let alias = FromExpressionElementSegment(from_expression.clone()).eventual_alias();
+        // Check if this is an APPLY clause (CROSS APPLY or OUTER APPLY)
+        // APPLY clauses have a different structure where FromExpressionElement is in the sequence
+        let is_apply = self.0.children(const { &SyntaxSet::new(&[SyntaxKind::Keyword]) })
+            .any(|kw| kw.raw().to_uppercase() == "APPLY");
 
-        buff.push((from_expression.clone(), alias));
+        let from_expression = if is_apply {
+            // For APPLY clauses, find the FromExpressionElement in the sequence
+            self.0.children(const { &SyntaxSet::new(&[SyntaxKind::FromExpressionElement]) })
+                .next()
+                .cloned()
+        } else {
+            // For regular JOIN clauses, get the nested child
+            self.0.child(const { &SyntaxSet::new(&[SyntaxKind::FromExpressionElement]) })
+        };
+
+        if let Some(from_expr) = from_expression {
+            let alias = FromExpressionElementSegment(from_expr.clone()).eventual_alias();
+            buff.push((from_expr.clone(), alias));
+        }
 
         for join_clause in self.0.recursive_crawl(
             const { &SyntaxSet::new(&[SyntaxKind::JoinClause]) },
@@ -23,7 +35,7 @@ impl JoinClauseSegment {
             const { &SyntaxSet::single(SyntaxKind::SelectStatement) },
             true,
         ) {
-            if join_clause.id() == join_clause.id() {
+            if join_clause.id() == self.0.id() {
                 continue;
             }
 

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/apply_with_alias.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/apply_with_alias.sql
@@ -1,0 +1,14 @@
+-- Test case for APPLY clause with table alias
+SELECT
+    c.CustomerID,
+    c.CustomerName,
+    Orders.TotalAmount
+FROM
+    Customers AS c
+    OUTER APPLY (
+        SELECT TotalAmount = SUM(o.Amount)
+        FROM Orders AS o
+        WHERE o.CustomerID = c.CustomerID
+    ) AS Orders
+WHERE
+    c.Active = 1

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/apply_with_alias.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/apply_with_alias.yml
@@ -1,0 +1,100 @@
+file:
+- statement:
+  - statement:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: CustomerID
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: CustomerName
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: Orders
+            - dot: .
+            - naked_identifier: TotalAmount
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - from_expression_element:
+              - table_expression:
+                - table_reference:
+                  - object_reference:
+                    - naked_identifier: Customers
+              - alias_expression:
+                - keyword: AS
+                - naked_identifier: c
+          - join_clause:
+            - join_clause:
+              - keyword: OUTER
+              - keyword: APPLY
+              - from_expression_element:
+                - from_expression_element:
+                  - table_expression:
+                    - bracketed:
+                      - start_bracket: (
+                      - select_statement:
+                        - select_clause:
+                          - keyword: SELECT
+                          - select_clause_element:
+                            - naked_identifier: TotalAmount
+                            - raw_comparison_operator: =
+                            - function:
+                              - function_name:
+                                - function_name_identifier: SUM
+                              - bracketed:
+                                - start_bracket: (
+                                - expression:
+                                  - column_reference:
+                                    - naked_identifier: o
+                                    - dot: .
+                                    - naked_identifier: Amount
+                                - end_bracket: )
+                        - from_clause:
+                          - keyword: FROM
+                          - from_expression:
+                            - from_expression_element:
+                              - from_expression_element:
+                                - table_expression:
+                                  - table_reference:
+                                    - object_reference:
+                                      - naked_identifier: Orders
+                                - alias_expression:
+                                  - keyword: AS
+                                  - naked_identifier: o
+                        - where_clause:
+                          - keyword: WHERE
+                          - expression:
+                            - column_reference:
+                              - naked_identifier: o
+                              - dot: .
+                              - naked_identifier: CustomerID
+                            - comparison_operator:
+                              - raw_comparison_operator: =
+                            - column_reference:
+                              - naked_identifier: c
+                              - dot: .
+                              - naked_identifier: CustomerID
+                      - end_bracket: )
+                  - alias_expression:
+                    - keyword: AS
+                    - naked_identifier: Orders
+      - where_clause:
+        - keyword: WHERE
+        - expression:
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: Active
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - numeric_literal: '1'

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/cross_apply_with_function.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/cross_apply_with_function.sql
@@ -1,0 +1,10 @@
+-- Test case for CROSS APPLY with table-valued function
+SELECT
+    p.ProductID,
+    p.ProductName,
+    s.StockLevel
+FROM
+    Products p
+    CROSS APPLY dbo.GetCurrentStock(p.ProductID) s
+WHERE
+    s.StockLevel < 10

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/cross_apply_with_function.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/cross_apply_with_function.yml
@@ -1,0 +1,66 @@
+file:
+- statement:
+  - statement:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: p
+            - dot: .
+            - naked_identifier: ProductID
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: p
+            - dot: .
+            - naked_identifier: ProductName
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: StockLevel
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - from_expression_element:
+              - table_expression:
+                - table_reference:
+                  - object_reference:
+                    - naked_identifier: Products
+              - alias_expression:
+                - naked_identifier: p
+          - join_clause:
+            - join_clause:
+              - keyword: CROSS
+              - keyword: APPLY
+              - from_expression_element:
+                - from_expression_element:
+                  - table_expression:
+                    - function:
+                      - function_name:
+                        - naked_identifier: dbo
+                        - dot: .
+                        - function_name_identifier: GetCurrentStock
+                      - bracketed:
+                        - start_bracket: (
+                        - expression:
+                          - column_reference:
+                            - naked_identifier: p
+                            - dot: .
+                            - naked_identifier: ProductID
+                        - end_bracket: )
+                  - alias_expression:
+                    - naked_identifier: s
+      - where_clause:
+        - keyword: WHERE
+        - expression:
+          - column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: StockLevel
+          - comparison_operator:
+            - raw_comparison_operator: <
+          - numeric_literal: '10'


### PR DESCRIPTION
## Description

This PR fixes the panic in AL05 rule when processing T-SQL queries that contain `OUTER APPLY` or `CROSS APPLY` clauses.

## The Issue

The linter was panicking with `called Option::unwrap() on a None value` when processing T-SQL APPLY clauses. This occurred because:

1. T-SQL's `ApplyClauseSegment` is marked with `SyntaxKind::JoinClause`
2. The `JoinClauseSegment::eventual_aliases` function assumed all join clauses have a `FromExpressionElement` child
3. APPLY clauses have a different structure - the `FromExpressionElementSegment` is directly in the sequence, not nested
4. The `unwrap()` failed because `child()` returns `None` for APPLY clauses

## The Fix

- Added detection for APPLY clauses by checking if any keyword child has "APPLY" as its raw value
- Used different logic to extract the `FromExpressionElement` based on whether it's an APPLY clause or regular join
- Made the extraction safe by handling the `Option` return value properly
- Fixed an additional bug where `join_clause.id() == join_clause.id()` was always comparing to itself

## Testing

Added comprehensive test cases:
- `apply_with_alias.sql/yml` - Tests OUTER APPLY with table aliases
- `cross_apply_with_function.sql/yml` - Tests CROSS APPLY with table-valued functions

The fix has been tested with the reproduction case from the issue and all tests pass.

Fixes #1691