### PR TITLE
feat: add global --dialect CLI option for all commands

### DIFF
--- a/crates/cli-lib/src/commands.rs
+++ b/crates/cli-lib/src/commands.rs
@@ -15,6 +15,9 @@ pub struct Cli {
     /// Path to a configuration file.
     #[arg(long, global = true)]
     pub config: Option<String>,
+    /// Override the dialect (e.g., bigquery, clickhouse, ansi).
+    #[arg(long, global = true)]
+    pub dialect: Option<String>,
     /// Show parse errors.
     #[arg(long, global = true, default_value = "false")]
     pub parsing_errors: bool,

--- a/crates/cli-lib/src/commands_parse.rs
+++ b/crates/cli-lib/src/commands_parse.rs
@@ -55,7 +55,7 @@ fn run_parse_files(args: ParseArgs, config: FluffConfig) -> i32 {
             }
         }
     }
-
+    
     exit_code
 }
 

--- a/crates/cli-lib/src/lib.rs
+++ b/crates/cli-lib/src/lib.rs
@@ -43,7 +43,11 @@ where
     let cli = Cli::parse_from(args);
     let collect_parse_errors = cli.parsing_errors;
 
-    let config: FluffConfig = if let Some(config) = cli.config.as_ref() {
+    let config: FluffConfig = if let Some(dialect) = cli.dialect.as_ref() {
+        // Override dialect - create a minimal config with just the dialect setting
+        let config_str = format!("[sqruff]\ndialect = {}", dialect);
+        FluffConfig::from_source(&config_str, None)
+    } else if let Some(config) = cli.config.as_ref() {
         if !Path::new(config).is_file() {
             eprintln!(
                 "The specified config file '{}' does not exist.",


### PR DESCRIPTION
Add global --dialect argument that allows overriding the dialect for any command.
This provides a convenient way to test different dialects without modifying
configuration files.

Usage:
  sqruff lint --dialect bigquery file.sql
  sqruff parse --dialect clickhouse file.sql
  sqruff fix --dialect ansi file.sql

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
