### PR TITLE
chore(ci): consolidate WASM build into bazel-lint job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,18 +28,6 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # ratchet:Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # ratchet:dtolnay/rust-toolchain@stable
       - run: cargo build --locked --release --all-features
-  compile-wasm:
-    name: Compile wasm32-unknown-unknown
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
-      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # ratchet:bazel-contrib/setup-bazel@0.18.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
-          repository-cache: true
-      - name: Build WASM
-        run: bazelisk build --config=ci //crates/lib-wasm:sqruff-wasm-bindgen
   test-cargo:
     name: Cargo test
     runs-on: ubuntu-latest
@@ -101,7 +89,9 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-      - name: Run lint checks
+      - name: Build all targets
+        run: bazelisk build --config=ci //...
+      - name: Run all tests
         run: bazelisk test --config=ci //...
   bazel-lockfile:
     name: Bazel Lockfile Check


### PR DESCRIPTION
## Summary
- Remove the separate `compile-wasm` job from PR checks
- Add `bazel build //...` step to the `bazel-lint` job before running tests
- This ensures all targets (including WASM) are built while reducing CI job count

## Test plan
- [ ] Verify the bazel-lint job builds all targets including `//crates/lib-wasm:sqruff-wasm-bindgen`
- [ ] Verify all bazel tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)