### PR TITLE
feat(lsp): report unparseable sections as warnings

### DIFF
--- a/crates/lib/src/core/config.rs
+++ b/crates/lib/src/core/config.rs
@@ -252,6 +252,16 @@ command. Available dialects: {}",
     pub fn sql_file_exts(&self) -> &[String] {
         self.sql_file_exts.as_ref()
     }
+
+    /// Returns whether the LSP should include parse errors as warnings.
+    pub fn lsp_parse_errors(&self) -> bool {
+        self.raw
+            .get("lsp")
+            .and_then(|lsp| lsp.as_map())
+            .and_then(|map| map.get("parse_errors"))
+            .map(|v| v.to_bool())
+            .unwrap_or(true)
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -429,3 +429,7 @@ forbid_subquery_in = join
 
 [sqlfluff:rules:structure.join_condition_order]
 preferred_first_table_in_join_clause = earlier
+
+[sqlfluff:lsp]
+# Whether to show warnings for unparseable SQL sections
+parse_errors = True

--- a/crates/lib/src/core/linter/core.rs
+++ b/crates/lib/src/core/linter/core.rs
@@ -671,6 +671,10 @@ impl Linter {
         &mut self.config
     }
 
+    pub fn set_include_parse_errors(&mut self, include: bool) {
+        self.include_parse_errors = include;
+    }
+
     pub fn rules(&self) -> &[ErasedRule] {
         self.rules.get_or_init(|| self.get_rulepack().rules)
     }


### PR DESCRIPTION
Enable parse error reporting in the LSP by passing `true` for the
`include_parse_errors` parameter when creating the Linter. This causes
unparseable SQL sections to appear as warnings in editors, helping users
identify syntax issues.