### PR TITLE
docs: add experimental dbt project support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,62 @@ For more details, see the documents in the [docs](./docs/) folder, which contain
 - [Details on the templaters](./docs/templaters.md)
 - [Sample configurations](./docs/sample_configurations.md)
 
+## Experimental
+
+### dbt Project Support
+
+Sqruff has experimental support for linting and formatting dbt projects. This feature requires the Python version of sqruff to be installed.
+
+#### Installation
+
+```bash
+pip install sqruff[dbt]
+```
+
+#### Configuration
+
+To use sqruff with a dbt project, create a `.sqruff` configuration file in your dbt project root:
+
+```ini
+[sqruff]
+dialect = snowflake  # Set to your target database dialect
+templater = dbt
+
+[sqruff:templater:dbt]
+profiles_dir = ~/.dbt  # Path to your dbt profiles directory (optional)
+```
+
+#### Configuration Options
+
+The following options can be set under `[sqruff:templater:dbt]`:
+
+| Option         | Description                                          | Default                                |
+| -------------- | ---------------------------------------------------- | -------------------------------------- |
+| `profiles_dir` | Path to the directory containing your `profiles.yml` | `~/.dbt`                               |
+| `project_dir`  | Path to your dbt project directory                   | Current working directory              |
+| `profile`      | The dbt profile to use                               | Profile specified in `dbt_project.yml` |
+| `target`       | The dbt target to use                                | Default target in profile              |
+
+#### Usage
+
+Once configured, run sqruff as usual from your dbt project directory:
+
+```bash
+# Lint all SQL files in the models directory
+sqruff lint models/
+
+# Fix formatting issues
+sqruff fix models/
+```
+
+Sqruff will automatically compile your dbt models using Jinja templating, resolving refs, sources, and macros before linting.
+
+#### Limitations
+
+- The dbt templater requires a valid dbt project setup with `dbt_project.yml` and `profiles.yml`
+- Macros and disabled models are automatically skipped
+- stdin input is not supported when using the dbt templater
+
 ## Community Projects
 
 If your project isn't listed here and you would like it to be, please feel free to create a PR.

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -216,6 +216,62 @@ For more details, see the documents in the [docs](./docs/) folder, which contain
 - [Details on the templaters](./docs/templaters.md)
 - [Sample configurations](./docs/sample_configurations.md)
 
+## Experimental
+
+### dbt Project Support
+
+Sqruff has experimental support for linting and formatting dbt projects. This feature requires the Python version of sqruff to be installed.
+
+#### Installation
+
+```bash
+pip install sqruff[dbt]
+```
+
+#### Configuration
+
+To use sqruff with a dbt project, create a `.sqruff` configuration file in your dbt project root:
+
+```ini
+[sqruff]
+dialect = snowflake  # Set to your target database dialect
+templater = dbt
+
+[sqruff:templater:dbt]
+profiles_dir = ~/.dbt  # Path to your dbt profiles directory (optional)
+```
+
+#### Configuration Options
+
+The following options can be set under `[sqruff:templater:dbt]`:
+
+| Option         | Description                                          | Default                                |
+| -------------- | ---------------------------------------------------- | -------------------------------------- |
+| `profiles_dir` | Path to the directory containing your `profiles.yml` | `~/.dbt`                               |
+| `project_dir`  | Path to your dbt project directory                   | Current working directory              |
+| `profile`      | The dbt profile to use                               | Profile specified in `dbt_project.yml` |
+| `target`       | The dbt target to use                                | Default target in profile              |
+
+#### Usage
+
+Once configured, run sqruff as usual from your dbt project directory:
+
+```bash
+# Lint all SQL files in the models directory
+sqruff lint models/
+
+# Fix formatting issues
+sqruff fix models/
+```
+
+Sqruff will automatically compile your dbt models using Jinja templating, resolving refs, sources, and macros before linting.
+
+#### Limitations
+
+- The dbt templater requires a valid dbt project setup with `dbt_project.yml` and `profiles.yml`
+- Macros and disabled models are automatically skipped
+- stdin input is not supported when using the dbt templater
+
 ## Community Projects
 
 If your project isn't listed here and you would like it to be, please feel free to create a PR.


### PR DESCRIPTION
Add documentation for using sqruff with dbt projects, including
installation requirements, configuration options, usage examples,
and known limitations.