### PR TITLE
feat: errors implement Error trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "smol_str",
  "strum",
  "strum_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/lib-core/Cargo.toml
+++ b/crates/lib-core/Cargo.toml
@@ -32,6 +32,7 @@ rustc-hash = "2.1.1"
 slyce = "0.3.1"
 enum_dispatch = "0.3.13"
 regex-automata = { version = "0.4.10", features = ["perf"] }
+thiserror = "2"
 log.workspace = true
 
 [dev-dependencies]

--- a/crates/lib-core/src/errors.rs
+++ b/crates/lib-core/src/errors.rs
@@ -1,13 +1,14 @@
-use std::fmt::Display;
 use std::ops::{Deref, DerefMut, Range};
 
 use fancy_regex::Regex;
+use thiserror::Error;
 
 use super::parser::segments::ErasedSegment;
 use crate::helpers::Config;
 use crate::parser::markers::PositionMarker;
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Error)]
+#[error("{description}")]
 pub struct SQLBaseError {
     pub fixable: bool,
     pub line_no: usize,
@@ -42,13 +43,8 @@ impl SQLBaseError {
     }
 }
 
-impl Display for SQLBaseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.description)
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
+#[error(transparent)]
 pub struct SQLLintError {
     base: SQLBaseError,
 }
@@ -91,17 +87,13 @@ impl From<SQLBaseError> for SQLLintError {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct SQLTemplaterError {}
-
-impl Display for SQLTemplaterError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SQLTemplaterError")
-    }
-}
+#[derive(Debug, PartialEq, Clone, Error)]
+#[error("SQLTemplaterError")]
+pub struct SQLTemplaterError;
 
 /// An error which should be fed back to the user.
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{value}")]
 pub struct SQLFluffUserError {
     pub value: String,
 }
@@ -112,13 +104,8 @@ impl SQLFluffUserError {
     }
 }
 
-impl Display for SQLFluffUserError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.value)
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{description}")]
 pub struct SQLParseError {
     pub description: String,
     pub segment: Option<ErasedSegment>,
@@ -164,7 +151,8 @@ impl From<SQLParseError> for SQLBaseError {
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Error)]
+#[error("{message}")]
 pub struct SQLLexError {
     message: String,
     position_marker: PositionMarker,
@@ -179,9 +167,9 @@ impl SQLLexError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{value}")]
 pub struct SQLFluffSkipFile {
-    #[allow(dead_code)]
     value: String,
 }
 


### PR DESCRIPTION
## Summary
- derive Display and Error for core error types using `thiserror`
- add `thiserror` dependency

## Testing
- `cargo test -p sqruff-lib-core`


------
https://chatgpt.com/codex/tasks/task_e_68b8936b68fc8330aa7df51b356f8aef