### PR TITLE
chore: use pnpm catalogs for TypeScript and ESLint

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -42,7 +42,7 @@
     "vscode-languageserver": "^9.0.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
+    "@eslint/js": "catalog:",
     "@rauschma/env-var": "^1.0.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "~22.18.13",
@@ -52,9 +52,9 @@
     "@vscode/test-web": "^0.0.78",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.27.2",
-    "eslint": "^9.39.2",
+    "eslint": "catalog:",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.52.0"
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -14,7 +14,7 @@
     "@playwright/test": "^1.57.0",
     "classnames": "^2.5.1",
     "cross-env": "^10.1.0",
-    "eslint": "^9.39.2",
+    "eslint": "catalog:",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -26,7 +26,7 @@
     "react-resizable-panels": "^3.0.6"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
+    "@eslint/js": "catalog:",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/lodash-es": "^4.17.12",
     "@types/react": "^19.2.8",
@@ -35,8 +35,8 @@
     "autoprefixer": "^10.4.23",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.52.0",
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:",
     "vite": "^7.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,21 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@eslint/js':
+      specifier: ^9.39.2
+      version: 9.39.2
+    eslint:
+      specifier: ^9.39.2
+      version: 9.39.2
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
+    typescript-eslint:
+      specifier: ^8.52.0
+      version: 8.52.0
+
 importers:
 
   .:
@@ -22,7 +37,7 @@ importers:
         version: 9.0.1
     devDependencies:
       '@eslint/js':
-        specifier: ^9.39.2
+        specifier: 'catalog:'
         version: 9.39.2
       '@rauschma/env-var':
         specifier: ^1.0.1
@@ -52,16 +67,16 @@ importers:
         specifier: ^0.27.2
         version: 0.27.2
       eslint:
-        specifier: ^9.39.2
+        specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.52.0
+        specifier: 'catalog:'
         version: 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
 
   playground:
@@ -79,7 +94,7 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       eslint:
-        specifier: ^9.39.2
+        specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       eslint-plugin-import:
         specifier: ^2.32.0
@@ -110,7 +125,7 @@ importers:
         version: 3.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
-        specifier: ^9.39.2
+        specifier: 'catalog:'
         version: 9.39.2
       '@tailwindcss/postcss':
         specifier: ^4.1.18
@@ -137,10 +152,10 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.52.0
+        specifier: 'catalog:'
         version: 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 packages:
   - 'editors/code'
   - 'playground'
+
+catalog:
+  # TypeScript
+  typescript: ^5.9.3
+
+  # ESLint
+  eslint: ^9.39.2
+  '@eslint/js': ^9.39.2
+  typescript-eslint: ^8.52.0


### PR DESCRIPTION
Centralize version definitions for shared dependencies using pnpm v10
catalogs. This ensures consistent versions across workspace packages.

Packages moved to catalog:
- typescript
- eslint
- @eslint/js
- typescript-eslint