### PR TITLE
chore: replace sqlfluff with sqruff in default config

### DIFF
--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -1,10 +1,10 @@
-[sqlfluff]
+[sqruff]
 # verbose is an integer (0-2) indicating the level of log output
 verbose = 0
 # Turn off color formatting of output
 nocolor = False
-# Supported dialects https://docs.sqlfluff.com/en/stable/dialects.html
-# Or run 'sqlfluff dialects'
+# Supported dialects https://docs.sqruff.com/dialects
+# Or run 'sqruff dialects'
 dialect = None
 # See templater docs for options
 templater = raw
@@ -12,7 +12,7 @@ templater = raw
 rules = core
 # Comma separated list of rules to exclude, or None
 exclude_rules = None
-# Below controls SQLFluff output, see max_line_length for SQL output
+# Below controls sqruff output, see max_line_length for SQL output
 output_line_length = 80
 # Number of passes to run before admitting defeat
 runaway_limit = 10
@@ -55,8 +55,8 @@ processes = 1
 # Set to zero or negative to disable checks.
 max_line_length = 80
 
-[sqlfluff:indentation]
-# See https://docs.sqlfluff.com/en/stable/layout.html#configuring-indent-locations
+[sqruff:indentation]
+# See https://docs.sqruff.com/layout#configuring-indent-locations
 indent_unit = space
 tab_space_size = 4
 indented_joins = False
@@ -77,150 +77,150 @@ skip_indentation_in = script_content
 trailing_comments = before
 
 # Layout configuration
-# See https://docs.sqlfluff.com/en/stable/layout.html#configuring-layout-and-spacing
-[sqlfluff:layout:type:comma]
+# See https://docs.sqruff.com/layout#configuring-layout-and-spacing
+[sqruff:layout:type:comma]
 spacing_before = touch
 line_position = trailing
 
-[sqlfluff:layout:type:binary_operator]
+[sqruff:layout:type:binary_operator]
 spacing_within = touch
 line_position = leading
 
-[sqlfluff:layout:type:statement_terminator]
+[sqruff:layout:type:statement_terminator]
 spacing_before = touch
 line_position = trailing
 
-[sqlfluff:layout:type:end_of_file]
+[sqruff:layout:type:end_of_file]
 spacing_before = touch
 
-[sqlfluff:layout:type:set_operator]
+[sqruff:layout:type:set_operator]
 line_position = alone:strict
 
-[sqlfluff:layout:type:start_bracket]
+[sqruff:layout:type:start_bracket]
 spacing_after = touch
 
-[sqlfluff:layout:type:end_bracket]
+[sqruff:layout:type:end_bracket]
 spacing_before = touch
 
-[sqlfluff:layout:type:start_square_bracket]
+[sqruff:layout:type:start_square_bracket]
 spacing_after = touch
 
-[sqlfluff:layout:type:end_square_bracket]
+[sqruff:layout:type:end_square_bracket]
 spacing_before = touch
 
-[sqlfluff:layout:type:start_angle_bracket]
+[sqruff:layout:type:start_angle_bracket]
 spacing_after = touch
 
-[sqlfluff:layout:type:end_angle_bracket]
+[sqruff:layout:type:end_angle_bracket]
 spacing_before = touch
 
-[sqlfluff:layout:type:casting_operator]
+[sqruff:layout:type:casting_operator]
 spacing_before = touch
 spacing_after = touch:inline
 
-[sqlfluff:layout:type:slice]
+[sqruff:layout:type:slice]
 spacing_before = touch
 spacing_after = touch
 
-[sqlfluff:layout:type:dot]
+[sqruff:layout:type:dot]
 spacing_before = touch
 spacing_after = touch
 
-[sqlfluff:layout:type:comparison_operator]
+[sqruff:layout:type:comparison_operator]
 spacing_within = touch
 line_position = leading
 
-[sqlfluff:layout:type:assignment_operator]
+[sqruff:layout:type:assignment_operator]
 spacing_within = touch
 line_position = leading
 
