### PR TITLE
fix: T-SQL parser incorrectly handles alias = expression syntax

### DIFF
--- a/crates/lib-dialects/test/fixtures/dialects/tsql/alias_equals_syntax.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/alias_equals_syntax.yml
@@ -5,16 +5,18 @@ file:
       - keyword: SELECT
       - select_clause_element:
         - naked_identifier: TsqlAlias
-        - raw_comparison_operator: =
-        - function:
-          - function_name:
-            - function_name_identifier: SUM
-          - bracketed:
-            - start_bracket: (
-            - expression:
-              - column_reference:
-                - naked_identifier: quantity
-            - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - expression:
+          - function:
+            - function_name:
+              - function_name_identifier: SUM
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: quantity
+              - end_bracket: )
     - from_clause:
       - keyword: FROM
       - from_expression:

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/apply_with_alias.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/apply_with_alias.yml
@@ -43,18 +43,20 @@ file:
                     - keyword: SELECT
                     - select_clause_element:
                       - naked_identifier: TotalAmount
-                      - raw_comparison_operator: =
-                      - function:
-                        - function_name:
-                          - function_name_identifier: SUM
-                        - bracketed:
-                          - start_bracket: (
-                          - expression:
-                            - column_reference:
-                              - naked_identifier: o
-                              - dot: .
-                              - naked_identifier: Amount
-                          - end_bracket: )
+                      - comparison_operator:
+                        - raw_comparison_operator: =
+                      - expression:
+                        - function:
+                          - function_name:
+                            - function_name_identifier: SUM
+                          - bracketed:
+                            - start_bracket: (
+                            - expression:
+                              - column_reference:
+                                - naked_identifier: o
+                                - dot: .
+                                - naked_identifier: Amount
+                            - end_bracket: )
                   - from_clause:
                     - keyword: FROM
                     - from_expression:

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/tsql_alias_column_ref.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/tsql_alias_column_ref.yml
@@ -5,13 +5,15 @@ file:
       - keyword: SELECT
       - select_clause_element:
         - naked_identifier: SimpleAlias
-        - raw_comparison_operator: =
+        - comparison_operator:
+          - raw_comparison_operator: =
         - column_reference:
           - naked_identifier: value
       - comma: ','
       - select_clause_element:
         - naked_identifier: QualifiedAlias
-        - raw_comparison_operator: =
+        - comparison_operator:
+          - raw_comparison_operator: =
         - column_reference:
           - naked_identifier: table1
           - dot: .
@@ -19,7 +21,8 @@ file:
       - comma: ','
       - select_clause_element:
         - naked_identifier: FullyQualifiedAlias
-        - raw_comparison_operator: =
+        - comparison_operator:
+          - raw_comparison_operator: =
         - column_reference:
           - naked_identifier: dbo
           - dot: .
@@ -29,20 +32,23 @@ file:
       - comma: ','
       - select_clause_element:
         - naked_identifier: FunctionAlias
-        - raw_comparison_operator: =
-        - function:
-          - function_name:
-            - function_name_identifier: SUM
-          - bracketed:
-            - start_bracket: (
-            - expression:
-              - column_reference:
-                - naked_identifier: quantity
-            - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - expression:
+          - function:
+            - function_name:
+              - function_name_identifier: SUM
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: quantity
+              - end_bracket: )
       - comma: ','
       - select_clause_element:
         - naked_identifier: ExpressionAlias
-        - raw_comparison_operator: =
+        - comparison_operator:
+          - raw_comparison_operator: =
         - expression:
           - column_reference:
             - naked_identifier: table1

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/tsql_alias_simple.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/tsql_alias_simple.yml
@@ -5,7 +5,8 @@ file:
       - keyword: SELECT
       - select_clause_element:
         - naked_identifier: TsqlAlias
-        - raw_comparison_operator: =
+        - comparison_operator:
+          - raw_comparison_operator: =
         - column_reference:
           - naked_identifier: value
     - from_clause:

--- a/crates/lib/src/rules/convention/cv05.rs
+++ b/crates/lib/src/rules/convention/cv05.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use ahash::AHashMap;
+use sqruff_lib_core::dialects::init::DialectKind;
 use sqruff_lib_core::dialects::syntax::{SyntaxKind, SyntaxSet};
 use sqruff_lib_core::parser::segments::{ErasedSegment, SegmentBuilder};
 use sqruff_lib_core::utils::functional::segments::Segments;
@@ -99,6 +100,17 @@ WHERE a IS NULL
                 if context.parent_stack[context.parent_stack.len() - 1].is_type(type_str) {
                     return Vec::new();
                 }
+            }
+        }
+
+        // Check for T-SQL alias syntax in SELECT clause (e.g., "name = null")
+        if !context.parent_stack.is_empty()
+            && context.parent_stack[context.parent_stack.len() - 1]
+                .is_type(SyntaxKind::SelectClauseElement)
+        {
+            // In T-SQL, "alias = expression" in SELECT is an alias assignment, not a comparison
+            if context.dialect.name == DialectKind::Tsql {
+                return Vec::new();
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes the T-SQL parser to properly handle the `alias = expression` syntax, particularly when used with `TOP` clauses. The parser was previously creating unparsable segments for this valid T-SQL syntax.

## Problem

The T-SQL dialect supports an alternative column alias syntax: `AliasName = ColumnExpression`. This was failing to parse correctly when used with `TOP` or `DISTINCT TOP` modifiers, causing the AL02 rule to incorrectly flag valid syntax.

Example of valid T-SQL that was failing:
```sql
SELECT DISTINCT TOP 20 JiraIssueID = JiraIssue.i_jira_id
FROM JiraIssue
```

## Solution

1. **Parser Grammar Fix**: Updated the T-SQL dialect grammar to use `SingleIdentifierGrammar` which properly handles terminators and doesn't consume tokens beyond line boundaries
2. **AST Structure Fix**: Fixed the grammar to properly wrap comparison operators in `ComparisonOperator` nodes
3. **CV05 Rule Update**: Added logic to exclude T-SQL alias assignments in SELECT clauses from NULL comparison detection

## Changes

- Updated T-SQL dialect `SelectClauseElementSegment` grammar to properly parse `alias = expression` syntax
- Fixed AST structure by removing duplicate `EqualsSegment` definition that prevented proper wrapping
- Updated CV05 rule to understand T-SQL alias syntax vs actual comparisons
- Updated 4 T-SQL test fixture files to reflect the correct AST structure

## Testing

- All existing tests pass
- Parser correctly handles T-SQL alias syntax with and without TOP modifiers
- CV05 correctly excludes T-SQL alias assignments from NULL comparison checks

Fixes #1750

🤖 Generated with [Claude Code](https://claude.ai/code)