### PR TITLE
Refactor Query struct to remove Arc RefCell

### DIFF
--- a/crates/lib-core/src/utils/analysis/query.rs
+++ b/crates/lib-core/src/utils/analysis/query.rs
@@ -1,6 +1,7 @@
-use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use ahash::AHashSet;
 use smol_str::{SmolStr, StrExt, ToSmolStr};
 
 use super::select::SelectStatementColumnsAndTables;
@@ -29,7 +30,13 @@ const SUBSELECT_TYPES: SyntaxSet = SyntaxSet::new(&[
     SyntaxKind::ValuesClause,
 ]);
 
-#[derive(Debug, Clone, Copy)]
+static QUERY_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn next_query_id() -> usize {
+    QUERY_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueryType {
     Simple,
     WithCompound,
@@ -152,28 +159,80 @@ impl Selectable<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Query<'me> {
-    pub inner: Rc<RefCell<QueryInner<'me>>>,
+/// Internal data structure holding all query fields.
+/// This replaces the old QueryInner struct but is now immutable after construction.
+#[derive(Debug)]
+struct QueryData<'me> {
+    id: usize,
+    query_type: QueryType,
+    dialect: &'me Dialect,
+    selectables: Vec<Selectable<'me>>,
+    ctes: IndexMap<SmolStr, Query<'me>>,
+    parent: Option<Query<'me>>,
+    subqueries: Vec<Query<'me>>,
+    cte_definition_segment: Option<ErasedSegment>,
+    cte_name_segment: Option<ErasedSegment>,
 }
 
+/// A flattened Query structure without interior mutability.
+/// Uses Rc for shared ownership but no RefCell - the structure is immutable after construction.
 #[derive(Debug, Clone)]
-pub struct QueryInner<'me> {
-    pub query_type: QueryType,
-    pub dialect: &'me Dialect,
-    pub selectables: Vec<Selectable<'me>>,
-    pub ctes: IndexMap<SmolStr, Query<'me>>,
-    pub parent: Option<Query<'me>>,
-    pub subqueries: Vec<Query<'me>>,
-    pub cte_definition_segment: Option<ErasedSegment>,
-    pub cte_name_segment: Option<ErasedSegment>,
+pub struct Query<'me> {
+    inner: Rc<QueryData<'me>>,
 }
 
 impl<'me> Query<'me> {
+    /// Returns a unique identifier for this query instance.
+    pub fn id(&self) -> usize {
+        self.inner.id
+    }
+
+    /// Returns the query type.
+    pub fn query_type(&self) -> QueryType {
+        self.inner.query_type
+    }
+
+    /// Returns the dialect.
+    pub fn dialect(&self) -> &'me Dialect {
+        self.inner.dialect
+    }
+
+    /// Returns the selectables in this query.
+    pub fn selectables(&self) -> &[Selectable<'me>] {
+        &self.inner.selectables
+    }
+
+    /// Returns the CTEs defined in this query.
+    pub fn ctes(&self) -> &IndexMap<SmolStr, Query<'me>> {
+        &self.inner.ctes
+    }
+
+    /// Returns the parent query, if any.
+    pub fn parent(&self) -> Option<&Query<'me>> {
+        self.inner.parent.as_ref()
+    }
+
+    /// Returns the subqueries within this query.
+    pub fn subqueries(&self) -> &[Query<'me>] {
+        &self.inner.subqueries
+    }
+
+    /// Returns the CTE definition segment, if this query is a CTE.
+    pub fn cte_definition_segment(&self) -> Option<&ErasedSegment> {
+        self.inner.cte_definition_segment.as_ref()
+    }
+
+    /// Returns the CTE name segment, if this query is a CTE.
+    pub fn cte_name_segment(&self) -> Option<&ErasedSegment> {
+        self.inner.cte_name_segment.as_ref()
+    }
+
+    /// Crawl sources from a segment, optionally looking up CTEs.
+    /// When `pop` is true, uses `consumed_ctes` to track which CTEs have been visited.
     pub fn crawl_sources(
         &self,
         segment: ErasedSegment,
-        pop: bool,
+        mut consumed_ctes: Option<&mut AHashSet<SmolStr>>,
         lookup_cte: bool,
     ) -> Vec<Source<'me>> {
         let mut acc = Vec::new();