-[sqlfluff:layout:type:object_reference]
+[sqruff:layout:type:object_reference]
 spacing_within = touch:inline
 
-[sqlfluff:layout:type:numeric_literal]
+[sqruff:layout:type:numeric_literal]
 spacing_within = touch:inline
 
-[sqlfluff:layout:type:sign_indicator]
+[sqruff:layout:type:sign_indicator]
 spacing_after = touch:inline
 
-[sqlfluff:layout:type:tilde]
+[sqruff:layout:type:tilde]
 spacing_after = touch:inline
 
-[sqlfluff:layout:type:function_name]
+[sqruff:layout:type:function_name]
 spacing_within = touch:inline
 
-[sqlfluff:layout:type:function_contents]
+[sqruff:layout:type:function_contents]
 spacing_before = touch:inline
 
-[sqlfluff:layout:type:function_parameter_list]
+[sqruff:layout:type:function_parameter_list]
 spacing_before = touch:inline
 
-[sqlfluff:layout:type:array_type]
+[sqruff:layout:type:array_type]
 spacing_within = touch:inline
 
-[sqlfluff:layout:type:typed_array_literal]
+[sqruff:layout:type:typed_array_literal]
 spacing_within = touch
 
-[sqlfluff:layout:type:sized_array_type]
+[sqruff:layout:type:sized_array_type]
 spacing_within = touch
 
-[sqlfluff:layout:type:struct_type]
+[sqruff:layout:type:struct_type]
 spacing_within = touch:inline
 
-[sqlfluff:layout:type:bracketed_arguments]
+[sqruff:layout:type:bracketed_arguments]
 spacing_before = touch:inline
 
-[sqlfluff:layout:type:typed_struct_literal]
+[sqruff:layout:type:typed_struct_literal]
 spacing_within = touch
 
-[sqlfluff:layout:type:semi_structured_expression]
+[sqruff:layout:type:semi_structured_expression]
 spacing_within = touch:inline
 spacing_before = touch:inline
 
-[sqlfluff:layout:type:array_accessor]
+[sqruff:layout:type:array_accessor]
 spacing_before = touch:inline
 
-[sqlfluff:layout:type:colon]
+[sqruff:layout:type:colon]
 spacing_before = touch
 
-[sqlfluff:layout:type:colon_delimiter]
+[sqruff:layout:type:colon_delimiter]
 spacing_before = touch
 spacing_after = touch
 
-[sqlfluff:layout:type:path_segment]
+[sqruff:layout:type:path_segment]
 spacing_within = touch
 
-[sqlfluff:layout:type:sql_conf_option]
+[sqruff:layout:type:sql_conf_option]
 spacing_within = touch
 
-[sqlfluff:layout:type:sqlcmd_operator]
+[sqruff:layout:type:sqlcmd_operator]
 # NOTE: This is the spacing between the operator and the colon
 spacing_before = touch
 
-[sqlfluff:layout:type:comment]
+[sqruff:layout:type:comment]
 spacing_before = any
 spacing_after = any
 
-[sqlfluff:layout:type:inline_comment]
+[sqruff:layout:type:inline_comment]
 spacing_before = any
 spacing_after = any
 
-[sqlfluff:layout:type:block_comment]
+[sqruff:layout:type:block_comment]
 spacing_before = any
 spacing_after = any
 
-[sqlfluff:layout:type:pattern_expression]
+[sqruff:layout:type:pattern_expression]
 # Snowflake pattern expressions shouldn't have their spacing changed.
 spacing_within = any
 
-[sqlfluff:layout:type:placeholder]
+[sqruff:layout:type:placeholder]
 # Placeholders exist "outside" the rendered SQL syntax
 # so we shouldn't enforce any particular spacing around
 # them.
 spacing_before = any
 spacing_after = any
 
