### PR TITLE
fix: preserve indentation after comment lines

### DIFF
--- a/crates/lib/src/utils/reflow/reindent.rs
+++ b/crates/lib/src/utils/reflow/reindent.rs
@@ -184,13 +184,24 @@ fn revise_comment_lines(lines: &mut [IndentLine], elements: &ReflowSequenceType)
         }
     }
 
-    let changes = changes.into_iter().chain(
-        comment_line_buffer
-            .into_iter()
-            .map(|comment_line_idx| (comment_line_idx, 0)),
-    );
+    let changes = changes
+        .into_iter()
+        .chain(comment_line_buffer.into_iter().map(|idx| (idx, 0)));
+
     for (comment_line_idx, initial_indent_balance) in changes {
-        lines[comment_line_idx].initial_indent_balance = initial_indent_balance;
+        let line = &mut lines[comment_line_idx];
+        line.initial_indent_balance = initial_indent_balance;
+        for ip in &mut line.indent_points {
+            ip.initial_indent_balance = initial_indent_balance;
+            ip.untaken_indents.clear();
+        }
+
+        if let Some(next) = lines.get_mut(comment_line_idx + 1) {
+            if let Some(first_ip) = next.indent_points.first_mut() {
+                first_ip.initial_indent_balance = initial_indent_balance;
+                first_ip.untaken_indents.clear();
+            }
+        }
     }
 }
 

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2174,3 +2174,12 @@ test_pass_implicit_where:
   configs:
     indentation:
       allow_implicit_indents: true
+
+test_pass_comment_at_start_of_parenthesis:
+  # Comment-only lines shouldn't affect following indentation.
+  pass_str: |
+    SELECT
+        (
+            -- comment
+            1
+        ) AS x

--- a/docs/comment-indentation-bug/README.md
+++ b/docs/comment-indentation-bug/README.md
@@ -1,0 +1,43 @@
+# Comment-Induced Indentation Bug
+
+A comment placed as the first line inside a parenthesized expression could cause the
+next line to receive an extra level of indentation. For example:
+
+```sql
+SELECT
+    col1,
+    (
+        -- BIG NOTE 1: Adding this comment breaks the indentation of the output.
+        file_type ILIKE '%tif%'
+    ) AS col2
+```
+
+Running `sqruff fix` on this query previously produced:
+
+```sql
+SELECT
+    col1,
+    (
+        -- BIG NOTE 1: Adding this comment breaks the indentation of the output.
+            file_type ILIKE '%tif%'
+        ) AS col2
+```
+
+The comment-only line after the opening parenthesis was treated as consuming an
+additional indent. The following line then inherited this inflated indent balance,
+shifting the subsequent lines too far to the right.
+
+## Fix
+
+The indentation mapper now resets comment-only lines to the preceding line's
+indentation and clears any untaken indents. As a result, comment lines no longer
+alter the indent level of the code that follows them:
+
+```sql
+SELECT
+    col1,
+    (
+        -- BIG NOTE 1: Adding this comment breaks the indentation of the output.
+        file_type ILIKE '%tif%'
+    ) AS col2
+```


### PR DESCRIPTION
## Summary
- reset indentation and untaken indents for comment-only lines
- test comment at start of parenthesized block keeps correct indent

## Testing
- `cargo test -p sqruff-lib --test rules -- LT02-indent.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c6d7e1944c833092f5e0695ec9f581