@@ -193,17 +252,21 @@ impl<'me> Query<'me> {
         ) {
             if seg.is_type(SyntaxKind::TableReference) {
                 let _seg = seg.reference();
-                if !_seg.is_qualified()
-                    && lookup_cte
-                    && let Some(cte) = self.lookup_cte(seg.raw().as_ref(), pop)
-                {
-                    acc.push(Source::Query(cte));
+                if !_seg.is_qualified() && lookup_cte {
+                    let cte = if let Some(consumed) = consumed_ctes.as_deref_mut() {
+                        self.lookup_cte_tracked(seg.raw().as_ref(), consumed)
+                    } else {
+                        self.lookup_cte(seg.raw().as_ref())
+                    };
+                    if let Some(cte) = cte {
+                        acc.push(Source::Query(cte));
+                    }
                 }
                 acc.push(Source::TableReference(seg.raw().clone()));
             } else {
                 acc.push(Source::Query(Query::from_segment(
                     &seg,
-                    self.inner.borrow().dialect,
+                    self.inner.dialect,
                     Some(self.clone()),
                 )))
             }
@@ -219,54 +282,56 @@ impl<'me> Query<'me> {
         acc
     }
 
+    /// Look up a CTE by name, searching up the parent chain.
+    /// Returns a clone of the CTE query if found.
+    pub fn lookup_cte(&self, name: &str) -> Option<Query<'me>> {
+        let upper_name = name.to_uppercase_smolstr();
+        if let Some(cte) = self.inner.ctes.get(&upper_name) {
+            return Some(cte.clone());
+        }
+        self.inner.parent.as_ref().and_then(|p| p.lookup_cte(name))
+    }
+
+    /// Look up a CTE by name, tracking which CTEs have been consumed.
+    /// This replaces the old `pop` behavior - once a CTE is found and returned,
+    /// its name is added to the consumed set so it won't be returned again.
     #[track_caller]
-    pub fn lookup_cte(&self, name: &str, pop: bool) -> Option<Query<'me>> {
-        let cte = if pop {
-            self.inner
-                .borrow_mut()
-                .ctes
-                .shift_remove(&name.to_uppercase_smolstr())
-        } else {
-            self.inner
-                .borrow()
-                .ctes
-                .get(&name.to_uppercase_smolstr())
-                .cloned()
-        };
+    pub fn lookup_cte_tracked(
+        &self,
+        name: &str,
+        consumed: &mut AHashSet<SmolStr>,
+    ) -> Option<Query<'me>> {
+        let upper_name = name.to_uppercase_smolstr();
 
-        cte.or_else(move || {
-            self.inner
-                .borrow_mut()
+        // Check if already consumed
+        if consumed.contains(&upper_name) {
+            // Look in parent instead
+            return self
+                .inner
                 .parent
-                .as_mut()
-                .and_then(|it| it.lookup_cte(name, pop))
-        })
-    }
-
-    pub fn id(&self) -> *const RefCell<QueryInner<'me>> {
-        Rc::as_ptr(&self.inner)
-    }
-
-    fn post_init(&self) {
-        let this = self.clone();
-
-        for subquery in &RefCell::borrow(&self.inner).subqueries {
-            RefCell::borrow_mut(&subquery.inner).parent = this.clone().into();
+                .as_ref()
+                .and_then(|p| p.lookup_cte_tracked(name, consumed));
         }
 
-        for cte in RefCell::borrow(&self.inner).ctes.values().cloned() {
-            RefCell::borrow_mut(&cte.inner).parent = this.clone().into();
+        // Try to find in our CTEs
+        if let Some(cte) = self.inner.ctes.get(&upper_name) {
+            consumed.insert(upper_name);
+            return Some(cte.clone());
         }
-    }
-}
 
