### PR TITLE
fix(reflow): use relevant untaken count for indent calculations

### DIFF
--- a/crates/cli-python/tests/dbt/output.stderr
+++ b/crates/cli-python/tests/dbt/output.stderr
@@ -1,6 +1,6 @@
 == [models/customers.sql] FAIL
 L:  22 | P:  16 | LT02 | Expected indent of 4 spaces. [layout.indent]
-L:  42 | P:  27 | LT02 | Expected line break and indent of 4 spaces before "on".
+L:  42 | P:  27 | LT02 | Expected line break and indent of 8 spaces before "on".
                        | [layout.indent]
 L:  42 | P:  31 | LT02 | Expected indent of 12 spaces. [layout.indent]
 L:  65 | P:  41 | LT01 | Expected only single space before "customers". Found " 


### PR DESCRIPTION
Refactor indentation calculation logic to properly account for indent troughs when determining relevant untaken indents. Previously, the code used `untaken_indents.len()` directly, which didn't filter out irrelevant indents when a trough was present. I was getting thread errors and incorrect indentation, especially on larger .sql files, if the spacing_before = align was used, as in the sample configuration

[sqruff:layout:type:alias_expression]
spacing_before = align
align_within = select_clause
align_scope = bracketed

[oracle_parsed.sql](https://github.com/user-attachments/files/24118360/oracle_parsed.sql)

Changes:
- Add `relevant_untaken_count()` method to `IndentPoint` that mirrors the filtering logic in `IndentLine::desired_indent_units()`
- Update `lint_line_untaken_positive_indents()` to use the new method
- Update `lint_line_untaken_negative_indents()` to use the new method
- Add `.max(0)` guards to prevent negative indent values

This fixes incorrect indentation calculations in cases where indent troughs are present, ensuring that only relevant untaken indents are considered when computing desired indentation levels.