### PR TITLE
chore: migrate Linux binary builds to Bazel

### DIFF
--- a/.github/actions/build-linux-binaries-bazel/action.yml
+++ b/.github/actions/build-linux-binaries-bazel/action.yml
@@ -1,0 +1,65 @@
+name: "Build Linux Binaries with Bazel"
+description: "Build Linux musl binaries using Bazel"
+inputs:
+  package:
+    description: "Whether to package the binaries into archives"
+    required: false
+    default: "false"
+  publish:
+    description: "Whether to publish the binaries"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+    - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # ratchet:bazel-contrib/setup-bazel@0.18.0
+      with:
+        bazelisk-cache: true
+        disk-cache: release-${{ matrix.platform.target }}
+        repository-cache: true
+    - name: Install musl-tools
+      run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
+      shell: bash
+    - name: Install musl cross-compilation toolchain (aarch64)
+      if: matrix.platform.target == 'aarch64-unknown-linux-musl'
+      run: |
+        sudo apt-get install --yes gcc-aarch64-linux-gnu
+      shell: bash
+    - name: Build binary with Bazel
+      run: |
+        bazelisk build --config=ci //:${{ matrix.platform.bazel_target }}
+      shell: bash
+    - name: Copy binary to workspace root
+      run: |
+        cp bazel-bin/crates/cli/sqruff ${{ matrix.platform.bin }}
+        chmod +x ${{ matrix.platform.bin }}
+      shell: bash
+    - name: Strip binary
+      run: |
+        if [[ "${{ matrix.platform.target }}" == "x86_64-unknown-linux-musl" ]]; then
+          strip ${{ matrix.platform.bin }}
+        elif [[ "${{ matrix.platform.target }}" == "aarch64-unknown-linux-musl" ]]; then
+          aarch64-linux-gnu-strip ${{ matrix.platform.bin }} || true
+        fi
+      shell: bash
+    - name: Package as archive
+      if: inputs.package == 'true'
+      shell: bash
+      run: |
+        tar czvf ${{ matrix.platform.name }} ${{ matrix.platform.bin }}
+    - name: Generate SHA-256 and Save to File
+      if: inputs.package == 'true'
+      shell: bash
+      run: |
+        if command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 "${{ matrix.platform.name }}" > "${{ matrix.platform.name }}.sha256"
+        else
+          sha256sum "${{ matrix.platform.name }}" > "${{ matrix.platform.name }}.sha256"
+        fi
+    - name: Generate artifact attestation
+      if: inputs.publish == 'true'
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # ratchet:actions/attest-build-provenance@v2
+      with:
+        subject-path: "sqruff-*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -163,21 +163,34 @@ jobs:
       - name: Sync dependencies with uv
         run: uv sync --python ${{ matrix.python-version }} --extra dev
       - run: make python_ci
-  build-binaries:
-    name: Build binaries for all platforms
-    runs-on: ${{ matrix.platform.os }}
+  build-linux-binaries:
+    name: Build Linux binaries with Bazel
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         platform:
           - name: sqruff-linux-x86_64-musl.tar.gz
-            os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             bin: sqruff
+            bazel_target: sqruff_linux_x86_64_musl
           - name: sqruff-linux-aarch64-musl.tar.gz
-            os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             bin: sqruff
+            bazel_target: sqruff_linux_aarch64_musl
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+      - uses: ./.github/actions/build-linux-binaries-bazel
+        with:
+          package: false
+          publish: false
+  build-binaries:
+    name: Build binaries for other platforms
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
           - name: sqruff-windows-x86_64.zip
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,45 @@ jobs:
           omitDraftDuringUpdate: true
           artifacts: |
             editors/code/*.vsix
+  release-linux:
+    name: Release Linux ${{ matrix.platform.target }}
+    runs-on: ubuntu-latest
+    needs:
+      - check-versions-match
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: sqruff-linux-x86_64-musl.tar.gz
+            target: x86_64-unknown-linux-musl
+            bin: sqruff
+            bazel_target: sqruff_linux_x86_64_musl
+          - name: sqruff-linux-aarch64-musl.tar.gz
+            target: aarch64-unknown-linux-musl
+            bin: sqruff
+            bazel_target: sqruff_linux_aarch64_musl
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+      - uses: ./.github/actions/build-linux-binaries-bazel
+        with:
+          package: true
+          publish: true
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # ratchet:ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          omitBody: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitDraftDuringUpdate: true
+          artifacts: |
+            sqruff-*
   release:
     name: Release ${{ matrix.platform.target }}
     runs-on: ${{ matrix.platform.os }}
@@ -88,14 +127,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - name: sqruff-linux-x86_64-musl.tar.gz
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            bin: sqruff
-          - name: sqruff-linux-aarch64-musl.tar.gz
-            os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            bin: sqruff
           - name: sqruff-windows-x86_64.zip
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -157,6 +188,7 @@ jobs:
     permissions: write-all
     needs:
       - release
+      - release-linux
       - release-vsix
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:prettier/package_json.bzl", prettier_bin = "bin")
 load("@rules_rust//rust:defs.bzl", "rust_clippy", "rustfmt_test")
@@ -185,4 +186,34 @@ sh_test(
         "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
         "MACHETE": "$(rlocationpath @cargo_machete//:cargo-machete)",
     },
+)
+
+# Platform definitions for cross-compilation
+platform(
+    name = "linux_x86_64_musl",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "linux_aarch64_musl",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+# Cross-compiled sqruff binaries for Linux musl targets
+platform_transition_filegroup(
+    name = "sqruff_linux_x86_64_musl",
+    srcs = ["//crates/cli:sqruff"],
+    target_platform = ":linux_x86_64_musl",
+)
+
+platform_transition_filegroup(
+    name = "sqruff_linux_aarch64_musl",
+    srcs = ["//crates/cli:sqruff"],
+    target_platform = ":linux_aarch64_musl",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -78,7 +78,11 @@ use_repo(playwright, "playwright")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
-    extra_target_triples = ["wasm32-unknown-unknown"],
+    extra_target_triples = [
+        "wasm32-unknown-unknown",
+        "x86_64-unknown-linux-musl",
+        "aarch64-unknown-linux-musl",
+    ],
     versions = ["1.92.0"],
 )
 use_repo(rust, "rust_toolchains")


### PR DESCRIPTION
- Add x86_64-unknown-linux-musl and aarch64-unknown-linux-musl targets
  to Rust toolchain in MODULE.bazel
- Create platform definitions and platform_transition_filegroup targets
  in BUILD.bazel for cross-compiling to Linux musl targets
- Add new build-linux-binaries-bazel GitHub action for building Linux
  binaries using Bazel
- Update release.yml to use Bazel for Linux builds (release-linux job)
  while keeping Windows and macOS builds using the existing action
- Update pr.yml to use Bazel for Linux builds (build-linux-binaries job)

Note: MODULE.bazel.lock will need to be updated after this change.