### PR TITLE
docs: add Docker image to installation docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,6 +39,14 @@ cargo install sqruff
 
 Releases: https://github.com/quarylabs/sqruff/releases
 
+## Docker
+
+You can use sqruff in a Docker container with our official image:
+
+```bash
+docker pull ghcr.io/quarylabs/sqruff:latest
+```
+
 ## GitHub Action
 
 Use the GitHub Action to install and run sqruff in CI.


### PR DESCRIPTION
## Summary
- Adds Docker installation instructions to the getting-started docs

## Test plan
- [x] Verify the Docker pull command works: `docker pull ghcr.io/quarylabs/sqruff:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)