### PR TITLE
chore: support custom installation directory in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ brew install sqruff
 Using `bash`:
 
 ```bash
+# Install to default location (/usr/local/bin)
 curl -fsSL https://raw.githubusercontent.com/quarylabs/sqruff/main/install.sh | bash
+
+# Install to custom directory
+curl -fsSL https://raw.githubusercontent.com/quarylabs/sqruff/main/install.sh | bash -s ~/.local/bin
 ```
 
 #### Pip

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -64,7 +64,11 @@ brew install sqruff
 Using `bash`:
 
 ```bash
+# Install to default location (/usr/local/bin)
 curl -fsSL https://raw.githubusercontent.com/quarylabs/sqruff/main/install.sh | bash
+
+# Install to custom directory
+curl -fsSL https://raw.githubusercontent.com/quarylabs/sqruff/main/install.sh | bash -s ~/.local/bin
 ```
 
 #### Pip

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ DOWNLOAD_URL=$(curl -sSL $RELEASE_URL | grep -o "browser_download_url.*$ASSET_NA
 ASSET_NAME=$(basename $DOWNLOAD_URL)
 
 # Define the installation directory
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${1:-/usr/local/bin}"
 
 DOWNLOAD_URL=`echo $DOWNLOAD_URL | tr -d '\"'`
 


### PR DESCRIPTION
Hi there!

Thank you for maintaining this project.
It’s been incredibly helpful for my own work.

## Why change?

Support installation in environments without root privileges.

## Checks

I ran the script with the URL of my topic branch.

https://raw.githubusercontent.com/23prime/sqruff/refs/heads/chore/install-custom-directory/install.sh

### to default directory

```bash
$ curl -fsSL https://raw.githubusercontent.com/23prime/sqruff/refs/heads/chore/install-custom-directory/install.sh | bash
...
Installation completed! 🎉
$ which sqruff
/usr/local/bin/sqruff
$ sqruff --version
sqruff 0.29.3
```

### to custom directory

```bash
$ curl -fsSL https://raw.githubusercontent.com/23prime/sqruff/refs/heads/chore/install-custom-directory/install.sh | bash -s ~/.local/bin
...
Installation completed! 🎉
$ which sqruff
/home/okkey/.local/bin/sqruff
$ sqruff --version
sqruff 0.29.3
```