### PR TITLE
Add pgvector support to PostgreSQL dialect

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -38,8 +38,10 @@ name = "depth_map"
 harness = false
 
 [features]
+default = ["postgres"]
 parser = ["sqruff-lib-core/stringify"]
 python = ["pyo3", "sqruff-lib-core/serde"]
+postgres = ["sqruff-lib-dialects/postgres"]
 
 [dependencies]
 sqruff-lib-core.workspace = true

--- a/crates/lib/src/core/config.rs
+++ b/crates/lib/src/core/config.rs
@@ -10,6 +10,8 @@ use sqruff_lib_core::dialects::init::{DialectKind, dialect_readout};
 use sqruff_lib_core::errors::SQLFluffUserError;
 use sqruff_lib_core::parser::Parser;
 use sqruff_lib_dialects::kind_to_dialect;
+#[cfg(feature = "postgres")]
+use sqruff_lib_dialects::postgres::apply_pgvector_extension;
 
 use crate::utils::reflow::config::ReflowConfig;
 
@@ -121,7 +123,30 @@ impl FluffConfig {
             _value => DialectKind::default(),
         };
 
-        let dialect = kind_to_dialect(&dialect);
+        let mut dialect = kind_to_dialect(&dialect);
+
+        // Apply dialect extensions based on configuration
+        #[cfg(feature = "postgres")]
+        if let Some(ref mut dialect) = dialect {
+            if dialect.name() == DialectKind::Postgres {
+                // Check for postgres extensions configuration
+                if let Some(postgres_config) = configs.get("postgres") {
+                    if let Some(extensions) = postgres_config
+                        .as_map()
+                        .and_then(|m| m.get("extensions"))
+                        .and_then(|v| v.as_string())
+                    {
+                        // Parse comma-separated extension list
+                        for ext in extensions.split(',').map(|s| s.trim()) {
+                            if ext.eq_ignore_ascii_case("pgvector") {
+                                apply_pgvector_extension(dialect);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         for (in_key, out_key) in [
             // Deal with potential ignore & warning parameters
             ("ignore", "ignore"),


### PR DESCRIPTION
Add support for pgvector types (VECTOR, HALFVEC, SPARSEVEC) as a configurable extension for the PostgreSQL dialect. This fixes the indentation bug when using VECTOR type in CREATE TABLE statements.

Configuration:
```ini
[sqruff]
dialect = postgres

[sqruff:postgres]
extensions = pgvector
```

This adds:
- `apply_pgvector_extension` function in postgres.rs that adds pgvector types with optional dimension parameters (e.g., VECTOR(3072))
- Configuration support in FluffConfig to read postgres-specific extensions
- Feature flag propagation from sqruff-lib to sqruff-lib-dialects

Fixes #2070