### PR TITLE
chore: improve Bazel CI lint output readability

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,4 +16,14 @@ test --test_output=errors
 
 # CI-specific settings
 build:ci --color=yes
-test:ci --test_output=all
+build:ci --curses=no
+build:ci --show_timestamps
+build:ci --verbose_failures
+
+# CI test output settings - show errors only but with detailed summary
+test:ci --test_output=errors
+test:ci --test_summary=detailed
+test:ci --verbose_failures
+
+# Keep tests running even if some fail to show all failures at once
+test:ci --keep_going


### PR DESCRIPTION
- Update .bazelrc with better CI-specific settings:
  - Disable curses (no terminal manipulation)
  - Show timestamps for timing info
  - Use verbose_failures for better error context
  - Use test_output=errors instead of all (cleaner output)
  - Add test_summary=detailed for clear pass/fail summary
  - Add keep_going to show all failures at once

- Update pr.yml lint step to:
  - Capture Bazel output for post-processing
  - Display a clean LINT RESULTS SUMMARY section
  - Show passed tests with checkmarks
  - Show failed tests with X marks
  - Use GitHub Actions ::group:: for collapsible error details
  - Use ::error:: annotation for clear failure indication