### PR TITLE
feat: combine playground and docs into single website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy playground to Github Pages
+name: Deploy website to Github Pages
 
 on:
   push:
@@ -26,14 +26,14 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-      - name: Build playground
-        run: bazelisk build //playground:build
+      - name: Build website
+        run: bazelisk build //:website
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # ratchet:actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # ratchet:actions/upload-pages-artifact@v4
         with:
-          path: "bazel-bin/playground/dist"
+          path: "bazel-bin/website"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # ratchet:actions/deploy-pages@v4

--- a/.hacking/scripts/zensical_genrule.sh
+++ b/.hacking/scripts/zensical_genrule.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Build documentation using zensical and output to specified directory.
+# Usage: zensical_genrule.sh <output_dir>
+set -eo pipefail
+
+OUTPUT_DIR_ARG="$1"
+
+# Save the original working directory (Bazel execroot)
+EXECROOT="$(pwd)"
+
+# Convert the output path to absolute if it's relative
+if [[ "$OUTPUT_DIR_ARG" == /* ]]; then
+    OUTPUT_DIR="$OUTPUT_DIR_ARG"
+else
+    OUTPUT_DIR="$EXECROOT/$OUTPUT_DIR_ARG"
+fi
+
+# Find runfiles directory - it's alongside the script with .runfiles suffix
+# When run via run_binary, RUNFILES_DIR may not be set, so we find it ourselves
+if [[ -z "$RUNFILES_DIR" ]]; then
+    # Get the directory where this script is located
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    RUNFILES_DIR="${SCRIPT_DIR}/zensical_genrule_tool.runfiles"
+fi
+
+# Find UV binary - the path from @uv//:uv is +tools+uv/uv
+UV_BIN="$RUNFILES_DIR/+tools+uv/uv"
+
+if [[ ! -e "$UV_BIN" ]]; then
+    echo "ERROR: Could not find uv binary at $UV_BIN"
+    ls -la "$RUNFILES_DIR" || true
+    exit 1
+fi
+
+# Create a temp directory for uv cache and build
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# The tool's data dependencies are in runfiles
+# Copy project files to temp directory (use -L to follow symlinks)
+cp -L "$RUNFILES_DIR/_main/pyproject.toml" "$WORKDIR/"
+cp -L "$RUNFILES_DIR/_main/uv.lock" "$WORKDIR/"
+cp -L "$RUNFILES_DIR/_main/zensical.toml" "$WORKDIR/"
+cp -rL "$RUNFILES_DIR/_main/docs" "$WORKDIR/"
+
+cd "$WORKDIR"
+
+# Set uv directories to temp locations to avoid read-only filesystem errors in sandbox
+export UV_CACHE_DIR="$WORKDIR/.uv-cache"
+export UV_PYTHON_INSTALL_DIR="$WORKDIR/.uv-python"
+
+# Sync dependencies
+echo "Syncing dependencies..."
+"$UV_BIN" sync --extra docs --no-install-project
+
+# Build docs using zensical
+echo "Building documentation..."
+"$UV_BIN" run --no-sync zensical build
+
+# Copy output to the specified directory (using absolute path)
+cp -r "$WORKDIR/site/"* "$OUTPUT_DIR/"
+
+echo "Documentation built successfully!"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:prettier/package_json.bzl", prettier_bin = "bin")
 load("@rules_rust//rust:defs.bzl", "rust_clippy", "rustfmt_test")
@@ -237,6 +239,50 @@ sh_test(
 sh_binary(
     name = "zensical_serve",
     srcs = [".hacking/scripts/zensical_serve.sh"],
+)
+
+# Zensical docs genrule tool - builds docs to output directory
+sh_binary(
+    name = "zensical_genrule_tool",
+    srcs = [".hacking/scripts/zensical_genrule.sh"],
+    data = [
+        "pyproject.toml",
+        "uv.lock",
+        "zensical.toml",
+        "@uv//:uv",
+    ] + glob(["docs/**"]),
+    env = {
+        "UV": "$(rlocationpath @uv//:uv)",
+    },
+)
+
+# Build zensical docs as output directory
+run_binary(
+    name = "docs_build",
+    srcs = [
+        "pyproject.toml",
+        "uv.lock",
+        "zensical.toml",
+    ] + glob(["docs/**"]),
+    outs = [],
+    args = ["$(BINDIR)/docs_site"],
+    out_dirs = ["docs_site"],
+    tool = ":zensical_genrule_tool",
+)
+
+# Combined website: playground at root, docs at /docs
+# Usage: bazel build //:website
+copy_to_directory(
+    name = "website",
+    srcs = [
+        "//playground:build",
+        ":docs_build",
+    ],
+    out = "website",
+    replace_prefixes = {
+        "playground/dist": "",
+        "docs_site": "docs",
+    },
 )
 
 # Python tests using uv - run for each Python version


### PR DESCRIPTION
## Summary
- Add `website` Bazel target that combines playground (at root) and zensical docs (at /docs)
- Add `docs_build` target using run_binary to build docs via zensical
- Add `zensical_genrule.sh` script to build docs and output to directory
- Update GitHub Pages workflow to deploy combined website

The deployed site will now have:
- `/` - Playground
- `/docs` - Documentation

## Test plan
- [x] `bazel build //:website` produces correct structure
- [x] `bazel test //:zensical_build` still passes
- [x] `bazel test //:shellcheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)