### PR TITLE
feat: add dialect configuration system

### DIFF
--- a/crates/cli-lib/src/docs.rs
+++ b/crates/cli-lib/src/docs.rs
@@ -101,6 +101,7 @@ struct Dialect {
     name: &'static str,
     description: &'static str,
     doc_url: Option<&'static str>,
+    config_section: String,
 }
 
 #[cfg(feature = "codegen-docs")]
@@ -110,6 +111,7 @@ impl From<DialectKind> for Dialect {
             name: value.name(),
             description: value.description(),
             doc_url: value.doc_url(),
+            config_section: value.config_section(),
         }
     }
 }

--- a/crates/cli-lib/src/docs/generate_dialect_docs_template.md
+++ b/crates/cli-lib/src/docs/generate_dialect_docs_template.md
@@ -15,5 +15,9 @@ Sqruff currently supports the following SQL dialects:
 {% if dialect.doc_url %}
 **Documentation:** [{{ dialect.doc_url }}]({{ dialect.doc_url }})
 {% endif %}
+**Configuration:**
+```ini
+{{ dialect.config_section }}
+```
 {% endfor %}
 We are working on adding support for more dialects in the future.

--- a/crates/lib-core/src/lib.rs
+++ b/crates/lib-core/src/lib.rs
@@ -8,3 +8,4 @@ pub mod segments;
 pub mod slice_helpers;
 pub mod templaters;
 pub mod utils;
+pub mod value;

