### PR TITLE
fix: correct YAML syntax in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
-      - name: Build playground with Bazel
-      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # ratchet:bazel-contrib/setup-bazel@0.18.0
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # ratchet:bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}


### PR DESCRIPTION
## Summary
- Fixed malformed YAML in the deploy workflow where the `uses:` directive for setup-bazel was on a separate line, creating an invalid step with only a name and no action

## Test plan
- [ ] Verify the deploy workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.ai/code)