### PR TITLE
Move codegen-check action to Bazel test

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,5 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # ratchet:stefanzweifel/git-auto-commit-action@v6
         with:
           push_options: "--force"
-  codegen-check:
-    name: codegen-check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # ratchet:Swatinem/rust-cache@v2
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # ratchet:dtolnay/rust-toolchain@stable
-      - run: env GITHUB_ACTIONS=false cargo r --bin sqruff -F codegen-docs
-      - run: git diff --quiet || exit 1
+  # Note: codegen-check has been moved to a Bazel test.
+  # Run with: bazel test //:codegen_docs_check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,6 +121,8 @@ jobs:
           repository-cache: true
       - name: Run lint checks
         run: bazel test --config=ci //:prettier_check //:shellcheck //:check_files_match //:ratchet_check //:check_versions_match //:ruff_check
+      - name: Check codegen docs are up-to-date
+        run: bazel test --config=ci //:codegen_docs_check
   python:
     name: Run python checks
     runs-on: ubuntu-latest

--- a/.hacking/scripts/codegen_docs_check.sh
+++ b/.hacking/scripts/codegen_docs_check.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Checks that generated documentation files are up-to-date.
+# Runs codegen-docs and compares output with committed files.
+set -eo pipefail
+
+cd "$RUNFILES_DIR/_main"
+CARGO_BIN="$RUNFILES_DIR/$CARGO"
+
+# Create temp directories for cargo build and doc backups
+BACKUP_DIR=$(mktemp -d)
+TARGET_DIR=$(mktemp -d)
+trap 'rm -rf "$BACKUP_DIR" "$TARGET_DIR"' EXIT
+
+# Use temp directory for cargo builds (runfiles may be read-only)
+export CARGO_TARGET_DIR="$TARGET_DIR"
+
+# Backup current docs
+cp docs/cli.md "$BACKUP_DIR/cli.md"
+cp docs/rules.md "$BACKUP_DIR/rules.md"
+cp docs/templaters.md "$BACKUP_DIR/templaters.md"
+
+# Run codegen (suppress GitHub Actions autocommit behavior)
+env GITHUB_ACTIONS=false "$CARGO_BIN" run --bin sqruff -F codegen-docs
+
+# Compare generated files with originals
+exit_code=0
+
+for file in cli.md rules.md templaters.md; do
+    if ! diff -q "docs/$file" "$BACKUP_DIR/$file" > /dev/null 2>&1; then
+        echo "ERROR: docs/$file is out of date"
+        echo "Please run: cargo run --bin sqruff -F codegen-docs"
+        echo ""
+        echo "Diff:"
+        diff "docs/$file" "$BACKUP_DIR/$file" || true
+        exit_code=1
+    else
+        echo "OK: docs/$file is up-to-date"
+    fi
+done
+
+exit $exit_code

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -177,3 +177,32 @@ sh_test(
         "MACHETE": "$(rlocationpath @cargo_machete//:cargo-machete)",
     },
 )
+
+# Codegen docs check - verifies generated documentation is up-to-date
+sh_test(
+    name = "codegen_docs_check",
+    size = "large",
+    srcs = [".hacking/scripts/codegen_docs_check.sh"],
+    data = [
+        "Cargo.lock",
+        "Cargo.toml",
+        "docs/cli.md",
+        "docs/rules.md",
+        "docs/templaters.md",
+        "//crates/cli:machete_srcs",
+        "//crates/cli-lib:machete_srcs",
+        "//crates/cli-lib:codegen_srcs",
+        "//crates/cli-python:machete_srcs",
+        "//crates/lib:machete_srcs",
+        "//crates/lib-core:machete_srcs",
+        "//crates/lib-dialects:machete_srcs",
+        "//crates/lib-wasm:machete_srcs",
+        "//crates/lineage:machete_srcs",
+        "//crates/lsp:machete_srcs",
+        "//crates/sqlinference:machete_srcs",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+    ],
+    env = {
+        "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
+    },
+)

--- a/crates/cli-lib/BUILD.bazel
+++ b/crates/cli-lib/BUILD.bazel
@@ -25,3 +25,10 @@ filegroup(
     ) + ["Cargo.toml"],
     visibility = ["//visibility:public"],
 )
+
+# Additional files needed for codegen-docs feature
+filegroup(
+    name = "codegen_srcs",
+    srcs = glob(["src/docs/*.md"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
- Add codegen_docs_check Bazel test that verifies generated docs are up-to-date
- Add shell script that runs codegen and compares output with committed files
- Remove codegen-check job from docs.yml workflow
- Add codegen_docs_check to bazel-lint job in pr.yml
- Add codegen_srcs filegroup for template files in cli-lib/BUILD.bazel