--- a/crates/lib-core/src/value.rs
+++ b/crates/lib-core/src/value.rs
@@ -1,0 +1,136 @@
+use std::ops::Index;
+use std::str::FromStr;
+
+use ahash::AHashMap;
+use itertools::Itertools;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+pub enum Value {
+    Int(i32),
+    Bool(bool),
+    Float(f64),
+    String(Box<str>),
+    Map(AHashMap<String, Value>),
+    Array(Vec<Value>),
+    #[default]
+    None,
+}
+
+impl Value {
+    pub fn is_none(&self) -> bool {
+        matches!(self, Value::None)
+    }
+
+    pub fn as_array(&self) -> Option<Vec<Value>> {
+        match self {
+            Self::Array(v) => Some(v.clone()),
+            Self::String(q) => {
+                let xs = q
+                    .split(',')
+                    .map(|it| Value::String(it.into()))
+                    .collect_vec();
+                Some(xs)
+            }
+            Self::Bool(b) => Some(vec![Value::String(b.to_string().into())]),
+            _ => None,
+        }
+    }
+}
+
+impl Index<&str> for Value {
+    type Output = Value;
+
+    fn index(&self, index: &str) -> &Self::Output {
+        match self {
+            Value::Map(map) => map.get(index).unwrap_or(&Value::None),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Value {
+    pub fn to_bool(&self) -> bool {
+        match *self {
+            Value::Int(v) => v != 0,
+            Value::Bool(v) => v,
+            Value::Float(v) => v != 0.0,
+            Value::String(ref v) => !v.is_empty(),
+            Value::Map(ref v) => !v.is_empty(),
+            Value::None => false,
+            Value::Array(ref v) => !v.is_empty(),
+        }
+    }
+
+    pub fn map<T>(&self, f: impl Fn(&Self) -> T) -> Option<T> {
+        if self == &Value::None {
+            return None;
+        }
+
+        Some(f(self))
+    }
+
+    pub fn as_map(&self) -> Option<&AHashMap<String, Value>> {
+        if let Self::Map(map) = self {
+            Some(map)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_map_mut(&mut self) -> Option<&mut AHashMap<String, Value>> {
+        if let Self::Map(map) = self {
+            Some(map)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_int(&self) -> Option<i32> {
+        if let Self::Int(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_string(&self) -> Option<&str> {
+        if let Self::String(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        if let Self::Bool(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+}
+
+impl FromStr for Value {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(value) = s.parse() {
+            return Ok(Value::Int(value));
+        }
+
+        if let Ok(value) = s.parse() {
+            return Ok(Value::Float(value));
+        }
+
+        let value = match () {
+            _ if s.eq_ignore_ascii_case("true") => Value::Bool(true),
+            _ if s.eq_ignore_ascii_case("false") => Value::Bool(false),
+            _ if s.eq_ignore_ascii_case("none") => Value::None,
+            _ => Value::String(Box::from(s)),
+        };
+
+        Ok(value)
+    }
+}

--- a/crates/lib-dialects/src/ansi.rs
+++ b/crates/lib-dialects/src/ansi.rs
@@ -18,8 +18,19 @@ use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::parser::types::ParseMode;
 
 use super::ansi_keywords::{ANSI_RESERVED_KEYWORDS, ANSI_UNRESERVED_KEYWORDS};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the ANSI dialect.
+/// Currently empty but can be extended with dialect-specific options.
+pub type AnsiDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: AnsiDialectConfig = config
+        .map(AnsiDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|this| this.expand())
 }
 

--- a/crates/lib-dialects/src/athena.rs
+++ b/crates/lib-dialects/src/athena.rs
@@ -4,6 +4,7 @@
 use itertools::Itertools;
 use sqruff_lib_core::dialects::Dialect;
 use sqruff_lib_core::dialects::init::DialectKind;
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
 use sqruff_lib_core::dialects::syntax::SyntaxKind;
 use sqruff_lib_core::helpers::{Config, ToMatchable};
 use sqruff_lib_core::parser::grammar::anyof::{AnyNumberOf, one_of, optionally_bracketed};
@@ -16,9 +17,18 @@ use sqruff_lib_core::parser::node_matcher::NodeMatcher;
 use sqruff_lib_core::parser::parsers::{RegexParser, StringParser, TypedParser};
 use sqruff_lib_core::parser::segments::generator::SegmentGenerator;
 use sqruff_lib_core::parser::segments::meta::MetaSegment;
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
-    let ansi_dialect = super::ansi::dialect();
+/// Configuration for the Athena dialect.
+pub type AthenaDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: AthenaDialectConfig = config
+        .map(AthenaDialectConfig::from_value)
+        .unwrap_or_default();
+
+    let ansi_dialect = super::ansi::dialect(None);
     let mut dialect = super::ansi::raw_dialect();
     dialect.name = DialectKind::Athena;
 

--- a/crates/lib-dialects/src/bigquery.rs
+++ b/crates/lib-dialects/src/bigquery.rs
@@ -17,8 +17,17 @@ use sqruff_lib_core::parser::types::ParseMode;
 
 use super::ansi::{self, raw_dialect};
 use super::bigquery_keywords::{BIGQUERY_RESERVED_KEYWORDS, BIGQUERY_UNRESERVED_KEYWORDS};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the BigQuery dialect.
+pub type BigQueryDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: BigQueryDialectConfig = config
+        .map(BigQueryDialectConfig::from_value)
+        .unwrap_or_default();
     let mut dialect = raw_dialect();
     dialect.name = DialectKind::Bigquery;
 

--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -19,8 +19,17 @@ use sqruff_lib_core::parser::types::ParseMode;
 
 use super::ansi::{self, raw_dialect};
 use crate::clickhouse_keywords::UNRESERVED_KEYWORDS;
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the ClickHouse dialect.
+pub type ClickHouseDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: ClickHouseDialectConfig = config
+        .map(ClickHouseDialectConfig::from_value)
+        .unwrap_or_default();
     let ansi_dialect = raw_dialect();
 
     let mut clickhouse_dialect = raw_dialect();

--- a/crates/lib-dialects/src/duckdb.rs
+++ b/crates/lib-dialects/src/duckdb.rs
@@ -12,14 +12,24 @@ use sqruff_lib_core::parser::parsers::StringParser;
 use sqruff_lib_core::parser::segments::meta::MetaSegment;
 
 use crate::{ansi, postgres};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the DuckDB dialect.
+pub type DuckDBDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: DuckDBDialectConfig = config
+        .map(DuckDBDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|dialect| dialect.expand())
 }
 
 pub fn raw_dialect() -> Dialect {
     let ansi_dialect = ansi::raw_dialect();
-    let postgres_dialect = postgres::dialect();
+    let postgres_dialect = postgres::dialect(None);
     let mut duckdb_dialect = postgres_dialect;
     duckdb_dialect.name = DialectKind::Duckdb;
 

--- a/crates/lib-dialects/src/hive.rs
+++ b/crates/lib-dialects/src/hive.rs
@@ -8,7 +8,7 @@ use sqruff_lib_core::parser::grammar::sequence::{Bracketed, Sequence};
 use sqruff_lib_core::parser::node_matcher::NodeMatcher;
 
 pub fn raw_dialect() -> Dialect {
-    let mut hive_dialect = super::ansi::dialect();
+    let mut hive_dialect = super::ansi::dialect(None);
 
     hive_dialect.add([
         (

--- a/crates/lib-dialects/src/lib.rs
+++ b/crates/lib-dialects/src/lib.rs
@@ -1,5 +1,6 @@
 use sqruff_lib_core::dialects::Dialect;
 use sqruff_lib_core::dialects::init::DialectKind;
+use sqruff_lib_core::value::Value;
 
 pub mod ansi;
 mod ansi_keywords;
@@ -54,36 +55,36 @@ pub mod tsql;
 #[cfg(feature = "tsql")]
 mod tsql_keywords;
 
-pub fn kind_to_dialect(kind: &DialectKind) -> Option<Dialect> {
+pub fn kind_to_dialect(kind: &DialectKind, config: Option<&Value>) -> Option<Dialect> {
     #[allow(unreachable_patterns)]
     Some(match kind {
-        DialectKind::Ansi => ansi::dialect(),
+        DialectKind::Ansi => ansi::dialect(config),
         #[cfg(feature = "athena")]
-        DialectKind::Athena => athena::dialect(),
+        DialectKind::Athena => athena::dialect(config),
         #[cfg(feature = "bigquery")]
-        DialectKind::Bigquery => bigquery::dialect(),
+        DialectKind::Bigquery => bigquery::dialect(config),
         #[cfg(feature = "clickhouse")]
-        DialectKind::Clickhouse => clickhouse::dialect(),
+        DialectKind::Clickhouse => clickhouse::dialect(config),
         #[cfg(feature = "databricks")]
-        DialectKind::Databricks => databricks::dialect(),
+        DialectKind::Databricks => databricks::dialect(config),
         #[cfg(feature = "duckdb")]
-        DialectKind::Duckdb => duckdb::dialect(),
+        DialectKind::Duckdb => duckdb::dialect(config),
         #[cfg(feature = "mysql")]
-        DialectKind::Mysql => mysql::dialect(),
+        DialectKind::Mysql => mysql::dialect(config),
         #[cfg(feature = "postgres")]
-        DialectKind::Postgres => postgres::dialect(),
+        DialectKind::Postgres => postgres::dialect(config),
         #[cfg(feature = "redshift")]
-        DialectKind::Redshift => redshift::dialect(),
+        DialectKind::Redshift => redshift::dialect(config),
         #[cfg(feature = "snowflake")]
-        DialectKind::Snowflake => snowflake::dialect(),
+        DialectKind::Snowflake => snowflake::dialect(config),
         #[cfg(feature = "sparksql")]
-        DialectKind::Sparksql => sparksql::dialect(),
+        DialectKind::Sparksql => sparksql::dialect(config),
         #[cfg(feature = "sqlite")]
-        DialectKind::Sqlite => sqlite::dialect(),
+        DialectKind::Sqlite => sqlite::dialect(config),
         #[cfg(feature = "trino")]
-        DialectKind::Trino => trino::dialect(),
+        DialectKind::Trino => trino::dialect(config),
         #[cfg(feature = "tsql")]
-        DialectKind::Tsql => tsql::dialect(),
+        DialectKind::Tsql => tsql::dialect(config),
         _ => return None,
     })
 }

--- a/crates/lib-dialects/src/mysql.rs
+++ b/crates/lib-dialects/src/mysql.rs
@@ -8,8 +8,18 @@ use sqruff_lib_core::parser::lexer::Matcher;
 use sqruff_lib_core::parser::node_matcher::NodeMatcher;
 
 use super::ansi;
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the MySQL dialect.
+pub type MySQLDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: MySQLDialectConfig = config
+        .map(MySQLDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|dialect| dialect.expand())
 }
 

--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -20,8 +20,18 @@ use sqruff_lib_core::parser::types::ParseMode;
 use super::ansi;
 use super::postgres_keywords::POSTGRES_POSTGIS_DATATYPE_KEYWORDS;
 use crate::postgres_keywords::{get_keywords, postgres_keywords};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the PostgreSQL dialect.
+pub type PostgresDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: PostgresDialectConfig = config
+        .map(PostgresDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|dialect| dialect.expand())
 }
 

--- a/crates/lib-dialects/src/redshift.rs
+++ b/crates/lib-dialects/src/redshift.rs
@@ -18,8 +18,18 @@ use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::parser::types::ParseMode;
 
 use crate::redshift_keywords::{REDSHIFT_RESERVED_KEYWORDS, REDSHIFT_UNRESERVED_KEYWORDS};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the Redshift dialect.
+pub type RedshiftDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: RedshiftDialectConfig = config
+        .map(RedshiftDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|this| this.expand())
 }
 

--- a/crates/lib-dialects/src/snowflake.rs
+++ b/crates/lib-dialects/src/snowflake.rs
@@ -20,8 +20,17 @@ use sqruff_lib_core::parser::types::ParseMode;
 
 use super::ansi::{self, raw_dialect};
 use super::snowflake_keywords::{SNOWFLAKE_RESERVED_KEYWORDS, SNOWFLAKE_UNRESERVED_KEYWORDS};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the Snowflake dialect.
+pub type SnowflakeDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: SnowflakeDialectConfig = config
+        .map(SnowflakeDialectConfig::from_value)
+        .unwrap_or_default();
     let mut snowflake_dialect = raw_dialect();
     snowflake_dialect.name = DialectKind::Snowflake;
 

--- a/crates/lib-dialects/src/sparksql.rs
+++ b/crates/lib-dialects/src/sparksql.rs
@@ -4458,6 +4458,17 @@ pub fn raw_dialect() -> Dialect {
     sparksql_dialect
 }
 
-pub fn dialect() -> Dialect {
-    raw_dialect().config(|config| config.expand())
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
+
+/// Configuration for the SparkSQL dialect.
+pub type SparkSQLDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: SparkSQLDialectConfig = config
+        .map(SparkSQLDialectConfig::from_value)
+        .unwrap_or_default();
+
+    raw_dialect().config(|c| c.expand())
 }

--- a/crates/lib-dialects/src/sqlite.rs
+++ b/crates/lib-dialects/src/sqlite.rs
@@ -14,8 +14,18 @@ use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::parser::types::ParseMode;
 
 use crate::sqlite_keywords::{RESERVED_KEYWORDS, UNRESERVED_KEYWORDS};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the SQLite dialect.
+pub type SQLiteDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: SQLiteDialectConfig = config
+        .map(SQLiteDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|dialect| dialect.expand())
 }
 

--- a/crates/lib-dialects/src/trino.rs
+++ b/crates/lib-dialects/src/trino.rs
@@ -1,5 +1,6 @@
 use sqruff_lib_core::dialects::Dialect;
 use sqruff_lib_core::dialects::init::DialectKind;
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
 use sqruff_lib_core::dialects::syntax::SyntaxKind;
 use sqruff_lib_core::helpers::{Config, ToMatchable};
 use sqruff_lib_core::parser::grammar::anyof::{AnyNumberOf, one_of, optionally_bracketed};
@@ -11,8 +12,16 @@ use sqruff_lib_core::parser::matchable::MatchableTrait;
 use sqruff_lib_core::parser::node_matcher::NodeMatcher;
 use sqruff_lib_core::parser::parsers::{StringParser, TypedParser};
 use sqruff_lib_core::parser::segments::meta::MetaSegment;
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the Trino dialect.
+pub type TrinoDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: TrinoDialectConfig = config
+        .map(TrinoDialectConfig::from_value)
+        .unwrap_or_default();
     let ansi_dialect = super::ansi::raw_dialect();
     let mut trino_dialect = ansi_dialect;
     trino_dialect.name = DialectKind::Trino;

--- a/crates/lib-dialects/src/tsql.rs
+++ b/crates/lib-dialects/src/tsql.rs
@@ -19,8 +19,18 @@ use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::parser::types::ParseMode;
 
 use crate::{ansi, tsql_keywords};
+use sqruff_lib_core::dialects::init::{DialectConfig, NullDialectConfig};
+use sqruff_lib_core::value::Value;
 
-pub fn dialect() -> Dialect {
+/// Configuration for the T-SQL dialect.
+pub type TSQLDialectConfig = NullDialectConfig;
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    // Parse and validate dialect configuration, falling back to defaults on failure
+    let _dialect_config: TSQLDialectConfig = config
+        .map(TSQLDialectConfig::from_value)
+        .unwrap_or_default();
+
     raw_dialect().config(|dialect| dialect.expand())
 }
 

--- a/crates/lib-dialects/tests/dialects.rs
+++ b/crates/lib-dialects/tests/dialects.rs
@@ -71,7 +71,7 @@ fn main() {
     // Go through each of the dialects and check if the files are present
     for dialect_name in &dialects {
         let dialect_kind = DialectKind::from_str(dialect_name).unwrap();
-        let Some(dialect) = kind_to_dialect(&dialect_kind) else {
+        let Some(dialect) = kind_to_dialect(&dialect_kind, None) else {
             println!("{dialect_name} disabled");
             continue;
         };

--- a/crates/lib/src/core/test_functions.rs
+++ b/crates/lib/src/core/test_functions.rs
@@ -16,5 +16,5 @@ pub fn parse_ansi_string(sql: &str) -> ErasedSegment {
 }
 
 pub fn fresh_ansi_dialect() -> Dialect {
-    kind_to_dialect(&DialectKind::Ansi).unwrap()
+    kind_to_dialect(&DialectKind::Ansi, None).unwrap()
 }

--- a/crates/lineage/src/lib.rs
+++ b/crates/lineage/src/lib.rs
@@ -73,7 +73,7 @@ impl<'config> Lineage<'config> {
 
 fn parse_sql(parser: &Parser, source: &str) -> ErasedSegment {
     let tables = sqruff_lib_core::parser::segments::Tables::default();
-    let ansi = sqruff_lib_dialects::ansi::dialect();
+    let ansi = sqruff_lib_dialects::ansi::dialect(None);
     let lexer = ansi.lexer();
 
     let (tokens, _) = lexer.lex(&tables, source);
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_lineage() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(parser, "a", "SELECT a FROM z")
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_lineage_sql_with_cte() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) =
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn test_lineage_source_with_cte() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(parser, "a", "SELECT a FROM z")
@@ -492,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_lineage_source_with_star() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) =
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_lineage_external_col() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -530,7 +530,7 @@ mod tests {
 
     #[test]
     fn test_lineage_values() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(parser, "a", "SELECT a FROM y")
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn test_lineage_union() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -593,7 +593,7 @@ mod tests {
     #[test]
     #[ignore = "TODO"]
     fn test_lineage_lateral_flatten() {
-        let dialect = sqruff_lib_dialects::snowflake::dialect();
+        let dialect = sqruff_lib_dialects::snowflake::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn test_subquery() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -650,7 +650,7 @@ mod tests {
 
     #[test]
     fn test_lineage_cte_union() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -692,7 +692,7 @@ mod tests {
 
     #[test]
     fn test_lineage_source_union() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(parser, "x", "SELECT x, created_at FROM dataset;")
@@ -732,7 +732,7 @@ mod tests {
 
     #[test]
     fn test_select_star() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) =
@@ -755,7 +755,7 @@ mod tests {
 
     #[test]
     fn test_unnest() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -773,7 +773,7 @@ mod tests {
     #[test]
     #[ignore = "TODO:"]
     fn test_lineage_normalize() {
-        let dialect = sqruff_lib_dialects::snowflake::dialect();
+        let dialect = sqruff_lib_dialects::snowflake::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -796,7 +796,7 @@ mod tests {
 
     #[test]
     fn test_trim() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_node_name_doesnt_contain_comment() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(
@@ -844,7 +844,7 @@ mod tests {
 
     #[test]
     fn test_lineage_downstream_id_in_join() {
-        let dialect = sqruff_lib_dialects::ansi::dialect();
+        let dialect = sqruff_lib_dialects::ansi::dialect(None);
         let parser = Parser::new(&dialect, Default::default());
 
         let (tables, node) = Lineage::new(

--- a/crates/sqlinference/src/columns.rs
+++ b/crates/sqlinference/src/columns.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_get_columns_internal() {
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         let (cols, unnamed) = get_columns_internal(
@@ -85,7 +85,7 @@ ORDER BY a DESC, b",
 
     #[test]
     fn test_sub_query() {
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         let (cols, unnamed) = get_columns_internal(

--- a/crates/sqlinference/src/infer_tests.rs
+++ b/crates/sqlinference/src/infer_tests.rs
@@ -1450,7 +1450,7 @@ mod tests {
             },
         ];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -1570,7 +1570,7 @@ mod tests {
             },
         ];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -2171,7 +2171,7 @@ FROM q.stg_employees e) SELECT * FROM data",
             },
         ];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -2350,7 +2350,7 @@ GROUP BY department",
             ]),
         }];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -2445,7 +2445,7 @@ LEFT JOIN q.shift_last sl
             ]),
         }];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -2489,7 +2489,7 @@ LEFT JOIN q.shift_last sl
             ),
         ];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for (sql, want) in tests {
@@ -2667,7 +2667,7 @@ from final",
             ),
         ];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for (sql, expected_map_entries, expected_not_parseable, expected_count) in tests {

--- a/crates/sqlinference/src/inference.rs
+++ b/crates/sqlinference/src/inference.rs
@@ -159,7 +159,7 @@ mod tests {
             ]),
         }];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -228,7 +228,7 @@ mod tests {
             },
         ];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {
@@ -297,7 +297,7 @@ mod tests {
             ]),
         }];
 
-        let dialect = ansi::dialect();
+        let dialect = ansi::dialect(None);
         let parser = Parser::from(&dialect);
 
         for test in tests {

--- a/docs/reference/dialects.md
+++ b/docs/reference/dialects.md
@@ -25,6 +25,10 @@ Sqruff currently supports the following SQL dialects:
 
 Standard SQL syntax. The default dialect and base for all others.
 
+**Configuration:**
+```ini
+[sqruff:dialect:ansi]
+```
 
 ### athena
 
@@ -32,6 +36,10 @@ Amazon Athena SQL dialect for querying data in S3.
 
 **Documentation:** [https://docs.aws.amazon.com/athena/latest/ug/ddl-sql-reference.html](https://docs.aws.amazon.com/athena/latest/ug/ddl-sql-reference.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:athena]
+```
 
 ### bigquery
 
@@ -39,6 +47,10 @@ Google BigQuery SQL dialect for analytics and data warehousing.
 
 **Documentation:** [https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax)
 
+**Configuration:**
+```ini
+[sqruff:dialect:bigquery]
+```
 
 ### clickhouse
 
@@ -46,6 +58,10 @@ ClickHouse SQL dialect for real-time analytics.
 
 **Documentation:** [https://clickhouse.com/docs/en/sql-reference/](https://clickhouse.com/docs/en/sql-reference/)
 
+**Configuration:**
+```ini
+[sqruff:dialect:clickhouse]
+```
 
 ### databricks
 
@@ -53,6 +69,10 @@ Databricks SQL dialect for lakehouse analytics.
 
 **Documentation:** [https://docs.databricks.com/en/sql/language-manual/index.html](https://docs.databricks.com/en/sql/language-manual/index.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:databricks]
+```
 
 ### duckdb
 
@@ -60,6 +80,10 @@ DuckDB SQL dialect for in-process analytical database.
 
 **Documentation:** [https://duckdb.org/docs/sql/introduction](https://duckdb.org/docs/sql/introduction)
 
+**Configuration:**
+```ini
+[sqruff:dialect:duckdb]
+```
 
 ### mysql
 
@@ -67,6 +91,10 @@ MySQL SQL dialect for the popular open-source database.
 
 **Documentation:** [https://dev.mysql.com/doc/](https://dev.mysql.com/doc/)
 
+**Configuration:**
+```ini
+[sqruff:dialect:mysql]
+```
 
 ### postgres
 
@@ -74,6 +102,10 @@ PostgreSQL SQL dialect for the advanced open-source database.
 
 **Documentation:** [https://www.postgresql.org/docs/current/sql.html](https://www.postgresql.org/docs/current/sql.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:postgres]
+```
 
 ### redshift
 
@@ -81,6 +113,10 @@ Amazon Redshift SQL dialect for cloud data warehousing.
 
 **Documentation:** [https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_SQLCommandRef.html](https://docs.aws.amazon.com/redshift/latest/dg/cm_chap_SQLCommandRef.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:redshift]
+```
 
 ### snowflake
 
@@ -88,6 +124,10 @@ Snowflake SQL dialect for cloud data platform.
 
 **Documentation:** [https://docs.snowflake.com/en/sql-reference.html](https://docs.snowflake.com/en/sql-reference.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:snowflake]
+```
 
 ### sparksql
 
@@ -95,6 +135,10 @@ Apache Spark SQL dialect for big data processing.
 
 **Documentation:** [https://spark.apache.org/sql/](https://spark.apache.org/sql/)
 
+**Configuration:**
+```ini
+[sqruff:dialect:sparksql]
+```
 
 ### sqlite
 
@@ -102,6 +146,10 @@ SQLite SQL dialect for embedded database.
 
 **Documentation:** [https://www.sqlite.org/lang.html](https://www.sqlite.org/lang.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:sqlite]
+```
 
 ### trino
 
@@ -109,6 +157,10 @@ Trino (formerly PrestoSQL) dialect for distributed SQL queries.
 
 **Documentation:** [https://trino.io/docs/current/sql.html](https://trino.io/docs/current/sql.html)
 
+**Configuration:**
+```ini
+[sqruff:dialect:trino]
+```
 
 ### tsql
 
@@ -116,5 +168,9 @@ T-SQL dialect for Microsoft SQL Server and Azure SQL.
 
 **Documentation:** [https://learn.microsoft.com/en-us/sql/t-sql/language-reference](https://learn.microsoft.com/en-us/sql/t-sql/language-reference)
 
+**Configuration:**
+```ini
+[sqruff:dialect:tsql]
+```
 
 We are working on adding support for more dialects in the future.


### PR DESCRIPTION
## Summary

- Move `Value` type from lib to lib-core for shared use across crates
- Add `DialectConfig` trait and `NullDialectConfig` for dialect-specific configuration
- Update `kind_to_dialect` to accept optional config parameter
- Each dialect validates its config using `DialectConfig::from_value()`, falling back to defaults on failure
- Config is read from dialect-specific section in config file (e.g., `[sqruff:snowflake]`)

This enables dialects to receive configuration from the config file's dialect-specific section, parsed and validated on dialect creation. Currently all dialects use `NullDialectConfig` (no options), but the infrastructure is now in place to add dialect-specific settings.

## Test plan

- [x] `cargo build` succeeds
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)