### PR TITLE
chore: bump version to 0.34.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "lineage"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "append-only-vec",
  "indexmap",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "assert_cmd",
  "dhat",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-cli-lib"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-cli-python"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "assert_cmd",
  "expect-test",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-lib"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "ahash",
  "codspeed-criterion-compat",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-lib-core"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "ahash",
  "enum_dispatch",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-lib-dialects"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "ahash",
  "expect-test",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-lsp"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "ahash",
  "console_error_panic_hook",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-sqlinference"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "sqruff-lib-core",
  "sqruff-lib-dialects",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "sqruff-wasm"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "line-index",
  "lineage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.34.0"
+version = "0.34.1"
 repository = "https://github.com/quarylabs/sqruff"
 edition = "2024"
 license = "Apache-2.0"
@@ -24,11 +24,11 @@ codegen-units = 1
 log = "0.4"
 ahash = { version = "=0.8.11", features = ["compile-time-rng", "serde"] }
 indexmap = "2.11.4"
-sqruff-cli-lib = { version = "0.34.0", path = "crates/cli-lib" }
-sqruff-lib = { version = "0.34.0", path = "crates/lib" }
-sqruff-lsp = { version = "0.34.0", path = "crates/lsp" }
-sqruff-lib-core = { version = "0.34.0", path = "crates/lib-core" }
-sqruff-lib-dialects = { version = "0.34.0", path = "crates/lib-dialects" }
+sqruff-cli-lib = { version = "0.34.1", path = "crates/cli-lib" }
+sqruff-lib = { version = "0.34.1", path = "crates/lib" }
+sqruff-lsp = { version = "0.34.1", path = "crates/lsp" }
+sqruff-lib-core = { version = "0.34.1", path = "crates/lib-core" }
+sqruff-lib-dialects = { version = "0.34.1", path = "crates/lib-dialects" }
 wasm-bindgen = "0.2"
 wasm-pack = "0.13.1"
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4279,8 +4279,8 @@
         "bzlTransitiveDigest": "qTu+BzWB6ISfBjR2c1BK7L4BvDgPR6v0aqDt93Qj8T0=",
         "usagesDigest": "OldazOYUGgaaawVs7Xdhw9lBVQyHQ5cmcR3eD4/qfX0=",
         "recordedFileInputs": {
-          "@@//Cargo.lock": "b5c018afd94681f8447906729cb65b73573a3813c71fb71347559dd090062490",
-          "@@//Cargo.toml": "f82054a18c93609d498f2c3ae215eabf06cd0d97d96007ed2675b399f18acf87",
+          "@@//Cargo.lock": "7e0e9136fb013ad9968e726c39d507f740408a6ed81ae222599ea73f3b25a19f",
+          "@@//Cargo.toml": "d2d115f2652bfa9825db13d0392b92d54cf8feb9e3d8d41f6e12212cb7c5a1eb",
           "@@//crates/cli-lib/Cargo.toml": "e2d0243a928ce0bd779f466ec0c5934bd67650361bc90d4f7df67b909691eea2",
           "@@//crates/cli-python/Cargo.toml": "e61a952ec3a7a7ea536a7017d809bb0f1831c30411bcb36cd685a174b902b499",
           "@@//crates/cli/Cargo.toml": "64603471dd40c59a0069613298d69b21a8db140f294e36fdc5e467f99cc48dc2",

--- a/crates/cli-python/pyproject.toml
+++ b/crates/cli-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqruff" 
-version = "0.34.0"
+version = "0.34.1"
 description = "A SQL linter written in rust." 
 requires-python = ">=3.10" 
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/quarylabs/sqruff.git"
   },
   "publisher": "Quary",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "engines": {
     "vscode": "^1.96.0"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqruff"
-version = "0.34.0"
+version = "0.34.1"
 requires-python = ">=3.10"
 dependencies = [
     "Jinja2>=3.0.0",


### PR DESCRIPTION
## Summary
This pull request bumps the version of all sqruff packages and related components from 0.34.0 to 0.34.1 in preparation for a patch release.

## Key Changes
- Updated workspace version in `Cargo.toml` from 0.34.0 to 0.34.1
- Updated all package versions in `Cargo.lock` for:
  - lineage
  - sqruff
  - sqruff-cli-lib
  - sqruff-cli-python
  - sqruff-lib
  - sqruff-lib-core
  - sqruff-lib-dialects
  - sqruff-lsp
  - sqruff-sqlinference
  - sqruff-wasm
- Updated Python package version in `crates/cli-python/pyproject.toml`
- Updated Python package version in `pyproject.toml`
- Updated VS Code extension version in `editors/code/package.json`
- Updated Bazel module lock file hashes to reflect the version changes

## Notes
This is a standard version bump across all components to maintain consistency across the monorepo and ensure all published artifacts (Rust crates, Python packages, and VS Code extension) are released with matching version numbers.