### PR TITLE
chore: add test for keywords: upper and functions: lower

### DIFF
--- a/crates/lib/test/fixtures/rules/std_rule_cases/CP01_CP03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CP01_CP03.yml
@@ -1,0 +1,10 @@
+rule: CP01,CP03
+
+test_pass_keyword_upper_function_lower:
+  pass_str: SELECT 1, coalesce(1, 0) FROM blah
+  configs:
+    rules:
+      capitalisation.keywords:
+        capitalisation_policy: upper
+      capitalisation.functions:
+        extended_capitalisation_policy: lower

--- a/crates/lib/tests/rules.rs
+++ b/crates/lib/tests/rules.rs
@@ -147,7 +147,7 @@ fn main() {
             }
 
             let has_config = !case.configs.is_empty();
-            let rule = case.configs.get("rules").and_then(|it| it.as_string());
+            let rule = &file.rule;
             if has_config {
                 *linter.config_mut() = FluffConfig::new(case.configs.clone(), None, None);
                 linter.config_mut().raw.extend(core.clone());
@@ -196,7 +196,7 @@ The following test test can be used to recreate the issue:
 
 #[cfg(test)]
 mod tests {{
-    use crate::core::{{config::FluffConfig, linter::core::Linter}};
+    use sqruff_lib::core::{{config::FluffConfig, linter::core::Linter}};
 
     #[test]
     fn test_example() {{
@@ -212,11 +212,11 @@ dialect = {dialect}
         let pass_str = r"{pass_str}";
 
         let f = linter.lint_string_wrapped(&pass_str, false);
-        assert_eq!(&f.paths[0].files[0].violations, &[]);
+        assert_eq!(&f.violations, &[]);
     }}
 }}
 "#,
-                        rule = rule.unwrap_or(""),
+                        rule = rule,
                         dialect = dialect_name,
                         pass_str = pass_str
                     );

--- a/crates/lib/tests/rules.rs
+++ b/crates/lib/tests/rules.rs
@@ -88,10 +88,17 @@ fn main() {
         let input = std::fs::read_to_string(path).unwrap();
 
         let file: TestFile = serde_yaml::from_str(&input).unwrap();
-        core.get_mut("core").unwrap().as_map_mut().unwrap().insert(
-            "rule_allowlist".into(),
-            Value::Array(vec![Value::String(file.rule.clone().into())]),
-        );
+        let file_rules = file
+            .rule
+            .split(",")
+            .map(|x| Value::String(x.into()))
+            .collect::<Vec<Value>>();
+
+        core.get_mut("core")
+            .unwrap()
+            .as_map_mut()
+            .unwrap()
+            .insert("rule_allowlist".into(), Value::Array(file_rules));
 
         linter.config_mut().raw.extend(core.clone());
         linter.config_mut().reload_reflow();


### PR DESCRIPTION
I think https://github.com/quarylabs/sqruff/pull/1698 broke formatting for functions (I didn't verify that this exact PR brakes it), see the test in 7d9a438dfc68a5b9b4f6f04430bcbc78b8e0d330

I checked that this test works correctly on v0.27.0, but it doesn't work on main

cc: @Fank @benfdking 