### PR TITLE
chore: add Playwright e2e tests to Bazel build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,7 @@ http_archive(
 )
 bazel_dep(name = "aspect_rules_js", version = "2.3.7")
 bazel_dep(name = "rules_nodejs", version = "6.3.4")
+bazel_dep(name = "rules_playwright", version = "0.5.3")
 bazel_dep(name = "rules_python", version = "1.7.0")
 
 # Python toolchain for hermetic Python builds (required by pyo3)
@@ -64,6 +65,14 @@ pnpm.pnpm(
     pnpm_version = "10.0.0",
 )
 use_repo(pnpm, "pnpm")
+
+# Playwright browsers for e2e testing
+playwright = use_extension("@rules_playwright//playwright:extensions.bzl", "playwright")
+playwright.repo(
+    name = "playwright",
+    playwright_version = "1.57.0",
+)
+use_repo(playwright, "playwright")
 
 # Rust toolchain
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,6 +19,7 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "2e0d8ab25c57a14f56ace1c8e881b69050417ff91b2fb7718dc00d201f3c3478",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.11.0/MODULE.bazel": "cb1ba9f9999ed0bc08600c221f532c1ddd8d217686b32ba7d45b0713b5131452",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.0/MODULE.bazel": "7fe0191f047d4fe4a4a46c1107e2350cbb58a8fc2e10913aa4322d3190dec0bf",
@@ -190,6 +191,8 @@
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_playwright/0.5.3/MODULE.bazel": "105db08158a3f32302a03252e5eec5e9ee01a2674d3ecda94ad2c41a30001217",
+    "https://bcr.bazel.build/modules/rules_playwright/0.5.3/source.json": "54f2c76d6e6bb0593b89077091e97cf29d8b1129a93497b49d6ca3f07d842e4b",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
@@ -1700,6 +1703,2223 @@
           }
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_playwright+//playwright:extensions.bzl%playwright": {
+      "general": {
+        "bzlTransitiveDigest": "vC3vgsJe0bM0uIqNnEECb5AtleG29ch64x2LOudADlw=",
+        "usagesDigest": "ivM/eR/uCKYws4RekgNnQGBqDI4prqG3Boxz9Pd60ks=",
+        "recordedFileInputs": {
+          "@@rules_playwright+//tools/release/artifacts/cli-x86_64-unknown-linux-musl": "c478e5f07bc0a2b513ff7e7d9f33e9420e8f3bac4ec058c3e3bf332bff8362a1"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "playwright-android-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac10.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-android-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-ieX7MC1xEehgOwtZHsyCXOWrW3QDz4B4hEKkWEWsix8=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-akamai.azureedge.net/builds/android/1001/android.zip",
+                "https://playwright-verizon.azureedge.net/builds/android/1001/android.zip"
+              ]
+            }
+          },
+          "playwright-chromium-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-headless-shell-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac10.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-headless-shell-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-headless-shell-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac10.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-tip-of-tree-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium-tip-of-tree/1380/chromium-tip-of-tree-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux.zip"
+              ]
+            }
+          },
+          "playwright-chromium-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-chromium-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/chromium/1200/chromium-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/chromium/1200/chromium-linux.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-JijAPwUxj/gSyMm6ryB96i3fU+gYwNyTZxSw++OvsAk=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-68dPxblIMBdqPCkUrpa9i8f2qR9PM4kCMPhKFy7mHMw=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-JijAPwUxj/gSyMm6ryB96i3fU+gYwNyTZxSw++OvsAk=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-68dPxblIMBdqPCkUrpa9i8f2qR9PM4kCMPhKFy7mHMw=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac10.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-fXfrDUS1msxAZfqiR2wN8aJCzJBMNG+CBiaBjJU8Unc=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-jzwvO/Ye/XXHTDzJVtZHtUqbW82tIQSa9er0Oioe05I=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-r94UveYB7hhMUfMWtEMGgyJf4ZgtOixo21Nbqmaz2iU=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-fXfrDUS1msxAZfqiR2wN8aJCzJBMNG+CBiaBjJU8Unc=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-fXfrDUS1msxAZfqiR2wN8aJCzJBMNG+CBiaBjJU8Unc=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-F+0Vovpg08dBgb78sr33ybsojRmyo7mJO5S2PyziYOQ=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-fXfrDUS1msxAZfqiR2wN8aJCzJBMNG+CBiaBjJU8Unc=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-JijAPwUxj/gSyMm6ryB96i3fU+gYwNyTZxSw++OvsAk=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-68dPxblIMBdqPCkUrpa9i8f2qR9PM4kCMPhKFy7mHMw=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-JijAPwUxj/gSyMm6ryB96i3fU+gYwNyTZxSw++OvsAk=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-68dPxblIMBdqPCkUrpa9i8f2qR9PM4kCMPhKFy7mHMw=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-JijAPwUxj/gSyMm6ryB96i3fU+gYwNyTZxSw++OvsAk=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux-arm64.zip"
+              ]
+            }
+          },
+          "playwright-ffmpeg-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-68dPxblIMBdqPCkUrpa9i8f2qR9PM4kCMPhKFy7mHMw=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-akamai.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
+                "https://playwright-verizon.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-11-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-11-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-11-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-11.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-11.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-11.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-12-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-12-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-12-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-12.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-12.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-debian-12.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac10.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-20.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-20.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-20.04.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-22.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-22.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-22.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-22.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-22.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-22.04.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-24.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-24.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-24.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-beta-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-24.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-24.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox-beta/1493/firefox-beta-ubuntu-24.04.zip"
+              ]
+            }
+          },
+          "playwright-firefox-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-debian-11-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-debian-11-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-debian-11-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-debian-11.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-debian-11.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-debian-11.zip"
+              ]
+            }
+          },
+          "playwright-firefox-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-debian-12-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-debian-12-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-debian-12-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-debian-12.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-debian-12.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-debian-12.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac10.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac.zip"
+              ]
+            }
+          },
+          "playwright-firefox-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-mac-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-20.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-ubuntu-20.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-ubuntu-20.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-20.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-ubuntu-20.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-ubuntu-20.04.zip"
+              ]
+            }
+          },
+          "playwright-firefox-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04.zip"
+              ]
+            }
+          },
+          "playwright-firefox-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-24.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-ubuntu-24.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-ubuntu-24.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-firefox-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-24.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/firefox/1497/firefox-ubuntu-24.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/firefox/1497/firefox-ubuntu-24.04.zip"
+              ]
+            }
+          },
+          "playwright-webkit-debian11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-Mhpjz9GNZiayIUQOxD92R1mfb1a7wnusdWPJeECkx+4=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2105/webkit-debian-11-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2105/webkit-debian-11-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2105/webkit-debian-11-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-debian11-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-pkeiZb0RIX+Hjce1JuQEfq6+nHjzGHJvuJxckdxo81o=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2105/webkit-debian-11.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2105/webkit-debian-11.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2105/webkit-debian-11.zip"
+              ]
+            }
+          },
+          "playwright-webkit-debian12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-debian-12-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-debian-12-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-debian-12-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-debian12-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-debian-12.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-debian-12.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-debian-12.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac10.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-onN55LO1UOlcHDsFoCJwpli0Dw4W94FJK4KOP1VWUJ4=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/deprecated-webkit-mac-10.14/1446/deprecated-webkit-mac-10.14.zip",
+                "https://playwright-akamai.azureedge.net/builds/deprecated-webkit-mac-10.14/1446/deprecated-webkit-mac-10.14.zip",
+                "https://playwright-verizon.azureedge.net/builds/deprecated-webkit-mac-10.14/1446/deprecated-webkit-mac-10.14.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac10.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-uCA1JD5urKP09FFJTAjBB9lnSEIKKe5zE6mEWic06BY=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/deprecated-webkit-mac-10.15/1616/deprecated-webkit-mac-10.15.zip",
+                "https://playwright-akamai.azureedge.net/builds/deprecated-webkit-mac-10.15/1616/deprecated-webkit-mac-10.15.zip",
+                "https://playwright-verizon.azureedge.net/builds/deprecated-webkit-mac-10.15/1616/deprecated-webkit-mac-10.15.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-RnHAPszuiEUg23UghFgbVKzz1iK42FFYE9t7PKYeJ2s=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/1816/webkit-mac-11.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/1816/webkit-mac-11.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/1816/webkit-mac-11.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac11-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-GeZSiz/rQ0R3S1CNPtAmGJayTxt3+kJpds4V052z/1Q=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/1816/webkit-mac-11-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/1816/webkit-mac-11-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/1816/webkit-mac-11-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-2s7UJ4+mgLHzkjxpYfdXYs/4Q4PLwb9W1SEuocgLHg0=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2009/webkit-mac-12.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2009/webkit-mac-12.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2009/webkit-mac-12.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac12-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-OR/j9ZBkFCgUD/CqSz1j3ZQAS6AC2HgLy/mmA/Cm4cM=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2009/webkit-mac-12-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2009/webkit-mac-12-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2009/webkit-mac-12-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-Ey7qjUHibCifUk9gEQA5ErFms2J7/y92HqkVnW5HAv4=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2140/webkit-mac-13.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2140/webkit-mac-13.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2140/webkit-mac-13.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac13-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-El5K5oAoyI9jv/4bJCUSXIMfhEGUipvtZZJ8LDQg5V0=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2140/webkit-mac-13-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2140/webkit-mac-13-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2140/webkit-mac-13-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-mac-14.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-mac-14.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-mac-14.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac14-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-mac-14-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-mac-14-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-mac-14-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-mac-15.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-mac-15.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-mac-15.zip"
+              ]
+            }
+          },
+          "playwright-webkit-mac15-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-mac-15-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-mac-15-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-mac-15-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-ubuntu20.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-YMRbRTBA6MQ3uMCgUgR5Oh3MCt9MbrQlepuKH/mCiN0=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2092/webkit-ubuntu-20.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2092/webkit-ubuntu-20.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2092/webkit-ubuntu-20.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-ubuntu20.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "sha256-4dHblulkxXiViVj8Irh6zzq1PsVCRfjgeSWpDHmZ+0Q=",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2092/webkit-ubuntu-20.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2092/webkit-ubuntu-20.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2092/webkit-ubuntu-20.04.zip"
+              ]
+            }
+          },
+          "playwright-webkit-ubuntu22.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-ubuntu-22.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-ubuntu-22.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-ubuntu-22.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-ubuntu22.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-ubuntu-22.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-ubuntu-22.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-ubuntu-22.04.zip"
+              ]
+            }
+          },
+          "playwright-webkit-ubuntu24.04-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04-arm64.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04-arm64.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04-arm64.zip"
+              ]
+            }
+          },
+          "playwright-webkit-ubuntu24.04-x64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "integrity": "",
+              "urls": [
+                "https://playwright.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04.zip",
+                "https://playwright-akamai.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04.zip",
+                "https://playwright-verizon.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04.zip"
+              ]
+            }
+          },
+          "playwright": {
+            "repoRuleId": "@@rules_playwright+//playwright:repositories.bzl%playwright_repository",
+            "attributes": {
+              "playwright_version": "1.57.0",
+              "browsers_workspace_name_prefix": "playwright",
+              "rules_playwright_cannonical_name": "@rules_playwright+"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_playwright+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@rules_python+//python/extensions:config.bzl%config": {

--- a/playground/BUILD.bazel
+++ b/playground/BUILD.bazel
@@ -15,6 +15,7 @@ The WASM bindings are built automatically from //crates/lib-wasm:sqruff-wasm-bin
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//playground:@playwright/test/package_json.bzl", playwright_test_bin = "bin")
 load("@npm//playground:vite/package_json.bzl", vite_bin = "bin")
 
 # Export package.json for the pnpm workspace data attribute
@@ -131,4 +132,27 @@ vite_bin.vite_binary(
     args = ["--host"],
     chdir = package_name(),
     data = VITE_DATA,
+)
+
+# Playwright end-to-end tests
+# Runs against the built playground using vite preview
+# Usage: bazel test //playground:playwright_test
+playwright_test_bin.playwright_test(
+    name = "playwright_test",
+    args = [
+        "test",
+        "--config=playwright.bazel.config.ts",
+    ],
+    chdir = package_name(),
+    data = VITE_DATA + [
+        ":node_modules/@playwright/test",
+        ":build",
+        "playwright.bazel.config.ts",
+        "@playwright//:chromium-headless-shell",
+    ] + glob(["tests/**/*.ts"]),
+    env = {
+        # Path needs to go up from _main/playground/ to runfiles root, then into the external repo
+        # The rootpath expands relative to _main workspace, so we need an extra ".." since we chdir to playground
+        "PLAYWRIGHT_BROWSERS_PATH": "../$(rootpath @playwright//:chromium-headless-shell)/..",
+    },
 )

--- a/playground/playwright.bazel.config.ts
+++ b/playground/playwright.bazel.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Bazel-specific Playwright config that serves the built dist directory
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    headless: true,
+    baseURL: "http://localhost:4173",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // Use Python's built-in http server to serve the built dist directory
+  webServer: {
+    command: "python3 -m http.server 4173 -d dist",
+    url: "http://localhost:4173",
+    reuseExistingServer: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `rules_playwright` dependency to hermetically download Chromium browser binaries
- Adds `playwright_test` Bazel target to run Playwright e2e tests
- Adds `playwright.bazel.config.ts` that uses Python's http.server to serve the built dist directory

## Test plan
- [x] Run `bazel test //playground:playwright_test` locally and verify tests pass
- [ ] CI should pass with new Bazel configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)