### PR TITLE
fix: enable jinja templater for previously ignored test fixtures

### DIFF
--- a/crates/lib/test/fixtures/rules/std_rule_cases/AL07.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/AL07.yml
@@ -246,11 +246,12 @@ test_fail_no_copy_code_out_of_template:
   # The rule wants to replace "t" with "foobar", but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
   # of the templated region. Hence, the query is not modified.
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT t.repo_id
     FROM {{ source_table }} AS t
   configs:
+    core:
+      templater: jinja
     templater:
       jinja:
         context:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CP01.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CP01.yml
@@ -122,17 +122,16 @@ test_pass_ignore_words_complex:
         ignore_words_regex: (^Se|^Fr)
 
 test_pass_ignore_templated_code_true:
-  ignored: "jinja is not set"
   pass_str: |
     {{ "select" }} a
     FROM foo
     WHERE 1
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: true
 
 test_fail_ignore_templated_code_false:
-  ignored: "jinja is not supported"
   fail_str: |
     {{ "select" }} a
     FROM foo
@@ -143,6 +142,7 @@ test_fail_ignore_templated_code_false:
     where 1
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_snowflake_group_by_cube:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CP03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CP03.yml
@@ -65,7 +65,6 @@ test_pass_ignore_templated_code_true:
       ignore_templated_areas: true
 
 test_fail_ignore_templated_code_false:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         {{ "greatest(a, b)" }},
@@ -76,6 +75,7 @@ test_fail_ignore_templated_code_false:
         greatest(i, j)
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_pass_func_name_templated_literal_mix:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CV10.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CV10.yml
@@ -294,12 +294,12 @@ test_pass_partially_templated_quoted_literals_simple:
         preferred_quoted_literal_style: double_quotes
 
 test_fail_partially_templated_quoted_literals_simple:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT '{{ "a string" }}'
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
@@ -310,17 +310,18 @@ test_pass_partially_templated_quoted_literals_complex:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_fail_partially_templated_quoted_literals_complex:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT 'this_is_a_lintable_{{ "string" }}'
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
@@ -331,23 +332,23 @@ test_pass_partially_templated_quoted_literals_with_multiple_templates:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_fail_partially_templated_quoted_literals_with_multiple_templates:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT 'this_{{ "is" }}_{{ "a_lintable" }}_{{ "string" }}'
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_fail_partially_templated_quoted_literals_inside_blocks:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         {% if true %}
@@ -356,45 +357,45 @@ test_fail_partially_templated_quoted_literals_inside_blocks:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_fully_templated_quoted_literals_are_ignored:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT {{ "'a_non_lintable_string'" }}
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_partially_templated_literals_are_ignored_when_some_quotes_are_inside_the_template_1:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT '{{ "string' FROM table1" }}
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_partially_templated_literals_are_ignored_when_some_quotes_are_inside_the_template_2:
-  ignored: "jinja is not set"
   pass_str: |
     {{ "SELECT 'stri" -}}ng' FROM table1
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_prefix_chars_are_correctly_detected_as_unlintable:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT
       r{{ "''" }},
@@ -402,6 +403,7 @@ test_pass_prefix_chars_are_correctly_detected_as_unlintable:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -5,11 +5,11 @@ test_pass_parenthesis_block_isolated:
     SELECT * FROM (SELECT 1 AS C1) AS T1;
 
 test_pass_parenthesis_block_isolated_template:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT * FROM (SELECT 1 AS C1) AS T1;' }}
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_parenthesis_block_not_isolated:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-commas.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-commas.yml
@@ -12,32 +12,32 @@ test_fail_whitespace_before_comma_template:
       ignore_templated_areas: false
 
 test_pass_errors_only_in_templated_and_ignore:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT 1 ,4' }}, 5, 6
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: true
 
 test_fail_errors_only_in_non_templated_and_ignore:
