### PR TITLE
chore: add Bazel build configuration for playground

### DIFF
--- a/.hacking/scripts/build_wasm.sh
+++ b/.hacking/scripts/build_wasm.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Build WASM package for the playground using wasm-pack.
+# This script should be run before building the playground.
+# Usage: ./.hacking/scripts/build_wasm.sh
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$ROOT_DIR"
+
+# Check if wasm-pack is installed
+if ! command -v wasm-pack &> /dev/null; then
+    echo "wasm-pack is not installed. Installing..."
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+fi
+
+# Build the WASM package with size optimization
+echo "Building WASM package..."
+RUSTFLAGS="-C opt-level=z" wasm-pack build \
+    crates/lib-wasm \
+    --target web \
+    --out-dir ../../playground/src/pkg
+
+echo "WASM package built successfully at playground/src/pkg/"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,19 +7,27 @@ load("@rules_shellcheck//:def.bzl", "shellcheck_test")
 # Link all npm packages into node_modules
 npm_link_all_packages(name = "node_modules")
 
-# Prettier configuration
+# Prettier configuration and pnpm workspace files
 exports_files([
     ".prettierrc.json",
+    "package.json",
     "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
 ])
 
 # Files to check with prettier (root package only)
 filegroup(
     name = "prettier_srcs",
-    srcs = glob([
-        ".github/**/*.yaml",
-        ".github/**/*.yml",
-    ]) + ["README.md"],
+    srcs = glob(
+        [
+            ".github/**/*.yaml",
+            ".github/**/*.yml",
+        ],
+    ) + [
+        "README.md",
+        "//editors/code:prettier_srcs",
+        "//playground:prettier_srcs",
+    ],
 )
 
 # Prettier format check test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,6 +51,7 @@ npm.npm_translate_lock(
     data = [
         "//:package.json",
         "//:pnpm-workspace.yaml",
+        "//playground:package.json",
         "//editors/code:package.json",
     ],
     pnpm_lock = "//:pnpm-lock.yaml",
@@ -77,9 +78,6 @@ register_toolchains("@rust_toolchains//:all")
 
 # Required for WASM cross-compilation
 register_toolchains("@rules_rust//rust/private/dummy_cc_toolchain:dummy_cc_wasm32_toolchain")
-
-# wasm-bindgen dependencies for generating JS bindings from WASM
-# The rules_rust_wasm_bindgen module handles toolchain registration internally
 
 # Crate universe - reads from Cargo.toml workspace
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")

