### PR TITLE
Fix STRING_AGG type casting style warning

### DIFF
--- a/crates/lib/src/rules/convention/cv11.rs
+++ b/crates/lib/src/rules/convention/cv11.rs
@@ -157,6 +157,12 @@ FROM foo;
         let functional_context = FunctionalContext::new(context);
         match self.preferred_type_casting_style {
             TypeCastingStyle::Consistent => {
+                // If current is None, it's not a cast operation (e.g., STRING_AGG, or
+                // other non-CAST/CONVERT functions), so skip it entirely.
+                if current_type_casting_style == TypeCastingStyle::None {
+                    return Vec::new();
+                }
+
                 let Some(prior_type_casting_style) = context.try_get::<TypeCastingStyle>() else {
                     context.set(current_type_casting_style);
                     return Vec::new();

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -382,3 +382,33 @@ test_fail_snowflake_semi_structured_cast_4453:
     rules:
       convention.casting_style:
         preferred_type_casting_style: cast
+
+# Test that shorthand cast inside non-CAST/CONVERT functions doesn't trigger
+# false positive inconsistency errors (e.g., STRING_AGG contains ::text cast
+# but STRING_AGG itself is not a casting function)
+test_pass_shorthand_cast_inside_aggregate_function:
+  pass_str: |
+    SELECT STRING_AGG(id::text, ' ')
+    FROM ou;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_shorthand_cast_inside_multiple_functions:
+  pass_str: |
+    SELECT
+        COALESCE(a::text, ''),
+        STRING_AGG(b::varchar, ', '),
+        TRIM(c::text)
+    FROM foo;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_cast_inside_aggregate_function:
+  pass_str: |
+    SELECT STRING_AGG(CAST(id AS text), ' ')
+    FROM ou;
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
When a shorthand cast (e.g., `id::text`) is used inside a non-CAST/CONVERT function like STRING_AGG, the rule was incorrectly flagging it as inconsistent casting style.

The issue was that when visiting a function like STRING_AGG, the rule returned `TypeCastingStyle::None` and stored it as the "prior style". Then when visiting the cast expression inside (e.g., `id::text`), it compared `None != Shorthand` and reported an inconsistency.

The fix skips storing and comparing `TypeCastingStyle::None` since it means "not a cast operation" and shouldn't be compared with actual casting styles.

Fixes issue where `SELECT STRING_AGG(id::text, ' ') FROM ou;` would incorrectly trigger CV11 with postgres dialect.