-impl<'me> Query<'me> {
+        // Look in parent
+        self.inner
+            .parent
+            .as_ref()
+            .and_then(|p| p.lookup_cte_tracked(name, consumed))
+    }
+
+    /// Returns all child queries (CTEs and subqueries).
     pub fn children(&self) -> Vec<Self> {
         self.inner
-            .borrow()
             .ctes
             .values()
-            .chain(self.inner.borrow().subqueries.iter())
+            .chain(self.inner.subqueries.iter())
             .cloned()
             .collect()
     }
@@ -354,25 +419,27 @@ impl<'me> Query<'me> {
             subqueries.extend(Self::extract_subqueries(selectable, dialect));
         }
 
+        // Build the outer query first without CTEs
         let outer_query = Query {
-            inner: Rc::new(RefCell::new(QueryInner {
+            inner: Rc::new(QueryData {
+                id: next_query_id(),
                 query_type,
                 dialect,
                 selectables,
-                ctes: <_>::default(),
-                parent,
-                subqueries,
+                ctes: IndexMap::default(),
+                parent: parent.clone(),
+                subqueries: subqueries.clone(),
                 cte_definition_segment: None,
                 cte_name_segment: None,
-            })),
+            }),
         };
 
-        outer_query.post_init();
-
         if cte_defs.is_empty() {
-            return outer_query;
+            // Set parent references on subqueries
+            return set_parent_on_children(outer_query);
         }
 
+        // Build CTEs with parent set to outer_query
         let mut ctes = IndexMap::default();
         for cte in cte_defs {
             let name_seg = cte.segments()[0].clone();
@@ -389,17 +456,136 @@ impl<'me> Query<'me> {
                 continue;
             };
 
-            let query = &queries[0];
-            let query = Self::from_segment(query, dialect, outer_query.clone().into());
+            let query_seg = &queries[0];
+            let cte_query = Self::from_segment(query_seg, dialect, Some(outer_query.clone()));
 
-            RefCell::borrow_mut(&query.inner).cte_definition_segment = cte.into();
-            RefCell::borrow_mut(&query.inner).cte_name_segment = name_seg.into();
+            // Create a new query with the CTE metadata set
+            let cte_query = Query {
+                inner: Rc::new(QueryData {
+                    id: cte_query.inner.id,
+                    query_type: cte_query.inner.query_type,
+                    dialect: cte_query.inner.dialect,
+                    selectables: cte_query.inner.selectables.clone(),
+                    ctes: cte_query.inner.ctes.clone(),
+                    parent: Some(outer_query.clone()),
+                    subqueries: cte_query.inner.subqueries.clone(),
+                    cte_definition_segment: Some(cte),
+                    cte_name_segment: Some(name_seg),
+                }),
+            };
 
-            ctes.insert(name, query);
+            ctes.insert(name, cte_query);
         }
 
