### PR TITLE
fix: avoid touching files when fixes are no-op

### DIFF
--- a/crates/cli-lib/src/commands_fix.rs
+++ b/crates/cli-lib/src/commands_fix.rs
@@ -22,13 +22,12 @@ pub(crate) fn run_fix(
         let files = result.len();
 
         for mut file in result {
-            let path = std::mem::take(&mut file.path);
-            let source = file.source_str().to_string();
-            let fixed = file.fix_string();
-
-            if fixed != source {
-                std::fs::write(path, fixed).unwrap();
+            if !file.has_fixes() {
+                continue;
             }
+            let path = std::mem::take(&mut file.path);
+            let fixed = file.fix_string();
+            std::fs::write(path, fixed).unwrap();
         }
 
         linter.formatter_mut().unwrap().completion_message(files);

--- a/crates/lib/src/core/linter/linted_file.rs
+++ b/crates/lib/src/core/linter/linted_file.rs
@@ -49,8 +49,8 @@ impl LintedFile {
         &self.path
     }
 
-    pub fn source_str(&self) -> &str {
-        &self.templated_file.source_str
+    pub fn has_fixes(&self) -> bool {
+        !self.patches.is_empty()
     }
 
     pub fn into_violations(self) -> Vec<SQLBaseError> {

--- a/crates/lib/src/core/linter/linted_file.rs
+++ b/crates/lib/src/core/linter/linted_file.rs
@@ -49,6 +49,10 @@ impl LintedFile {
         &self.path
     }
 
+    pub fn source_str(&self) -> &str {
+        &self.templated_file.source_str
+    }
+
     pub fn into_violations(self) -> Vec<SQLBaseError> {
         self.violations
     }


### PR DESCRIPTION
## Summary
- avoid rewriting files when fixes do not change content
- expose the original source string from lint results
- test that fixing with parse errors does not change file timestamp

## Testing
- `cargo +1.88.0 test -p sqruff-cli-lib`

------
https://chatgpt.com/codex/tasks/task_e_689c97d99fcc8330bf633d7d7368f883