-[sqlfluff:layout:type:common_table_expression]
+[sqruff:layout:type:common_table_expression]
 # The definition part of a CTE should fit on one line where possible.
 # For users which regularly define column names in their CTEs they
 # may which to relax this config to just `single`.
@@ -231,161 +231,161 @@ spacing_within = single:inline
 # first place to add newlines would be around these clauses.
 # Setting this to "alone:strict" would always _force_ line breaks
 # around them even if the line isn't too long.
-[sqlfluff:layout:type:select_clause]
+[sqruff:layout:type:select_clause]
 line_position = alone
 
-[sqlfluff:layout:type:where_clause]
+[sqruff:layout:type:where_clause]
 line_position = alone
 
-[sqlfluff:layout:type:from_clause]
+[sqruff:layout:type:from_clause]
 line_position = alone
 
-[sqlfluff:layout:type:join_clause]
+[sqruff:layout:type:join_clause]
 line_position = alone
 
-[sqlfluff:layout:type:groupby_clause]
+[sqruff:layout:type:groupby_clause]
 line_position = alone
 
-[sqlfluff:layout:type:orderby_clause]
+[sqruff:layout:type:orderby_clause]
 # NOTE: Order by clauses appear in many places other than in a select
 # clause. To avoid unexpected behaviour we use `leading` in this
 # case rather than `alone`.
 line_position = leading
 
-[sqlfluff:layout:type:having_clause]
+[sqruff:layout:type:having_clause]
 line_position = alone
 
-[sqlfluff:layout:type:limit_clause]
+[sqruff:layout:type:limit_clause]
 line_position = alone
 
 # Template loop tokens shouldn't dictate spacing around them.
-[sqlfluff:layout:type:template_loop]
+[sqruff:layout:type:template_loop]
 spacing_before = any
 spacing_after = any
 
-[sqlfluff:templater]
+[sqruff:templater]
 unwrap_wrapped_queries = True
 
-[sqlfluff:templater:jinja]
+[sqruff:templater:jinja]
 apply_dbt_builtins = True
 
 # Some rules can be configured directly from the config common to other rules
-[sqlfluff:rules]
+[sqruff:rules]
 allow_scalar = True
 single_table_references = consistent
 unquoted_identifiers_policy = all
 
-[sqlfluff:rules:capitalisation.keywords]
+[sqruff:rules:capitalisation.keywords]
 # Keywords
 capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:capitalisation.identifiers]
+[sqruff:rules:capitalisation.identifiers]
 # Unquoted identifiers
 extended_capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:capitalisation.functions]
+[sqruff:rules:capitalisation.functions]
 # Function names
 extended_capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:capitalisation.literals]
+[sqruff:rules:capitalisation.literals]
 # Null & Boolean Literals
 capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:capitalisation.types]
+[sqruff:rules:capitalisation.types]
 # Data Types
 extended_capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:ambiguous.join]
+[sqruff:rules:ambiguous.join]
 # Fully qualify JOIN clause
 fully_qualify_join_types = inner
 
-[sqlfluff:rules:ambiguous.column_references]
+[sqruff:rules:ambiguous.column_references]
 # GROUP BY/ORDER BY column references
 group_by_and_order_by_style = consistent
 
-[sqlfluff:rules:aliasing.table]
+[sqruff:rules:aliasing.table]
 # Aliasing preference for tables
 aliasing = explicit
 
-[sqlfluff:rules:aliasing.column]
+[sqruff:rules:aliasing.column]
 # Aliasing preference for columns
 aliasing = explicit
 
-[sqlfluff:rules:aliasing.length]
+[sqruff:rules:aliasing.length]
 min_alias_length = None
 max_alias_length = None
 
-[sqlfluff:rules:aliasing.forbid]
+[sqruff:rules:aliasing.forbid]
 # Avoid table aliases in from clauses and join conditions.
 # Disabled by default for all dialects unless explicitly enabled.
 # We suggest instead using aliasing.length (AL06) in most cases.
 force_enable = False
 