-        RefCell::borrow_mut(&outer_query.inner).ctes = ctes;
-        outer_query
+        // Rebuild outer_query with CTEs included
+        let outer_query = Query {
+            inner: Rc::new(QueryData {
+                id: outer_query.inner.id,
+                query_type: outer_query.inner.query_type,
+                dialect: outer_query.inner.dialect,
+                selectables: outer_query.inner.selectables.clone(),
+                ctes,
+                parent,
+                subqueries,
+                cte_definition_segment: None,
+                cte_name_segment: None,
+            }),
+        };
+
+        set_parent_on_children(outer_query)
+    }
+}
+
+/// Recursively links all queries in the tree to point to the correct final parent.
+/// This is called after the entire tree is built to ensure parent chains are correct.
+fn set_parent_on_children<'a>(root: Query<'a>) -> Query<'a> {
+    // Since we have an immutable structure, we need to rebuild the entire tree
+    // with correct parent references. We do this by keeping track of all CTEs
+    // at each level and rebuilding from top to bottom.
+
+    // Collect ancestor CTEs from the parent chain (if any)
+    let mut ancestor_ctes = IndexMap::default();
+    let mut current = root.inner.parent.clone();
+    while let Some(p) = current {
+        // Add parent's CTEs (don't overwrite - inner CTEs take precedence)
+        for (name, cte) in p.ctes().iter() {
+            ancestor_ctes.entry(name.clone()).or_insert_with(|| cte.clone());
+        }
+        current = p.parent().cloned();
+    }
+
+    // Add root's own CTEs (these take precedence over ancestor CTEs)
+    for (name, cte) in root.inner.ctes.iter() {
+        ancestor_ctes.insert(name.clone(), cte.clone());
+    }
+
+    // Preserve the parent if it exists
+    rebuild_tree_with_cte_context(root.clone(), root.inner.parent.clone(), &ancestor_ctes)
+}
+
+/// Recursively rebuilds the query tree, ensuring all queries can access CTEs from their ancestors.
+/// The `ancestor_ctes` map accumulates all CTEs that should be visible from this level.
+fn rebuild_tree_with_cte_context<'a>(
+    query: Query<'a>,
+    new_parent: Option<Query<'a>>,
+    ancestor_ctes: &IndexMap<SmolStr, Query<'a>>,
+) -> Query<'a> {
+    // Build merged CTEs for this level (this query's CTEs + ancestor CTEs)
+    let mut merged_ctes = ancestor_ctes.clone();
+    for (name, cte) in query.inner.ctes.iter() {
+        merged_ctes.insert(name.clone(), cte.clone());
+    }
+
+    // First create a temporary parent query to pass to children
+    let temp_query = Query {
+        inner: Rc::new(QueryData {
+            id: query.inner.id,
+            query_type: query.inner.query_type,
+            dialect: query.inner.dialect,
+            selectables: query.inner.selectables.clone(),
+            ctes: merged_ctes.clone(), // Include all ancestor CTEs for lookups
+            parent: new_parent.clone(),
+            subqueries: Vec::new(),
+            cte_definition_segment: query.inner.cte_definition_segment.clone(),
+            cte_name_segment: query.inner.cte_name_segment.clone(),
+        }),
+    };
+
+    // Recursively rebuild CTEs with this query as parent
+    let new_ctes: IndexMap<SmolStr, Query<'a>> = query
+        .inner
+        .ctes
+        .iter()
+        .map(|(name, cte)| {
+            let new_cte =
+                rebuild_tree_with_cte_context(cte.clone(), Some(temp_query.clone()), &merged_ctes);
+            (name.clone(), new_cte)
+        })
+        .collect();
+
+    // Recursively rebuild subqueries with this query as parent
+    let new_subqueries: Vec<Query<'a>> = query
+        .inner
+        .subqueries
+        .iter()
+        .map(|sq| rebuild_tree_with_cte_context(sq.clone(), Some(temp_query.clone()), &merged_ctes))
+        .collect();
+
+    // Create the final query with all children properly set
+    // Note: we only include the query's OWN CTEs in its ctes map.
+    // Ancestor CTEs are accessible through the parent chain via lookup_cte().
+    Query {
+        inner: Rc::new(QueryData {
+            id: query.inner.id,
+            query_type: query.inner.query_type,
+            dialect: query.inner.dialect,
+            selectables: query.inner.selectables.clone(),
+            ctes: new_ctes,
+            parent: new_parent,
+            subqueries: new_subqueries,
+            cte_definition_segment: query.inner.cte_definition_segment.clone(),
+            cte_name_segment: query.inner.cte_name_segment.clone(),
+        }),
     }
 }
 