--- a/crates/lib-wasm/BUILD.bazel
+++ b/crates/lib-wasm/BUILD.bazel
@@ -38,8 +38,10 @@ rust_shared_library(
 
 # Generate JavaScript bindings using wasm-bindgen
 # This produces the .wasm file and JS glue code for web usage
+# out_name matches what wasm-pack produces for compatibility with playground imports
 rust_wasm_bindgen(
     name = "sqruff-wasm-bindgen",
+    out_name = "sqruff_wasm",
     target = "web",
     wasm_file = ":sqruff-wasm-cdylib",
     visibility = ["//visibility:public"],

--- a/editors/code/BUILD.bazel
+++ b/editors/code/BUILD.bazel
@@ -1,29 +1,26 @@
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-
-# Export files for other build targets
+# Export files for the pnpm workspace data attribute and other build targets
 exports_files([
     "LICENSE",
     "package.json",
     "README.md",
 ])
 
-# Source files for prettier formatting
-# Uses js_library so it can be added to deps of js_test targets in other packages
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+# Source files for prettier formatting (referenced by root BUILD.bazel)
+# Wrapped in js_library to support cross-package usage with js_binary
 js_library(
     name = "prettier_srcs",
-    srcs = glob(
-        [
-            "**/*.ts",
-            "**/*.js",
-            "**/*.json",
-            "**/*.md",
-        ],
-        exclude = [
-            "node_modules/**",
-            "dist/**",
-            "out/**",
-            ".vscode-test/**",
-        ],
-    ),
+    srcs = glob([
+        "**/*.ts",
+        "**/*.js",
+        "**/*.json",
+        "**/*.md",
+    ], exclude = [
+        "node_modules/**",
+        "dist/**",
+        "out/**",
+        ".vscode-test/**",
+    ]),
     visibility = ["//visibility:public"],
 )

--- a/playground/BUILD.bazel
+++ b/playground/BUILD.bazel
@@ -1,23 +1,134 @@
-load("@aspect_rules_js//js:defs.bzl", "js_library")
+"""Bazel build configuration for the sqruff playground.
 
-# Source files for prettier formatting
+The playground is a React/TypeScript web application that uses WASM bindings
+to run sqruff in the browser.
+
+Build:
+- bazel build //playground:build
+
+Development:
+- bazel run //playground:dev
+
+The WASM bindings are built automatically from //crates/lib-wasm:sqruff-wasm-bindgen.
+"""
+
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//playground:vite/package_json.bzl", vite_bin = "bin")
+
+# Export package.json for the pnpm workspace data attribute
+exports_files(["package.json"])
+
+# Source files for prettier formatting (referenced by root BUILD.bazel)
+# Wrapped in js_library to support cross-package usage with js_binary
 js_library(
     name = "prettier_srcs",
+    srcs = glob([
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.css",
+        "**/*.html",
+        "**/*.json",
+    ], exclude = [
+        "node_modules/**",
+        "dist/**",
+        "src/pkg/**",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+# Link npm packages for the playground workspace
+npm_link_all_packages(name = "node_modules")
+
+# All playground source files (TypeScript, CSS, config files)
+filegroup(
+    name = "playground_srcs",
     srcs = glob(
         [
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.js",
-            "**/*.css",
-            "**/*.html",
-            "**/*.json",
+            "src/**/*.ts",
+            "src/**/*.tsx",
+            "src/**/*.css",
+            "src/**/*.d.ts",
         ],
-        allow_empty = True,
         exclude = [
-            "node_modules/**",
-            "dist/**",
             "src/pkg/**",
         ],
-    ),
+    ) + [
+        "index.html",
+        "postcss.config.cjs",
+        "tailwind.config.cjs",
+        "tsconfig.json",
+        "tsconfig.node.json",
+        "vite.config.ts",
+    ],
     visibility = ["//visibility:public"],
+)
+
+# Generate package.json for the WASM package (matches what wasm-pack creates)
+genrule(
+    name = "wasm_pkg_json",
+    outs = ["_wasm_pkg_json/package.json"],
+    cmd = """echo '{"name": "sqruff-wasm", "main": "sqruff_wasm.js", "types": "sqruff_wasm.d.ts"}' > $@""",
+)
+
+# Copy WASM bindgen output to src/pkg/ structure expected by Vite
+# This takes the output from rust_wasm_bindgen and places it where
+# the TypeScript imports expect it
+# root_paths flattens the directory structure so files end up directly in src/pkg/
+copy_to_directory(
+    name = "wasm_pkg",
+    srcs = [
+        "//crates/lib-wasm:sqruff-wasm-bindgen",
+        ":wasm_pkg_json",
+    ],
+    out = "src/pkg",
+    root_paths = [
+        "crates/lib-wasm/sqruff-wasm-bindgen",
+        "playground/_wasm_pkg_json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Common data dependencies for Vite builds
+VITE_DATA = [
+    ":node_modules/@monaco-editor/react",
+    ":node_modules/@tailwindcss/postcss",
+    ":node_modules/@vitejs/plugin-react-swc",
+    ":node_modules/autoprefixer",
+    ":node_modules/classnames",
+    ":node_modules/fflate",
+    ":node_modules/lodash-es",
+    ":node_modules/monaco-editor",
+    ":node_modules/postcss",
+    ":node_modules/react",
+    ":node_modules/react-dom",
+    ":node_modules/react-resizable-panels",
+    ":node_modules/tailwindcss",
+    ":node_modules/typescript",
+    ":node_modules/vite",
+    ":playground_srcs",
+    ":wasm_pkg",
+]
+
+# Build the playground using Vite
+# Produces dist/ directory with JS, HTML, CSS, and WASM files
+# Usage: bazel build //playground:build
+vite_bin.vite(
+    name = "build",
+    srcs = VITE_DATA,
+    args = ["build"],
+    chdir = package_name(),
+    out_dirs = ["dist"],
+    visibility = ["//visibility:public"],
+)
+
+# Development server for the playground
+# WASM bindings are built automatically as a dependency
+# Usage: bazel run //playground:dev
+vite_bin.vite_binary(
+    name = "dev",
+    args = ["--host"],
+    chdir = package_name(),
+    data = VITE_DATA,
 )

--- a/playground/package.json
+++ b/playground/package.json
@@ -33,6 +33,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.2",
     "autoprefixer": "^10.4.23",
+    "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.52.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18


### PR DESCRIPTION
## Summary

Adds Bazel build support for the playground web application:

- Add `//playground:build` target to build the playground with Vite
- Add `//playground:dev` target for development server
- Configure `rust_wasm_bindgen` with `out_name` to match wasm-pack output naming
- Generate package.json for WASM package to support module resolution
- Add `postcss` as direct dev dependency (required by Bazel's npm linking)
- Add helper script `.hacking/scripts/build_wasm.sh` for standalone WASM builds

## Test plan

- [x] `bazel build //playground:build` completes successfully
- [x] Output includes all expected assets (JS, CSS, WASM)

🤖 Generated with [Claude Code](https://claude.ai/code)