-  ignored: "jinja is not supported"
   fail_str: |
     {{ 'SELECT 1, 4' }}, 5 , 6
   fix_str: |
     {{ 'SELECT 1, 4' }}, 5, 6
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: true
 
 test_pass_single_whitespace_after_comma:
   pass_str: SELECT 1, 4
 
 test_pass_single_whitespace_after_comma_template:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT 1, 4' }}
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_multiple_whitespace_after_comma:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -4,11 +4,11 @@ test_basic:
   pass_str: SELECT 1
 
 test_basic_template:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT 1' }}
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_basic_fix:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -93,7 +93,6 @@ pass_concat_string:
 test_pass_placeholder_spacing:
   # Test for spacing issues around placeholders
   # https://github.com/sqlfluff/sqlfluff/issues/4253
-  ignored: "jinja is not supported"
   pass_str: |
     {% set is_dev_environment = true %}
 
@@ -108,6 +107,9 @@ test_pass_placeholder_spacing:
         {% endif %}
         AND TRUE
     ;
+  configs:
+    core:
+      templater: jinja
 
 fail_bigquery_whitespaces_in_function_reference:
   fail_str: SELECT dataset    .    AddFourAndDivide(5, 10)

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-trailing.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-trailing.yml
@@ -11,21 +11,24 @@ test_fail_trailing_whitespace_on_initial_blank_line:
 
 
 test_pass_trailing_whitespace_before_template_code:
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT
         {% for elem in ["a", "b"] %}
         {{ elem }},
         {% endfor %}
         0
+  configs:
+    core:
+      templater: jinja
 
 test_fail_trailing_whitespace_and_whitespace_control:
-  ignored: "jinja is not supported"
   fail_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1, \n    2,\n"
   fix_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1,\n    2,\n"
+  configs:
+    core:
+      templater: jinja
 
 test_pass_macro_trailing:
-  ignored: "jinja is not supported"
   pass_str: |
     {% macro foo(bar) %}
         {{bar}}
@@ -41,3 +44,6 @@ test_pass_macro_trailing:
 
     select *
     from tbl
+  configs:
+    core:
+      templater: jinja

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -396,7 +396,6 @@ test_jinja_with_disbalanced_pairs:
   # The range(3) -%} results in swallowing the \n
   # N.B. The way LT02 handles this is questionable,
   # and this test seals in that behaviour.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT
         cohort_month
@@ -405,6 +404,9 @@ test_jinja_with_disbalanced_pairs:
         {% endfor -%}
         , TRUE AS overall
     FROM orders
+  configs:
+    core:
+      templater: jinja
 
 test_fail_attempted_hanger_fix:
   # Check messy hanger correction.
@@ -502,7 +504,6 @@ test_fail_clean_reindent_fix:
 
 # https://github.com/sqlfluff/sqlfluff/issues/643
 test_pass_indent_snowflake:
-  ignored: "jinja is not set"
   pass_str: |
     with source_data as (
         select * from {{ source('source_name', 'xxx_yyy_zzz') }}
@@ -513,10 +514,10 @@ test_pass_indent_snowflake:
   configs:
     core:
       dialect: snowflake
+      templater: jinja
 
 # https://github.com/sqlfluff/sqlfluff/issues/643
 test_pass_indent_indent_bigquery:
-  ignored: "jinja is not set"
   pass_str: |
     with source_data as (
         select * from {{ source('source_name', 'xxx_yyy_zzz') }}
@@ -526,9 +527,9 @@ test_pass_indent_indent_bigquery:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
 
 test_jinja_indent_templated_table_name_a:
-  ignored: "jinja is not set"
   fail_str: |
     -- This file combines product data from individual brands into a staging table
     {% for product in ['table1', 'table2'] %}
@@ -555,11 +556,13 @@ test_jinja_indent_templated_table_name_a:
             {{ product }}
         {% if not loop.last -%} UNION ALL {%- endif %}
     {% endfor %}
+  configs:
+    core:
+      templater: jinja
 
 # Like test_jinja_indent_1_a but "FROM" table not initially
 # indented.
 test_jinja_indent_templated_table_name_b:
-  ignored: "jinja is not supported"
   fail_str: |
     -- This file combines product data from individual brands into a staging table
     {% for product in ['table1', 'table2'] %}
@@ -586,9 +589,11 @@ test_jinja_indent_templated_table_name_b:
             {{ product }}
         {% if not loop.last -%} UNION ALL {%- endif %}
     {% endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_jinja_nested_blocks:
-  ignored: "jinja is not supported"
   fail_str: |
     WITH
     raw_effect_sizes AS (
@@ -612,6 +617,9 @@ test_jinja_nested_blocks:
             {% endfor %}
     )
     SELECT 1
+  configs:
+    core:
+      templater: jinja
 
 # LIMIT, QUALIFY, and WINDOW both indent
 test_limit_and_qualify_and_window_indent:
@@ -841,7 +849,6 @@ test_tsql_function:
       dialect: tsql
 
 test_pass_ignore_templated_whitespace:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT
         c1,
@@ -849,10 +856,10 @@ test_pass_ignore_templated_whitespace:
     FROM my_table
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_ignore_templated_whitespace_1:
-  ignored: "jinja is not set"
   fail_str: |
     SELECT
         c1,
@@ -866,6 +873,7 @@ test_fail_ignore_templated_whitespace_1:
 
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_ignore_templated_whitespace_2:
@@ -884,7 +892,6 @@ test_fail_ignore_templated_whitespace_2:
       ignore_templated_areas: false
 
 test_fail_ignore_templated_whitespace_3:
-  ignored: "jinja is not set"
   fail_str: |
     SELECT
         c1,
@@ -897,10 +904,10 @@ test_fail_ignore_templated_whitespace_3:
     FROM my_table
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_pass_ignore_templated_whitespace_4:
-  ignored: "jinja is not set"
   # Note the newline after c2. This causes "AS other_id" to be on a different
   # line in templated space, but not raw space. LT02 should ignore lines like
   # this.
@@ -909,21 +916,28 @@ test_pass_ignore_templated_whitespace_4:
         c1,
         {{ "      c2\n" }} AS other_id
     FROM my_table
+  configs:
+    core:
+      templater: jinja
 
 test_pass_ignore_templated_newline_not_last_line:
-  ignored: "jinja is not supported"
   pass_str: |
     select *
     from {{ "\n\nmy_table" }}
     inner join
         my_table2
         using (id)
+  configs:
+    core:
+      templater: jinja
 
 test_pass_ignore_templated_newline_last_line:
-  ignored: "jinja is not set"
   pass_str: |
     select *
     from {{ "\n\nmy_table" }}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_fix_template_indentation_1:
   fail_str: |
@@ -936,7 +950,6 @@ test_fail_fix_template_indentation_1:
         {{ "c2" }}
 
 test_fail_fix_template_indentation_2:
-  ignored: "jinja is not supported"
   fail_str: |
     with
     first_join as (
@@ -959,6 +972,9 @@ test_fail_fix_template_indentation_2:
     )
 
     select * from first_join
+  configs:
+    core:
+      templater: jinja
 
 test_pass_tsql_update_indent:
   pass_str: |
@@ -1309,7 +1325,6 @@ test_tsql_outer_apply_indentation_fix:
       dialect: tsql
 
 test_fail_consuming_whitespace_a:
-  ignored: "jinja is not supported"
   # Test that this works even with tags which consume whitespace.
   fail_str: |
     {% for item in [1, 2] -%}
@@ -1323,9 +1338,11 @@ test_fail_consuming_whitespace_a:
         FROM some_table
         {{ 'UNION ALL\n' if not loop.last }}
     {%- endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_consuming_whitespace_b:
-  ignored: "jinja is not supported"
   # Additional test to make sure that crazy things don't happen
   # with the first newline.
   fail_str: |
@@ -1340,9 +1357,11 @@ test_fail_consuming_whitespace_b:
         FROM some_table
         {{ 'UNION ALL\n' if not loop.last }}
     {%- endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_pass_consuming_whitespace_stable:
-  ignored: "jinja is not supported"
   # Test for stability in fixes with loops and consuming tags.
   # https://github.com/sqlfluff/sqlfluff/issues/3185
   pass_str: |
@@ -1351,6 +1370,9 @@ test_pass_consuming_whitespace_stable:
         FROM some_table
         {{ 'UNION ALL\n' if not loop.last }}
     {%- endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_trailing_comments:
   # Additional test to make sure that crazy things don't happen
@@ -1388,7 +1410,6 @@ test_fail_case_statement:
       tab_space_size: 2
 
 test_pass_templated_case_statement:
-  ignored: "jinja is not supported"
   # Test for template block in case statement indentation
   # https://github.com/sqlfluff/sqlfluff/issues/3988
   pass_str: |
@@ -1412,9 +1433,11 @@ test_pass_templated_case_statement:
 
     select *
     from dummy
+  configs:
+    core:
+      templater: jinja
 
 test_pass_jinja_tag_multiline:
-  ignored: "jinja is not supported"
   # Test that jinja block tags which contain newlines
   # aren't linted, because we can't reliably fix them.
   # The default fixing routine would only moving the
@@ -1435,6 +1458,9 @@ test_pass_jinja_tag_multiline:
     {%       endif
     %}
         4
+  configs:
+    core:
+      templater: jinja
 
 test_pass_trailing_inline_noqa:
   pass_str: |
@@ -1475,7 +1501,6 @@ test_fail_deny_implicit_indent:
       allow_implicit_indents: false
 
 test_pass_templated_newlines:
-  ignored: "jinja is not supported"
   # NOTE: The macro has many newlines in it,
   # and the calling of it is indented. Check that
   # this doesn't panic.
@@ -1490,9 +1515,11 @@ test_pass_templated_newlines:
     SELECT
         {{ my_macro() }} as awkward_indentation
     FROM foo
+  configs:
+    core:
+      templater: jinja
 
 test_fail_fix_beside_templated:
-  ignored: "jinja is not supported"
   # Check that templated code checks aren't too aggressive.
   # https://github.com/sqlfluff/sqlfluff/issues/4215
   fail_str: |
@@ -1511,6 +1538,9 @@ test_fail_fix_beside_templated:
         FROM t
         WHERE c < 0
     {% endif %}
+  configs:
+    core:
+      templater: jinja
 
 test_pass_block_comment:
   # Check that subsequent block comment lines are ok to be indented.
@@ -1592,7 +1622,6 @@ test_fail_case_else_end_clause:
     from foo
 
 test_fail_hard_templated_indents:
-  ignored: "jinja is not supported"
   # Test for consumed initial indents and consumed line indents.
   # https://github.com/sqlfluff/sqlfluff/issues/4230
   # NOTE: We're using a block indentation indicator because the
@@ -1606,6 +1635,9 @@ test_fail_hard_templated_indents:
     {%- if true -%}
         SELECT * FROM {{ "t1" }}
     {%- endif %}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_fix_consistency_around_comments:
   # Check that comments don't make fixes inconsistent.
@@ -1823,7 +1855,6 @@ test_fix_implicit_indents_4467_b:
 
 test_fix_macro_indents_4367:
   # https://github.com/sqlfluff/sqlfluff/issues/4367
-  ignored: "jinja is not supported"
   fail_str: |
     {% macro my_macro(col) %}
         {{ col }}
@@ -1842,6 +1873,9 @@ test_fix_macro_indents_4367:
         {{ my_macro("mycol") }},
         something_else
     FROM mytable
+  configs:
+    core:
+      templater: jinja
 
 test_fix_untaken_positive_4433:
   # https://github.com/sqlfluff/sqlfluff/issues/4433
@@ -1910,7 +1944,6 @@ test_jinja_nested_tracking:
   # in the lexer. If that's not functioning properly
   # the indentation of the nested jinja blocks in this
   # query will likely fail.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT *
     FROM
@@ -1924,6 +1957,9 @@ test_jinja_nested_tracking:
                 (c, d, e)
         {% endif %}
     {% endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_configure_no_indent_before_then_4589:
   # THEN can be configured to not be indented
@@ -1976,7 +2012,6 @@ test_bigquery_merge_statement_values_clause:
       dialect: bigquery
 
 test_fail_issue_4680:
-  ignored: "jinja is not supported"
   # NOTE: It doesn't reindent the second clause, but the important
   # thing is that we don't get an exception.
   fail_str: |
@@ -1997,6 +2032,9 @@ test_fail_issue_4680:
         {% else %}
         col1 > 0
       {% endif %}
+  configs:
+    core:
+      templater: jinja
 
 test_implicit_indent_when:
   fail_str: |
@@ -2044,7 +2082,6 @@ test_implicit_indent_nested_when:
       indented_then_contents: false
 
 test_fail_issue_4745:
-  ignored: "jinja is not supported"
   fail_str: |
     with
     {% for a in [1, 2, 3] %}{% for b in ['C'] %}
@@ -2067,6 +2104,9 @@ test_fail_issue_4745:
     {% endfor %}{% endfor %}
 
     select 1
+  configs:
+    core:
+      templater: jinja
 
 test_pass_trailing_comment_1:
   # NOTE: This checks that we allow the alternative placement of comments

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT03.yml
@@ -215,7 +215,6 @@ fails_trailing_with_comments:
   configs: *operator_before
 
 passes_templated_newline:
-  ignored: "jinja is not set"
   pass_str: |
     {% macro binary_literal(expression) %}
       X'{{ expression }}'
@@ -226,9 +225,11 @@ passes_templated_newline:
     from my_table
     where
         a = {{ binary_literal("0000") }}
+  configs:
+    core:
+      templater: jinja
 
 fails_templated_code_non_templated_newline:
-  ignored: "jinja is not supported"
   fail_str: |
     {% macro binary_literal(expression) %}
       X'{{ expression }}'
@@ -240,6 +241,9 @@ fails_templated_code_non_templated_newline:
     where
         a =
             {{ binary_literal("0000") }}
+  configs:
+    core:
+      templater: jinja
 
 passes_operator_alone_on_line:
   # Special case: An operator on a line by itself is always okay.
@@ -252,7 +256,6 @@ passes_operator_alone_on_line:
 fixes_tuple_error_issue:
   # https://github.com/sqlfluff/sqlfluff/issues/4184
   # NB: This one isn't fixable.
-  ignored: "jinja is not supported"
   fail_str: |
     select * from foo
     where c is not null and -- comment
@@ -261,5 +264,7 @@ fixes_tuple_error_issue:
         {% endif %}
         true
   configs:
+    core:
+      templater: jinja
     indentation:
       template_blocks_indent: false

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT04.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT04.yml
@@ -298,7 +298,6 @@ leading_comma_with_templated_column_1:
           line_position: leading
 
 leading_comma_with_templated_column_2:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT
         c1
@@ -306,13 +305,14 @@ leading_comma_with_templated_column_2:
     c2" }} AS days_since
     FROM logs
   configs:
+    core:
+      templater: jinja
     layout:
       type:
         comma:
           line_position: leading
 
 trailing_comma_with_templated_column_1:
-  ignored: "jinja is not set"
   fail_str: |
     SELECT
         {{ "c1" }}
@@ -323,14 +323,19 @@ trailing_comma_with_templated_column_1:
         {{ "c1" }},
         c2 AS days_since
     FROM logs
+  configs:
+    core:
+      templater: jinja
 
 trailing_comma_with_templated_column_2:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT
         {{ "c1
     " }}, c2 AS days_since
     FROM logs
+  configs:
+    core:
+      templater: jinja
 
 leading_comma_fix_mixed_indent:
   # See: https://github.com/sqlfluff/sqlfluff/issues/4255

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -121,7 +121,6 @@ test_pass_line_too_long_ignore_comments_false:
 test_compute_line_length_before_template_expansion_1:
   # Line 3 is fine before expansion. Too long after expansion is NOT considered
   # a violation.
-  ignored: "jinja is not set"
   pass_str: |
     SELECT user_id
     FROM
@@ -129,6 +128,7 @@ test_compute_line_length_before_template_expansion_1:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     templater:
       jinja:
         context:
@@ -136,7 +136,6 @@ test_compute_line_length_before_template_expansion_1:
           bi_ecommerce_orders: bq-business-intelligence.user.ecommerce_orders
 
 test_compute_line_length_before_template_expansion_2:
-  ignored: "jinja is not supported"
   # Line 3 is too long before expansion. It's fine after expansion, but the rule
   # does not look at that.
   fail_str: |
@@ -157,6 +156,7 @@ test_compute_line_length_before_template_expansion_2:
   configs:
     core:
       dialect: bigquery
+      templater: jinja
     templater:
       jinja:
         context:
@@ -178,7 +178,6 @@ test_long_jinja_comment:
 
 test_long_jinja_comment_ignore:
   # A Jinja comment is a comment.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT *
     {# comment #}
@@ -187,23 +186,25 @@ test_long_jinja_comment_ignore:
   configs:
     core:
       max_line_length: 80
+      templater: jinja
     rules:
       layout.long_lines:
         ignore_comment_lines: true
 
 test_for_loop:
   # A Jinja for loop
-  ignored: "jinja is not set"
   pass_str: |
     {% for elem in 'foo' %}
     SELECT '{{ elem }}' FROM table1;
     SELECT '{{ elem }}' FROM table2;
     {% endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_for_loop_repeating_elements_starts_with_literal:
   # A Jinja for loop with repeating elements (that are difficult to match)
   # but starting with a literal that can be used to match
-  ignored: "jinja is not set"
   pass_str: |
     {% set elements = 'foo' %}
     SELECT
@@ -213,9 +214,11 @@ test_for_loop_repeating_elements_starts_with_literal:
             WHEN '{{ elem }}' = '' THEN 1
             {% endfor %}
         END
+  configs:
+    core:
+      templater: jinja
 
 test_for_loop_starting_with_templated_piece:
-  ignored: "jinja is not set"
   # A Jinja for loop starting with non-literals
   # But unique parts can be used to match
   pass_str: |
@@ -228,12 +231,14 @@ test_for_loop_starting_with_templated_piece:
             {{ when }} '{{ elem }}' = '' THEN 2
             {% endfor %}
         END
+  configs:
+    core:
+      templater: jinja
 
 test_for_loop_fail_complex_match:
   # A Jinja for loop starting with non-literals
   # But non-unique parts which therefore cannot
   # be used to match
-  ignored: "jinja is not set"
   pass_str: |
     {% set elements = 'foo' %}
     {% set when = 'WHEN' %}
@@ -244,10 +249,12 @@ test_for_loop_fail_complex_match:
             {{ when }} '{{ elem }}' = '' THEN 1
             {% endfor %}
         END
+  configs:
+    core:
+      templater: jinja
 
 test_for_loop_fail_simple_match:
   # If for loop only contains literals it should still pass
-  ignored: "jinja is not set"
   pass_str: |
     {% set elements = 'foo' %}
     SELECT
@@ -256,16 +263,19 @@ test_for_loop_fail_simple_match:
             WHEN 'f' THEN a
             {% endfor %}
         END
+  configs:
+    core:
+      templater: jinja
 
 test_set_statement:
   # A Jinja set statement
-  ignored: "jinja is not set"
   pass_str: |
     {% set statement = "SELECT 1 from table1;" %}
     {{ statement }}{{ statement }}
   configs:
     core:
       max_line_length: 80
+      templater: jinja
 
 test_issue_1666_line_too_long_unfixable_jinja:
   # Note the trailing space at the end of line 1. This is a necessary part of
@@ -273,7 +283,9 @@ test_issue_1666_line_too_long_unfixable_jinja:
   # "tricking" LT05 into trying to split the line, then encountering an internal
   # error.
   fail_str: "{{ config (schema='bronze', materialized='view', sort =['id','number'], dist = 'all', tags =['longlonglonglonglong']) }} \n\nselect 1\n"
-  ignored: "jinja is not set"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_ignore_comment_clauses_1:
   # Too long, comment clause not ignored
@@ -370,12 +382,13 @@ test_pass_ignore_templated_comment_lines:
   # NOTE: This is potentially a behaviour change in 2.0.0.
   # This was erroneously using the `ignore_comment_clauses`
   # config when this query contains no comment clauses.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT *
         {# ........................................................................... #}
     FROM table
   configs:
+    core:
+      templater: jinja
     rules:
       layout.long_lines:
         ignore_comment_lines: true
@@ -438,7 +451,6 @@ test_pass_long_multiline_jinja:
   # None of the lines are longer than 30
   # but the whole tag is. It shouldn't
   # cause issues.
-  ignored: "jinja is not set"
   pass_str: |
     select
         {{
@@ -449,6 +461,7 @@ test_pass_long_multiline_jinja:
   configs:
     core:
       max_line_length: 30
+      templater: jinja
 
 test_fail_long_inline_statement:
   # Tests that breaks happen between clauses properly
@@ -647,7 +660,6 @@ test_long_functions_and_aliases:
     FROM my_table
 
 test_order_by_rebreak_span:
-  ignored: "jinja is not supported"
   # This tests that we can correctly rebreak an "order by" expressions.
   fail_str: |
     select * from
@@ -675,6 +687,9 @@ test_order_by_rebreak_span:
             inner join tbl2
                 on tbl1.the_name = tbl2.the_name
         )
+  configs:
+    core:
+      templater: jinja
 
 test_trailing_semicolon_moves:
   # The checks that we don't move the semicolon or the comma.

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT07.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT07.yml
@@ -52,7 +52,6 @@ test_pass_cte_with_column_list:
     select * from search_path
 
 test_pass_with_clause_closing_misaligned_indentation_in_templated_block:
-  ignored: "jinja is not set"
   pass_str: |
     with
     {% if true %}
@@ -65,9 +64,11 @@ test_pass_with_clause_closing_misaligned_indentation_in_templated_block:
       )
     {% endif %}
     select * from cte
+  configs:
+    core:
+      templater: jinja
 
 test_move_parenthesis_to_next_line_in_templated_block:
-  ignored: "jinja is not supported"
   fail_str: |
     with
     {% if true %}
@@ -84,9 +85,11 @@ test_move_parenthesis_to_next_line_in_templated_block:
     )
     {% endif %}
     select * from cte
+  configs:
+    core:
+      templater: jinja
 
 test_pass_templated_clauses:
-  ignored: "jinja is not set"
   pass_str: |
     with
 
@@ -103,3 +106,6 @@ test_pass_templated_clauses:
     select * from final
     join a using (x)
     join b using (x)
+  configs:
+    core:
+      templater: jinja

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT12.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT12.yml
@@ -12,21 +12,26 @@ test_fail_multiple_final_newlines:
   fix_str: "SELECT foo FROM bar\n"
 
 test_pass_templated_plus_raw_newlines:
-  ignored: "jinja is not set"
   pass_str: "{{ '\n\n' }}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_templated_plus_raw_newlines:
-  ignored: "jinja is not set"
   fail_str: "{{ '\n\n' }}"
   fix_str: "{{ '\n\n' }}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_templated_plus_raw_newlines_extra_newline:
-  ignored: "jinja is not set"
   fail_str: "{{ '\n\n' }}\n\n"
   fix_str: "{{ '\n\n' }}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_pass_templated_macro_newlines:
-  ignored: "jinja is not set"
   # Tricky because the rendered code ends with two newlines:
   # - Literal newline inserted by the macro
   # - Literal newline at the end of the file
@@ -37,10 +42,15 @@ test_pass_templated_macro_newlines:
       {{ columns }}
     {% endmacro %}
     SELECT {{ get_keyed_nulls("other_id") }}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_templated_no_newline:
-  ignored: "jinja is not set"
   # Tricky because there's no newline at the end of the file (following the
   # templated code).
   fail_str: "{% if true %}\nSELECT 1 + 1\n{%- endif %}"
   fix_str: "{% if true %}\nSELECT 1 + 1\n{%- endif %}\n"
+  configs:
+    core:
+      templater: jinja

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT13.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT13.yml
@@ -16,16 +16,22 @@ test_pass_leading_whitespace_inline_comment_hash:
       dialect: bigquery
 
 test_pass_leading_whitespace_jinja_comment:
-  ignored: "jinja is not set"
   pass_str: "{# I am a comment #}\nSELECT foo FROM bar\n"
+  configs:
+    core:
+      templater: jinja
 
 test_pass_leading_whitespace_jinja_if:
-  ignored: "jinja is not set"
   pass_str: "{% if True %}\nSELECT foo\nFROM bar;\n{% endif %}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_pass_leading_whitespace_jinja_for:
-  ignored: "jinja is not set"
   pass_str: "{% for item in range(10) %}\nSELECT foo_{{ item }}\nFROM bar;\n{% endfor %}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_leading_whitespace_statement:
   fail_str: "\n  SELECT foo FROM bar\n"
@@ -40,16 +46,22 @@ test_fail_leading_whitespace_inline_comment:
   fix_str: "--I am a comment\nSELECT foo FROM bar\n"
 
 test_fail_leading_whitespace_jinja_comment:
-  ignored: "jinja is not set"
   fail_str: "\n  {# I am a comment #}\nSELECT foo FROM bar\n"
   fix_str: "{# I am a comment #}\nSELECT foo FROM bar\n"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_leading_whitespace_jinja_if:
-  ignored: "jinja is not set"
   fail_str: "\n  {% if True %}\nSELECT foo\nFROM bar;\n{% endif %}\n"
   fix_str: "{% if True %}\nSELECT foo\nFROM bar;\n{% endif %}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_leading_whitespace_jinja_for:
-  ignored: "jinja is not set"
   fail_str: "\n  {% for item in range(10) %}\nSELECT foo_{{ item }}\nFROM bar;\n{% endfor %}\n"
   fix_str: "{% for item in range(10) %}\nSELECT foo_{{ item }}\nFROM bar;\n{% endfor %}\n"
+  configs:
+    core:
+      templater: jinja

--- a/crates/lib/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -310,21 +310,24 @@ passes_tql_table_variable:
         single_table_references: qualified
 
 fail_but_dont_fix_templated_table_name_consistent:
-  ignored: "jinja is not supported"
-  fail_str: |
-    SELECT
-        a,
-        {{ "foo" }}.b
-    FROM {{ "foo" }}
-
-fail_but_dont_fix_templated_table_name_qualified:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         a,
         {{ "foo" }}.b
     FROM {{ "foo" }}
   configs:
+    core:
+      templater: jinja
+
+fail_but_dont_fix_templated_table_name_qualified:
+  fail_str: |
+    SELECT
+        a,
+        {{ "foo" }}.b
+    FROM {{ "foo" }}
+  configs:
+    core:
+      templater: jinja
     rules:
       references.consistent:
         single_table_references: qualified

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -258,7 +258,6 @@ test_fail_no_copy_code_out_of_template:
   # The rule wants to replace the case statement with coalesce(), but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
   # of the templated region. Hence, the query is not modified.
-  ignored: "jinja is not supported"
   fail_str: |
     select
         foo,
@@ -270,6 +269,7 @@ test_fail_no_copy_code_out_of_template:
     from baz;
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
     templater:
       jinja:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST04.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST04.yml
@@ -209,7 +209,6 @@ test_fail_no_copy_code_out_of_template:
   # The rule wants to replace the case statement with coalesce(), but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
   # of the templated region. Hence, the query is not modified.
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         c1,
@@ -223,6 +222,7 @@ test_fail_no_copy_code_out_of_template:
     FROM mytable
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
     templater:
       jinja:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST07.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST07.yml
@@ -65,7 +65,6 @@ test_fail_parent_child_positioning:
     join (select * from c3 join c4 ON c3.ID = c4.ID) as c5 on c1.ID = c5.ID
 
 fail_but_dont_fix_templated_table_names:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         {{ "table_a" }}.field_1,
@@ -73,6 +72,9 @@ fail_but_dont_fix_templated_table_names:
     FROM
         {{ "table_a" }}
     INNER JOIN table_b USING (id)
+  configs:
+    core:
+      templater: jinja
 
 test_pass_clickhouse:
   pass_str: SELECT * FROM test1 as t1 LEFT SEMI JOIN test2 USING ty1,ty2;


### PR DESCRIPTION
## Summary
- Update rule test fixtures that were ignored due to missing jinja templater configuration
- For each test using jinja syntax (`{{ }}`, `{% %}`), add `templater: jinja` to configs
- Enables ~80 tests across 20 fixture files that were previously skipped

## Test plan
- [ ] Run `cargo test` to verify all updated fixtures pass
- [ ] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)