--- a/crates/lib/src/rules/references/rf03.rs
+++ b/crates/lib/src/rules/references/rf03.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use ahash::{AHashMap, AHashSet};
 use itertools::Itertools;
 use smol_str::SmolStr;
@@ -35,7 +33,7 @@ impl RuleRF03 {
         let mut select_info = None;
 
         let mut acc = Vec::new();
-        let selectables = &RefCell::borrow(&query.inner).selectables;
+        let selectables = query.selectables();
 
         if !selectables.is_empty() {
             select_info = selectables[0].select_info();
@@ -47,7 +45,7 @@ impl RuleRF03 {
                 let mut fixable = true;
                 let possible_ref_tables = iter_available_targets(query.clone());
 
-                if let Some(_parent) = &RefCell::borrow(&query.inner).parent {}
+                if query.parent().is_some() {}
 
                 if possible_ref_tables.len() > 1 {
                     fixable = false;
@@ -85,8 +83,8 @@ impl RuleRF03 {
 }
 
 fn iter_available_targets(query: Query<'_>) -> Vec<SmolStr> {
-    RefCell::borrow(&query.inner)
-        .selectables
+    query
+        .selectables()
         .iter()
         .flat_map(|selectable| {
             selectable

--- a/crates/lib/src/rules/structure/st03.rs
+++ b/crates/lib/src/rules/structure/st03.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use ahash::AHashMap;
 use smol_str::StrExt;
 use sqruff_lib_core::dialects::syntax::{SyntaxKind, SyntaxSet};
@@ -71,8 +69,8 @@ FROM cte1
         let mut result = Vec::new();
         let query: Query<'_> = Query::from_root(&context.segment, context.dialect).unwrap();
 
-        let mut remaining_ctes: IndexMap<_, _> = RefCell::borrow(&query.inner)
-            .ctes
+        let mut remaining_ctes: IndexMap<_, _> = query
+            .ctes()
             .keys()
             .map(|it| (it.to_uppercase_smolstr(), it.clone()))
             .collect();
@@ -87,14 +85,13 @@ FROM cte1
         }
 
         for name in remaining_ctes.values() {
-            let tmp = RefCell::borrow(&query.inner);
-            let cte = RefCell::borrow(&tmp.ctes[name].inner);
+            let cte = &query.ctes()[name];
             result.push(LintResult::new(
-                cte.cte_name_segment.clone(),
+                cte.cte_name_segment().cloned(),
                 Vec::new(),
                 Some(format!(
                     "Query defines CTE \"{}\" but does not use it.",
-                    cte.cte_name_segment.as_ref().unwrap().raw()
+                    cte.cte_name_segment().unwrap().raw()
                 )),
                 None,
             ));

--- a/crates/sqlinference/src/columns.rs
+++ b/crates/sqlinference/src/columns.rs
@@ -20,7 +20,7 @@ pub fn get_columns_internal(
     let mut unnamed: Vec<String> = vec![];
 
     let query: Query<'_> = Query::from_root(&ast, parser.dialect()).unwrap();
-    let ast = query.inner.borrow().selectables[0].selectable.clone();
+    let ast = query.selectables()[0].selectable.clone();
 
     for segment in ast.recursive_crawl(
         const { &SyntaxSet::new(&[SyntaxKind::SelectClauseElement]) },


### PR DESCRIPTION
This refactoring simplifies the Query struct by:
- Removing the RefCell wrapper, making Query immutable after construction
- Flattening QueryInner into QueryData
- Adding accessor methods (ctes(), selectables(), parent(), etc.)
- Changing lookup_cte API to use external tracking for consumed CTEs

The key insight is that the original RefCell design allowed mutation after construction to set up parent-child cycles. The new design rebuilds the tree after construction to set up proper parent references.

Updated all dependent modules to use the new accessor API:
- rf01.rs, rf03.rs, al05.rs, st03.rs, st05.rs
- am04.rs, am07.rs (with lookup_cte_tracked for external consumed set)
- sqlinference columns.rs and infer_tests.rs