### PR TITLE
docs: fix links to templater details

### DIFF
--- a/docs/templaters.md
+++ b/docs/templaters.md
@@ -21,11 +21,11 @@ templater = raw
 
 Sqruff comes with the following templaters out of the box:
 
-- [raw](raw)
-- [placeholder](placeholder)
-- [python](python)
-- [jinja](jinja)
-- [dbt](dbt)
+- [raw](###raw)
+- [placeholder](###placeholder)
+- [python](###python)
+- [jinja](###jinja)
+- [dbt](###dbt)
 
 ## Details
 


### PR DESCRIPTION
The links in this document go nowhere.

PR to redirect them to the corresponding parts of the doc.