### PR TITLE
test: add dialect override test

### DIFF
--- a/crates/cli/tests/dialect_override.rs
+++ b/crates/cli/tests/dialect_override.rs
@@ -1,8 +1,7 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
-use expect_test::expect_file;
 
 /// Tests that the dialect override works.
 ///
@@ -12,30 +11,76 @@ use expect_test::expect_file;
 /// 3. with a config file set to ANSI to ensure it fails
 /// 4. with a config file set to ANSI but with a dialect override to ensure it succeeds
 fn main() {
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-    let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    lint_dir.push("tests/lint");
+    dialect_override();
+}
+
+fn dialect_override() {
+    let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
+
+    let cargo_folder = Path::new(env!("CARGO_MANIFEST_DIR"));
 
     // Construct the path to the sqruff binary
-    let mut sqruff_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut sqruff_path = PathBuf::from(cargo_folder);
     sqruff_path.push(format!("../../target/{}/sqruff", profile));
 
+    // Temporary directory and SQL file used in all test cases
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let sql_path = tmp_dir.path().join("example.sql");
+    fs::write(&sql_path, STATEMENT).unwrap();
 
+    // 1. No config file - defaults to ANSI and fails
+    let mut cmd = Command::new(&sqruff_path);
+    cmd.arg("lint").arg("-f").arg("human").arg(&sql_path);
+    cmd.env("HOME", cargo_folder);
+    cmd.current_dir(tmp_dir.path());
+    let output = cmd.assert();
+    assert_eq!(output.get_output().status.code().unwrap(), 1);
+
+    // 2. No config but override dialect to Postgres - succeeds
+    let mut cmd = Command::new(&sqruff_path);
+    cmd.arg("lint")
+        .arg("-f")
+        .arg("human")
+        .arg("--dialect")
+        .arg("postgres")
+        .arg(&sql_path);
+    cmd.env("HOME", cargo_folder);
+    cmd.current_dir(tmp_dir.path());
+    let output = cmd.assert();
+    assert_eq!(output.get_output().status.code().unwrap(), 0);
+
+    // Prepare config file set to ANSI
+    let cfg_path = tmp_dir.path().join("sqruff.cfg");
+    fs::write(&cfg_path, "[sqruff]\ndialect = ansi\n").unwrap();
+
+    // 3. Config file set to ANSI - fails
+    let mut cmd = Command::new(&sqruff_path);
+    cmd.arg("lint")
+        .arg("-f")
+        .arg("human")
+        .arg("--config")
+        .arg(&cfg_path)
+        .arg(&sql_path);
+    cmd.env("HOME", cargo_folder);
+    cmd.current_dir(tmp_dir.path());
+    let output = cmd.assert();
+    assert_eq!(output.get_output().status.code().unwrap(), 1);
+
+    // 4. Config file set to ANSI with dialect override - succeeds
+    let mut cmd = Command::new(&sqruff_path);
+    cmd.arg("lint")
+        .arg("-f")
+        .arg("human")
+        .arg("--config")
+        .arg(&cfg_path)
+        .arg("--dialect")
+        .arg("postgres")
+        .arg(&sql_path);
+    cmd.env("HOME", cargo_folder);
+    cmd.current_dir(tmp_dir.path());
+    let output = cmd.assert();
+    assert_eq!(output.get_output().status.code().unwrap(), 0);
 }
 
-fn option_1() {
-    // Create temp folder 
-    
+const STATEMENT: &str = "SELECT DISTINCT ON (customer_id)\n    customer_id, total, created_at\nFROM orders\nORDER BY customer_id, created_at DESC;\n";
 
-}
-
-
-
-const statement: &str = "SELECT DISTINCT ON (customer_id)
-       customer_id, total, created_at
-FROM orders
-ORDER BY customer_id, created_at DESC;";


### PR DESCRIPTION
## Summary
- cover CLI dialect override behavior

## Testing
- `cargo test -p sqruff --test dialect_override --locked`

------
https://chatgpt.com/codex/tasks/task_e_68ada5ebc64083309aa99a4f11d8f90b