### PR TITLE
chore: add ESLint linting to Bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -75,6 +75,17 @@ prettier_bin.prettier_binary(
     ],
 )
 
+# ESLint check for all TypeScript packages
+# Runs ESLint on both playground and editors/code
+# Usage: bazel test //:eslint_check
+test_suite(
+    name = "eslint_check",
+    tests = [
+        "//editors/code:eslint_check",
+        "//playground:eslint_check",
+    ],
+)
+
 # Shellcheck test for shell scripts
 shellcheck_test(
     name = "shellcheck",

--- a/editors/code/BUILD.bazel
+++ b/editors/code/BUILD.bazel
@@ -3,9 +3,15 @@ exports_files([
     "LICENSE",
     "package.json",
     "README.md",
+    "eslint.config.mjs",
 ])
 
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//editors/code:eslint/package_json.bzl", eslint_bin = "bin")
+
+# Link npm packages for the editors/code workspace
+npm_link_all_packages(name = "node_modules")
 
 # Source files for prettier formatting (referenced by root BUILD.bazel)
 # Wrapped in js_library to support cross-package usage with js_binary
@@ -23,4 +29,54 @@ js_library(
         ".vscode-test/**",
     ]),
     visibility = ["//visibility:public"],
+)
+
+# Source files for ESLint (TypeScript files in src/)
+js_library(
+    name = "eslint_srcs",
+    srcs = glob([
+        "src/**/*.ts",
+    ]) + [
+        "eslint.config.mjs",
+        "tsconfig.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ESLint check test
+# Usage: bazel test //editors/code:eslint_check
+eslint_bin.eslint_test(
+    name = "eslint_check",
+    size = "small",
+    args = [
+        "src",
+        "--max-warnings",
+        "0",
+    ],
+    chdir = package_name(),
+    data = [
+        ":eslint_srcs",
+        ":node_modules/@eslint/js",
+        ":node_modules/eslint",
+        ":node_modules/typescript",
+        ":node_modules/typescript-eslint",
+    ],
+)
+
+# ESLint fix binary (for fixing locally)
+# Usage: bazel run //editors/code:eslint_fix
+eslint_bin.eslint_binary(
+    name = "eslint_fix",
+    args = [
+        "src",
+        "--fix",
+    ],
+    chdir = package_name(),
+    data = [
+        ":eslint_srcs",
+        ":node_modules/@eslint/js",
+        ":node_modules/eslint",
+        ":node_modules/typescript",
+        ":node_modules/typescript-eslint",
+    ],
 )

--- a/playground/BUILD.bazel
+++ b/playground/BUILD.bazel
@@ -16,10 +16,14 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//playground:@playwright/test/package_json.bzl", playwright_test_bin = "bin")
+load("@npm//playground:eslint/package_json.bzl", eslint_bin = "bin")
 load("@npm//playground:vite/package_json.bzl", vite_bin = "bin")
 
 # Export package.json for the pnpm workspace data attribute
-exports_files(["package.json"])
+exports_files([
+    "package.json",
+    "eslint.config.mjs",
+])
 
 # Source files for prettier formatting (referenced by root BUILD.bazel)
 # Wrapped in js_library to support cross-package usage with js_binary
@@ -37,6 +41,62 @@ js_library(
         "src/pkg/**",
     ]),
     visibility = ["//visibility:public"],
+)
+
+# Source files for ESLint (TypeScript files in src/)
+js_library(
+    name = "eslint_srcs",
+    srcs = glob(
+        [
+            "src/**/*.ts",
+            "src/**/*.tsx",
+        ],
+        exclude = [
+            "src/pkg/**",
+        ],
+    ) + [
+        "eslint.config.mjs",
+        "tsconfig.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# ESLint check test
+# Usage: bazel test //playground:eslint_check
+eslint_bin.eslint_test(
+    name = "eslint_check",
+    size = "small",
+    args = [
+        "src",
+        "--max-warnings",
+        "0",
+    ],
+    chdir = package_name(),
+    data = [
+        ":eslint_srcs",
+        ":node_modules/@eslint/js",
+        ":node_modules/eslint",
+        ":node_modules/typescript",
+        ":node_modules/typescript-eslint",
+    ],
+)
+
+# ESLint fix binary (for fixing locally)
+# Usage: bazel run //playground:eslint_fix
+eslint_bin.eslint_binary(
+    name = "eslint_fix",
+    args = [
+        "src",
+        "--fix",
+    ],
+    chdir = package_name(),
+    data = [
+        ":eslint_srcs",
+        ":node_modules/@eslint/js",
+        ":node_modules/eslint",
+        ":node_modules/typescript",
+        ":node_modules/typescript-eslint",
+    ],
 )
 
 # Link npm packages for the playground workspace


### PR DESCRIPTION
Add Bazel targets for ESLint linting in both the playground and
editors/code packages, migrating from npm scripts to Bazel.

New targets:
- //playground:eslint_check - test target for playground linting
- //playground:eslint_fix - binary to auto-fix playground issues
- //editors/code:eslint_check - test target for VS Code extension linting
- //editors/code:eslint_fix - binary to auto-fix extension issues
- //:eslint_check - test_suite running both package checks