### PR TITLE
chore: debug release job push failure

### DIFF
--- a/.hacking/scripts/download_extension.sh
+++ b/.hacking/scripts/download_extension.sh
@@ -9,4 +9,4 @@ repo="quarylabs/sqruff"
 URL="https://github.com/${repo}/releases/download/v${VERSION}/sqruff-${VERSION}.vsix"
 echo "URL: $URL"
 
-curl -L -o extension.vsix "$URL"
+curl -fL -o extension.vsix "$URL"


### PR DESCRIPTION
Without the -f flag, curl returns exit code 0 even for HTTP errors (like 404). This could cause the vsix publish to fail silently when downloading the extension, as curl would save the error HTML page instead of failing.