### PR TITLE
fix: avoid capacity overflow in alignment spacing

### DIFF
--- a/crates/lib/src/utils/reflow/respace.rs
+++ b/crates/lib/src/utils/reflow/respace.rs
@@ -293,14 +293,19 @@ fn determine_aligned_inline_spacing(
         }
     }
 
-    " ".repeat(
-        1 + max_desired_line_pos
-            - whitespace_seg
-                .get_position_marker()
-                .as_ref()
-                .unwrap()
-                .working_line_pos,
-    )
+    let ws_pos = whitespace_seg
+        .get_position_marker()
+        .as_ref()
+        .unwrap()
+        .working_line_pos;
+
+    // If the existing whitespace is already beyond the desired position, we
+    // shouldn't attempt to create a negative repeat length. Saturating the
+    // subtraction guards against underflow which would otherwise cause a
+    // capacity overflow panic when calling `repeat`.
+    let diff = max_desired_line_pos.saturating_sub(ws_pos);
+
+    " ".repeat(1 + diff)
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary
- guard against negative spacing when aligning inline elements

## Testing
- `cargo test -p sqruff-lib` *(fails: Unknown templater: jinja)*

------
https://chatgpt.com/codex/tasks/task_e_68b882fd687083309bea8cc6a51dcbd7