### PR TITLE
Remove UV lockfile check from CI workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -145,21 +145,6 @@ jobs:
             git diff MODULE.bazel.lock
             exit 1
           fi
-  uv-lockfile:
-    name: UV Lockfile Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
-      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # ratchet:astral-sh/setup-uv@v7
-      - name: Update lockfile
-        run: uv lock
-      - name: Check lockfile is up to date
-        run: |
-          if ! git diff --quiet uv.lock; then
-            echo "::error::uv.lock is out of date. Run 'uv lock' and commit the changes."
-            git diff uv.lock
-            exit 1
-          fi
   build-binaries:
     name: Build binaries for all platforms
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
## Summary
Removes the `uv-lockfile` job from the PR CI workflow that was checking whether the `uv.lock` file was up to date.

## Changes
- Deleted the entire `uv-lockfile` job from `.github/workflows/pr.yml`
- This job was responsible for:
  - Running `uv lock` to update the lockfile
  - Verifying that `uv.lock` was committed and up to date
  - Failing the CI check if the lockfile was out of sync

## Rationale
This check is no longer needed in the CI pipeline. The UV lockfile management is either being handled elsewhere or is no longer a requirement for this project.