-[sqlfluff:rules:convention.select_trailing_comma]
+[sqruff:rules:convention.select_trailing_comma]
 # Trailing commas
 select_clause_trailing_comma = forbid
 
-[sqlfluff:rules:convention.count_rows]
+[sqruff:rules:convention.count_rows]
 # Consistent syntax to count all rows
 prefer_count_1 = False
 prefer_count_0 = False
 
-[sqlfluff:rules:convention.terminator]
+[sqruff:rules:convention.terminator]
 # Semi-colon formatting approach
 multiline_newline = False
 require_final_semicolon = False
 
-[sqlfluff:rules:convention.blocked_words]
+[sqruff:rules:convention.blocked_words]
 # Comma separated list of blocked words that should not be used
 blocked_words = None
 blocked_regex = None
 match_source = False
 
-[sqlfluff:rules:convention.quoted_literals]
+[sqruff:rules:convention.quoted_literals]
 # Consistent usage of preferred quotes for quoted literals
 preferred_quoted_literal_style = consistent
 # Disabled for dialects that do not support single and double quotes for quoted literals (e.g. Postgres)
 force_enable = False
 
-[sqlfluff:rules:convention.casting_style]
+[sqruff:rules:convention.casting_style]
 # SQL type casting
 preferred_type_casting_style = consistent
 
-[sqlfluff:rules:convention.not_equal]
+[sqruff:rules:convention.not_equal]
 # Consistent usage of preferred "not equal to" comparison
 preferred_not_equal_style = consistent
 
-[sqlfluff:rules:references.from]
+[sqruff:rules:references.from]
 # References must be in FROM clause
 # Disabled for some dialects (e.g. bigquery)
 force_enable = False
 
-[sqlfluff:rules:references.qualification]
+[sqruff:rules:references.qualification]
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:references.consistent]
+[sqruff:rules:references.consistent]
 # References must be consistently used
 # Disabled for some dialects (e.g. bigquery)
 force_enable = False
 
-[sqlfluff:rules:references.keywords]
+[sqruff:rules:references.keywords]
 # Keywords should not be used as identifiers.
 unquoted_identifiers_policy = aliases
 quoted_identifiers_policy = none
@@ -393,7 +393,7 @@ quoted_identifiers_policy = none
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:references.special_chars]
+[sqruff:rules:references.special_chars]
 # Special characters in identifiers
 unquoted_identifiers_policy = all
 quoted_identifiers_policy = all
@@ -402,7 +402,7 @@ additional_allowed_characters = None
 ignore_words = None
 ignore_words_regex = None
 
-[sqlfluff:rules:references.quoting]
+[sqruff:rules:references.quoting]
 # Policy on quoted and unquoted identifiers
 prefer_quoted_identifiers = False
 prefer_quoted_keywords = False
@@ -410,22 +410,22 @@ ignore_words = None
 ignore_words_regex = None
 force_enable = False
 
-[sqlfluff:rules:layout.long_lines]
+[sqruff:rules:layout.long_lines]
 # Line length
 ignore_comment_lines = False
 ignore_comment_clauses = False
 
-[sqlfluff:rules:layout.select_targets]
+[sqruff:rules:layout.select_targets]
 wildcard_policy = single
 
-[sqlfluff:rules:layout.newlines]
+[sqruff:rules:layout.newlines]
 # Consecutive blank lines
 maximum_empty_lines_between_statements = 2
 maximum_empty_lines_inside_statements = 1
 
-[sqlfluff:rules:structure.subquery]
+[sqruff:rules:structure.subquery]
 # By default, allow subqueries in from clauses, but not join clauses
 forbid_subquery_in = join
 
-[sqlfluff:rules:structure.join_condition_order]
+[sqruff:rules:structure.join_condition_order]
 preferred_first_table_in_join_clause = earlier


### PR DESCRIPTION
Update all section headers and comments in the default configuration file to use sqruff instead of sqlfluff, including documentation URLs.