### PR TITLE
chore: update PyO3 to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "libc",
@@ -1241,18 +1241,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/cli-lib/Cargo.toml
+++ b/crates/cli-lib/Cargo.toml
@@ -33,7 +33,7 @@ log.workspace = true
 anstyle = "1.0"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4.23"
-pyo3 = { version = "0.26.0", optional = true }
+pyo3 = { version = "0.27.2", optional = true }
 # Codegen dependencies
 clap-markdown = { version = "0.1.5", optional = true }
 minijinja = { version = "2.11.0", optional = true }

--- a/crates/cli-lib/src/commands_info.rs
+++ b/crates/cli-lib/src/commands_info.rs
@@ -15,13 +15,9 @@ pub(crate) fn info() {
 
             // Get some attributes from sys
             let version = sys.getattr("version").unwrap();
-            let version = version.downcast().unwrap();
             let executable = sys.getattr("executable").unwrap();
-            let executable = executable.downcast().unwrap();
             let prefix = sys.getattr("prefix").unwrap();
-            let prefix = prefix.downcast().unwrap();
             let base_prefix = sys.getattr("base_prefix").unwrap();
-            let base_prefix = base_prefix.downcast().unwrap();
             // Print them out or do whatever you want with them
             println!("Python Version: {}", version.str().unwrap());
             println!("Executable: {}", executable.str().unwrap());
@@ -29,7 +25,7 @@ pub(crate) fn info() {
             println!("Base Prefix: {}", base_prefix.str().unwrap());
 
             let sys_path = sys.getattr("path").unwrap();
-            let sys_path = sys_path.downcast::<PyList>().unwrap();
+            let sys_path: &Bound<'_, PyList> = sys_path.cast().unwrap();
             println!("sys.path:");
             for p in sys_path.iter() {
                 println!("  {p}");
@@ -39,11 +35,10 @@ pub(crate) fn info() {
             // you can import "os" and query os.environ:
             let os = py.import("os").unwrap();
             let environ = os.getattr("environ").unwrap();
-            let environ = environ.downcast::<PyMapping>().unwrap();
+            let environ: &Bound<'_, PyMapping> = environ.cast().unwrap();
             // If VIRTUAL_ENV is set, you can get it like:
-            if let Ok(environ) = environ.get_item("VIRTUAL_ENV") {
-                // if string
-                let virtual_env = environ.downcast::<PyString>();
+            if let Ok(virtual_env_val) = environ.get_item("VIRTUAL_ENV") {
+                let virtual_env: Result<&Bound<'_, PyString>, _> = virtual_env_val.cast();
                 if let Ok(virtual_env) = virtual_env {
                     println!("VIRTUAL_ENV: {virtual_env}");
                 } else {

--- a/crates/cli-python/Cargo.toml
+++ b/crates/cli-python/Cargo.toml
@@ -62,6 +62,6 @@ expect-test = "1.5.0"
 tempfile = "3.23.0"
 
 [dependencies.pyo3]
-version = "0.26.0"
+version = "0.27.2"
 # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
 features = ["abi3-py38"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -69,7 +69,7 @@ ignored = ["pyo3"]
 
 [dependencies]
 sqruff-cli-lib.workspace = true
-pyo3 = { version = "0.26.0", features = ["auto-initialize"], optional = true }
+pyo3 = { version = "0.27.2", features = ["auto-initialize"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -68,7 +68,7 @@ serde_yaml = { version = "0.9.34", optional = true }
 serde_json = "1"
 
 # Only activated on python
-pyo3 = { version = "0.26.0", optional = true }
+pyo3 = { version = "0.27.2", optional = true }
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -88,4 +88,4 @@ serde_with = { version = "3.13", default-features = false, features = [
     "macros",
 ] }
 sqruff-lib-core = { path = "../lib-core", features = ["serde"] }
-pyo3 = { version = "0.26.0", features = ["auto-initialize"] }
+pyo3 = { version = "0.27.2", features = ["auto-initialize"] }


### PR DESCRIPTION
Update pyo3 to latest version 0.27.2 with necessary API changes:
- FromPyObject trait now requires two lifetime parameters and Error type
- extract_bound renamed to extract with Borrowed parameter type
- downcast deprecated in favor of cast