### PR TITLE
perf: reduce cloning in reflow hot paths

### DIFF
--- a/crates/lib/src/utils/reflow/elements.rs
+++ b/crates/lib/src/utils/reflow/elements.rs
@@ -590,7 +590,7 @@ pub struct IndentStats {
 }
 
 impl IndentStats {
-    pub fn from_combination(first: Option<IndentStats>, second: &IndentStats) -> Self {
+    pub fn from_combination(first: Option<&IndentStats>, second: &IndentStats) -> Self {
         match first {
             Some(first_stats) => IndentStats {
                 impulse: first_stats.impulse + second.impulse,


### PR DESCRIPTION
## Summary

- Changed `IndentPoint.untaken_indents` from `Vec<isize>` to `Rc<[isize]>` for cheap cloning
- Changed `IndentStats::from_combination` to take `Option<&IndentStats>` instead of owned value
- Optimized `map_line_buffers` to avoid storing full `IndentPoint` in `previous_points` - only stores the `is_line_break` flag that's actually needed
- Reduced redundant clones by referencing the just-pushed point in the buffer

## Test plan

- [x] All existing tests pass
- [ ] Verify performance improvement with codspeed benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)