### PR TITLE
chore: add dbt source example using duckdb information_schema

### DIFF
--- a/crates/cli-python/tests/dbt/output.stderr
+++ b/crates/cli-python/tests/dbt/output.stderr
@@ -5,5 +5,5 @@ L:  42 | P:  27 | LT02 | Expected line break and indent of 4 spaces before "on".
 L:  42 | P:  31 | LT02 | Expected indent of 12 spaces. [layout.indent]
 L:  65 | P:  41 | LT01 | Expected only single space before "customers". Found " 
                        | ". [layout.spacing]
-The linter processed 5 file(s).
+The linter processed 6 file(s).
 All Finished

--- a/crates/cli-python/tests/dbt_sample/models/sources.yml
+++ b/crates/cli-python/tests/dbt_sample/models/sources.yml
@@ -1,0 +1,19 @@
+version: 2
+
+sources:
+  - name: information_schema
+    description: DuckDB system catalog tables
+    database: memory
+    schema: information_schema
+    tables:
+      - name: tables
+        description: Contains metadata about all tables in the database
+        columns:
+          - name: table_catalog
+            description: The catalog (database) the table belongs to
+          - name: table_schema
+            description: The schema the table belongs to
+          - name: table_name
+            description: The name of the table
+          - name: table_type
+            description: The type of table (BASE TABLE, VIEW, etc.)

--- a/crates/cli-python/tests/dbt_sample/models/staging/schema.yml
+++ b/crates/cli-python/tests/dbt_sample/models/staging/schema.yml
@@ -29,3 +29,15 @@ models:
         tests:
           - accepted_values:
               values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']
+
+  - name: stg_database_tables
+    description: Staging view of database tables from information_schema
+    columns:
+      - name: table_catalog
+        description: The catalog (database) the table belongs to
+      - name: table_schema
+        description: The schema the table belongs to
+      - name: table_name
+        description: The name of the table
+      - name: table_type
+        description: The type of table (BASE TABLE, VIEW, etc.)

--- a/crates/cli-python/tests/dbt_sample/models/staging/stg_database_tables.sql
+++ b/crates/cli-python/tests/dbt_sample/models/staging/stg_database_tables.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('information_schema', 'tables') }}
+
+),
+
+filtered as (
+
+    select
+        table_catalog,
+        table_schema,
+        table_name,
+        table_type
+
+    from source
+    where table_schema not in ('information_schema', 'pg_catalog')
+
+)
+
+select * from filtered

--- a/crates/cli-python/tests/ui_with_dbt.rs
+++ b/crates/cli-python/tests/ui_with_dbt.rs
@@ -36,7 +36,11 @@ fn main() {
     for (key, value) in std::env::vars() {
         cmd.env(key, value);
     }
-    cmd.arg("lint").arg("-f").arg("human").arg("models/");
+    cmd.arg("lint")
+        .arg("-f")
+        .arg("human")
+        .arg("--parsing-errors")
+        .arg("models/");
 
     // Run the command and capture the output
     let assert = cmd.assert();


### PR DESCRIPTION
## Summary
- Add `stg_database_tables.sql` model demonstrating dbt `source()` function with DuckDB's information_schema
- Add `sources.yml` defining the `duckdb_info` source
- Update `staging/schema.yml` with the new model documentation
- Fix `ui_with_dbt` test for the updated file count (5 → 6 files)
- Add `--parsing-errors` flag to `ui_with_dbt` test to ensure all dbt models parse correctly

## Test plan
- [x] `cargo test -p sqruff-cli-python --test ui_with_dbt` passes
- [x] All dbt models in the sample project parse without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)