### PR TITLE
Add LT15 rule for blank lines

### DIFF
--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -413,6 +413,11 @@ ignore_comment_clauses = False
 [sqlfluff:rules:layout.select_targets]
 wildcard_policy = single
 
+[sqlfluff:rules:layout.newlines]
+# Consecutive blank lines
+maximum_empty_lines_between_statements = 2
+maximum_empty_lines_inside_statements = 1
+
 [sqlfluff:rules:structure.subquery]
 # By default, allow subqueries in from clauses, but not join clauses
 forbid_subquery_in = join

--- a/crates/lib/src/rules/layout.rs
+++ b/crates/lib/src/rules/layout.rs
@@ -13,6 +13,7 @@ pub mod lt10;
 pub mod lt11;
 pub mod lt12;
 pub mod lt13;
+pub mod lt15;
 
 pub fn rules() -> Vec<ErasedRule> {
     use crate::core::rules::Erased as _;
@@ -31,5 +32,6 @@ pub fn rules() -> Vec<ErasedRule> {
         lt11::RuleLT11.erased(),
         lt12::RuleLT12.erased(),
         lt13::RuleLT13.erased(),
+        lt15::RuleLT15::default().erased(),
     ]
 }

--- a/crates/lib/src/rules/layout/lt15.rs
+++ b/crates/lib/src/rules/layout/lt15.rs
@@ -1,0 +1,124 @@
+use ahash::AHashMap;
+use sqruff_lib_core::dialects::syntax::{SyntaxKind, SyntaxSet};
+use sqruff_lib_core::lint_fix::LintFix;
+
+use crate::core::config::Value;
+use crate::core::rules::context::RuleContext;
+use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
+use crate::core::rules::{Erased, ErasedRule, LintResult, Rule, RuleGroups};
+
+#[derive(Debug, Clone)]
+pub struct RuleLT15 {
+    maximum_empty_lines_between_statements: usize,
+    maximum_empty_lines_inside_statements: usize,
+}
+
+impl Default for RuleLT15 {
+    fn default() -> Self {
+        Self {
+            maximum_empty_lines_between_statements: 2,
+            maximum_empty_lines_inside_statements: 1,
+        }
+    }
+}
+
+impl Rule for RuleLT15 {
+    fn load_from_config(&self, config: &AHashMap<String, Value>) -> Result<ErasedRule, String> {
+        Ok(RuleLT15 {
+            maximum_empty_lines_between_statements: config
+                .get("maximum_empty_lines_between_statements")
+                .and_then(Value::as_int)
+                .map(|v| v as usize)
+                .unwrap_or(self.maximum_empty_lines_between_statements),
+            maximum_empty_lines_inside_statements: config
+                .get("maximum_empty_lines_inside_statements")
+                .and_then(Value::as_int)
+                .map(|v| v as usize)
+                .unwrap_or(self.maximum_empty_lines_inside_statements),
+        }
+        .erased())
+    }
+
+    fn name(&self) -> &'static str {
+        "layout.newlines"
+    }
+
+    fn description(&self) -> &'static str {
+        "Too many consecutive blank lines."
+    }
+
+    fn long_description(&self) -> &'static str {
+        r#"**Anti-pattern**
+
+In this example, the maximum number of empty lines inside a statement is set to 0.
+
+```sql
+    SELECT 'a' AS col
+    FROM tab
+
+
+    WHERE x = 4
+    ORDER BY y
+
+
+    LIMIT 5
+    ;
+```
+
+**Best practice**
+
+```sql
+    SELECT 'a' AS col
+    FROM tab
+    WHERE x = 4
+    ORDER BY y
+    LIMIT 5
+    ;
+```"#
+    }
+
+    fn groups(&self) -> &'static [RuleGroups] {
+        &[RuleGroups::All, RuleGroups::Layout]
+    }
+
+    fn eval(&self, context: &RuleContext) -> Vec<LintResult> {
+        let inside_statement = context
+            .parent_stack
+            .iter()
+            .any(|seg| seg.is_type(SyntaxKind::Statement));
+        let maximum_empty_lines = if inside_statement {
+            self.maximum_empty_lines_inside_statements
+        } else {
+            self.maximum_empty_lines_between_statements
+        };
+
+        if context.raw_stack.len() < maximum_empty_lines {
+            return Vec::new();
+        }
+
+        let slice_start = context.raw_stack.len() - maximum_empty_lines;
+        if context.raw_stack[slice_start..]
+            .iter()
+            .all(|seg| seg.is_type(SyntaxKind::Newline))
+        {
+            return vec![LintResult::new(
+                context.segment.clone().into(),
+                vec![LintFix::delete(context.segment.clone())],
+                None,
+                None,
+            )];
+        }
+
+        Vec::new()
+    }
+
+    fn is_fix_compatible(&self) -> bool {
+        true
+    }
+
+    fn crawl_behaviour(&self) -> Crawler {
+        SegmentSeekerCrawler::new(const { SyntaxSet::new(&[SyntaxKind::Newline]) })
+            .provide_raw_stack()
+            .into()
+    }
+}

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -1,0 +1,82 @@
+rule: LT15
+
+test_pass_no_empty_lines:
+  pass_str: |
+    SELECT foo
+    FROM bar
+
+test_pass_one_empty_line:
+  pass_str: |
+    SELECT foo
+
+    FROM
+      bar
+  configs:
+    rules:
+      layout.newlines:
+        maximum_empty_lines_inside_statements: 1
+
+test_fail_no_empty_lines:
+  fail_str: |
+    SELECT foo
+
+    FROM
+      bar
+  fix_str: |
+    SELECT foo
+    FROM
+      bar
+  configs:
+    rules:
+      layout.newlines:
+        maximum_empty_lines_inside_statements: 0
+
+test_fail_one_empty_line_between_statements:
+  fail_str: |
+    SELECT foo
+    FROM
+      bar
+    ;
+
+
+    SELECT foo
+    ;
+  fix_str: |
+    SELECT foo
+    FROM
+      bar
+    ;
+
+    SELECT foo
+    ;
+  configs:
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_statements: 1
+
+test_fail_bad_edge_case:
+  fail_str: |
+    SELECT foo
+    FROM
+      bar
+
+
+    ;
+
+
+    SELECT foo
+    ;
+  fix_str: |
+    SELECT foo
+    FROM
+      bar
+
+    ;
+
+    SELECT foo
+    ;
+  configs:
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_statements: 1
+        maximum_empty_lines_within_statements: 0

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -49,10 +49,10 @@ The following rules are available in this create. This list is generated from th
 | LT09 | [layout.select_targets](#layoutselect_targets) | Select targets should be on a new line unless there is only one select target. | 
 | LT10 | [layout.select_modifiers](#layoutselect_modifiers) | 'SELECT' modifiers (e.g. 'DISTINCT') must be on the same line as 'SELECT'. | 
 | LT11 | [layout.set_operators](#layoutset_operators) | Set operators should be surrounded by newlines. | 
-| LT12 | [layout.end_of_file](#layoutend_of_file) | Files must end with a single trailing newline. |
-| LT13 | [layout.start_of_file](#layoutstart_of_file) | Files must not begin with newlines or whitespace. |
-| LT15 | [layout.newlines](#layoutnewlines) | Too many consecutive blank lines. |
-| RF01 | [references.from](#referencesfrom) | References cannot reference objects not present in 'FROM' clause. |
+| LT12 | [layout.end_of_file](#layoutend_of_file) | Files must end with a single trailing newline. | 
+| LT13 | [layout.start_of_file](#layoutstart_of_file) | Files must not begin with newlines or whitespace. | 
+| LT15 | [layout.newlines](#layoutnewlines) | Too many consecutive blank lines. | 
+| RF01 | [references.from](#referencesfrom) | References cannot reference objects not present in 'FROM' clause. | 
 | RF02 | [references.qualification](#referencesqualification) | References should be qualified if select has more than one referenced table/view. | 
 | RF03 | [references.consistent](#referencesconsistent) | References should be consistent in statements with a single table. | 
 | RF04 | [references.keywords](#referenceskeywords) | Keywords should not be used as identifiers. | 
@@ -1796,8 +1796,8 @@ Start file on either code or comment. (The ^ represents the beginning of the fil
  ^--This is a description of my SQL code.
  SELECT
      a
-FROM
-    foo
+ FROM
+     foo
 ```
 
 
@@ -1810,7 +1810,6 @@ Too many consecutive blank lines.
 **Groups:** `all`, `layout`
 
 **Fixable:** Yes
-
 **Anti-pattern**
 
 In this example, the maximum number of empty lines inside a statement is set to 0.
@@ -1838,7 +1837,6 @@ In this example, the maximum number of empty lines inside a statement is set to 
     LIMIT 5
     ;
 ```
-
 
 ### references.from
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -49,9 +49,10 @@ The following rules are available in this create. This list is generated from th
 | LT09 | [layout.select_targets](#layoutselect_targets) | Select targets should be on a new line unless there is only one select target. | 
 | LT10 | [layout.select_modifiers](#layoutselect_modifiers) | 'SELECT' modifiers (e.g. 'DISTINCT') must be on the same line as 'SELECT'. | 
 | LT11 | [layout.set_operators](#layoutset_operators) | Set operators should be surrounded by newlines. | 
-| LT12 | [layout.end_of_file](#layoutend_of_file) | Files must end with a single trailing newline. | 
-| LT13 | [layout.start_of_file](#layoutstart_of_file) | Files must not begin with newlines or whitespace. | 
-| RF01 | [references.from](#referencesfrom) | References cannot reference objects not present in 'FROM' clause. | 
+| LT12 | [layout.end_of_file](#layoutend_of_file) | Files must end with a single trailing newline. |
+| LT13 | [layout.start_of_file](#layoutstart_of_file) | Files must not begin with newlines or whitespace. |
+| LT15 | [layout.newlines](#layoutnewlines) | Too many consecutive blank lines. |
+| RF01 | [references.from](#referencesfrom) | References cannot reference objects not present in 'FROM' clause. |
 | RF02 | [references.qualification](#referencesqualification) | References should be qualified if select has more than one referenced table/view. | 
 | RF03 | [references.consistent](#referencesconsistent) | References should be consistent in statements with a single table. | 
 | RF04 | [references.keywords](#referenceskeywords) | Keywords should not be used as identifiers. | 
@@ -1795,8 +1796,47 @@ Start file on either code or comment. (The ^ represents the beginning of the fil
  ^--This is a description of my SQL code.
  SELECT
      a
- FROM
-     foo
+FROM
+    foo
+```
+
+
+### layout.newlines
+
+Too many consecutive blank lines.
+
+**Code:** `LT15`
+
+**Groups:** `all`, `layout`
+
+**Fixable:** Yes
+
+**Anti-pattern**
+
+In this example, the maximum number of empty lines inside a statement is set to 0.
+
+```sql
+    SELECT 'a' AS col
+    FROM tab
+
+
+    WHERE x = 4
+    ORDER BY y
+
+
+    LIMIT 5
+    ;
+```
+
+**Best practice**
+
+```sql
+    SELECT 'a' AS col
+    FROM tab
+    WHERE x = 4
+    ORDER BY y
+    LIMIT 5
+    ;
 ```
 
 


### PR DESCRIPTION
## Summary
- implement layout.newlines rule (LT15)
- document LT15 and add default configuration
- add YAML test cases for LT15

## Testing
- `cargo test --manifest-path crates/lib/Cargo.toml --no-run`

------
https://chatgpt.com/codex/tasks/task_e_687a0c650e1483308a25af6658625633