### PR TITLE
feat: format and into outfile in clickhouse

### DIFF
--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/format.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/format.sql
@@ -1,0 +1,9 @@
+SELECT test FROM toto FORMAT CSV;
+
+SELECT 1 FORMAT CSV;
+
+SELECT 1 as test FORMAT CSV;
+
+SELECT test FROM dual where test = '1' FORMAT CSV;
+
+SELECT test FROM dual where test = '1' FORMAT CSV SETTINGS format_csv_delimiter = ',';

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/format.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/format.yml
@@ -1,0 +1,94 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: test
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: toto
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - numeric_literal: '1'
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - numeric_literal: '1'
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: test
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: test
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: dual
+    - where_clause:
+      - keyword: where
+      - expression:
+        - column_reference:
+          - naked_identifier: test
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''1'''
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: test
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: dual
+    - where_clause:
+      - keyword: where
+      - expression:
+        - column_reference:
+          - naked_identifier: test
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''1'''
+    - keyword: FORMAT
+    - word: CSV
+    - keyword: SETTINGS
+    - naked_identifier: format_csv_delimiter
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - quoted_literal: ''','''
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/into_outfile.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/into_outfile.sql
@@ -1,0 +1,7 @@
+SELECT 1 INTO OUTFILE '/tmp/test';
+
+SELECT 1 as test INTO OUTFILE '/tmp/test' FORMAT TabSeparated;
+
+SELECT test FROM dual where test = '1' INTO OUTFILE '/tmp/test' FORMAT TabSeparated;
+
+SELECT test FROM dual INTO OUTFILE '/tmp/test' FORMAT CSV;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/into_outfile.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/into_outfile.yml
@@ -1,0 +1,74 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - numeric_literal: '1'
+    - keyword: INTO
+    - keyword: OUTFILE
+    - quoted_literal: '''/tmp/test'''
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - numeric_literal: '1'
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: test
+    - keyword: INTO
+    - keyword: OUTFILE
+    - quoted_literal: '''/tmp/test'''
+    - keyword: FORMAT
+    - word: TabSeparated
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: test
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: dual
+    - where_clause:
+      - keyword: where
+      - expression:
+        - column_reference:
+          - naked_identifier: test
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''1'''
+    - keyword: INTO
+    - keyword: OUTFILE
+    - quoted_literal: '''/tmp/test'''
+    - keyword: FORMAT
+    - word: TabSeparated
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: test
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: dual
+    - keyword: INTO
+    - keyword: OUTFILE
+    - quoted_literal: '''/tmp/test'''
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;


### PR DESCRIPTION
see https://github.com/sqlfluff/sqlfluff/pull/6065

This is not 1:1 translation of changes from sqlfluff

IMO formats should not be treated as keyword, because:
* capitalisation rules should not be applied to formats
* I want to avoid maintaining a list of formats