### PR TITLE
fix(RF01): support parenthesized joined tables in FROM clause

### DIFF
--- a/crates/lib-core/src/parser/segments/join.rs
+++ b/crates/lib-core/src/parser/segments/join.rs
@@ -16,7 +16,7 @@ impl JoinClauseSegment {
             .children(const { &SyntaxSet::new(&[SyntaxKind::Keyword]) })
             .any(|kw| kw.raw().to_uppercase() == "APPLY");
 
-        let from_expression = if is_apply {
+        let from_expression_element = if is_apply {
             // For APPLY clauses, find the FromExpressionElement in the sequence
             self.0
                 .children(const { &SyntaxSet::new(&[SyntaxKind::FromExpressionElement]) })
@@ -28,9 +28,27 @@ impl JoinClauseSegment {
                 .child(const { &SyntaxSet::new(&[SyntaxKind::FromExpressionElement]) })
         };
 
-        if let Some(from_expr) = from_expression {
+        if let Some(from_expr) = from_expression_element {
             let alias = FromExpressionElementSegment(from_expr.clone()).eventual_alias();
             buff.push((from_expr.clone(), alias));
+        }
+
+        // Handle parenthesized joined tables: JOIN (table1 JOIN table2 ON ...)
+        // In this case, the join clause contains a Bracketed segment with a FromExpression
+        // that has its own FromExpressionElement and JoinClause children
+        if let Some(bracketed) = self
+            .0
+            .child(const { &SyntaxSet::new(&[SyntaxKind::Bracketed]) })
+            && let Some(from_expression) =
+                bracketed.child(const { &SyntaxSet::new(&[SyntaxKind::FromExpression]) })
+        {
+            // Get the direct table from the FromExpression
+            for from_expr_elem in from_expression
+                .children(const { &SyntaxSet::new(&[SyntaxKind::FromExpressionElement]) })
+            {
+                let alias = FromExpressionElementSegment(from_expr_elem.clone()).eventual_alias();
+                buff.push((from_expr_elem.clone(), alias));
+            }
         }
 
         for join_clause in self.0.recursive_crawl(

--- a/crates/lib-dialects/src/ansi.rs
+++ b/crates/lib-dialects/src/ansi.rs
@@ -1065,6 +1065,18 @@ pub fn raw_dialect() -> Dialect {
             "NestedJoinGrammar".into(),
             Nothing::new().to_matchable().into(),
         ),
+        // Grammar for join targets - either a simple table expression or a
+        // bracketed join expression (for parenthesized joined tables)
+        (
+            "JoinTargetGrammar".into(),
+            one_of(vec![
+                Ref::new("FromExpressionElementSegment").to_matchable(),
+                Bracketed::new(vec![Ref::new("FromExpressionSegment").to_matchable()])
+                    .to_matchable(),
+            ])
+            .to_matchable()
+            .into(),
+        ),
         (
             "ReferentialActionGrammar".into(),
             one_of(vec![
@@ -2344,7 +2356,7 @@ pub fn raw_dialect() -> Dialect {
                             .to_matchable(),
                         Ref::new("JoinKeywordsGrammar").to_matchable(),
                         MetaSegment::indent().to_matchable(),
-                        Ref::new("FromExpressionElementSegment").to_matchable(),
+                        Ref::new("JoinTargetGrammar").to_matchable(),
                         AnyNumberOf::new(vec![Ref::new("NestedJoinGrammar").to_matchable()])
                             .to_matchable(),
                         MetaSegment::dedent().to_matchable(),
@@ -2382,14 +2394,14 @@ pub fn raw_dialect() -> Dialect {
                         Ref::new("NaturalJoinKeywordsGrammar").to_matchable(),
                         Ref::new("JoinKeywordsGrammar").to_matchable(),
                         MetaSegment::indent().to_matchable(),
-                        Ref::new("FromExpressionElementSegment").to_matchable(),
+                        Ref::new("JoinTargetGrammar").to_matchable(),
                         MetaSegment::dedent().to_matchable(),
                     ])
                     .to_matchable(),
                     Sequence::new(vec![
                         Ref::new("ExtendedNaturalJoinKeywordsGrammar").to_matchable(),
                         MetaSegment::indent().to_matchable(),
-                        Ref::new("FromExpressionElementSegment").to_matchable(),
+                        Ref::new("JoinTargetGrammar").to_matchable(),
                         MetaSegment::dedent().to_matchable(),
                     ])
                     .to_matchable(),

--- a/crates/lib-dialects/src/tsql.rs
+++ b/crates/lib-dialects/src/tsql.rs
@@ -1615,7 +1615,7 @@ pub fn raw_dialect() -> Dialect {
                     .to_matchable(),
                 Ref::new("JoinKeywordsGrammar").to_matchable(),
                 MetaSegment::indent().to_matchable(),
-                Ref::new("FromExpressionElementSegment").to_matchable(),
+                Ref::new("JoinTargetGrammar").to_matchable(),
                 AnyNumberOf::new(vec![Ref::new("NestedJoinGrammar").to_matchable()]).to_matchable(),
                 MetaSegment::dedent().to_matchable(),
                 Sequence::new(vec![

--- a/crates/lib/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -251,8 +251,6 @@ test_nested_join_clauses_do_not_flag:
       dialect: tsql
 
 test_parenthesized_join_clauses_do_not_flag:
-  # TODO: Fix T-SQL parenthesized JOIN parsing causing panic in join.rs
-  ignored: "T-SQL parenthesized JOIN syntax causes panic in parser"
   pass_str: |
     SELECT
         1 AS RegionCode
@@ -361,3 +359,25 @@ test_fail_trino_row_field_access_aliased_source:
   configs:
     core:
       dialect: trino
+test_pass_postgres_parenthesized_join:
+  # https://github.com/quarylabs/sqruff/issues/1573
+  pass_str: |
+    SELECT
+      c.short_name || ': ' || c.title || ', ' || ci.long_name AS label,
+      c.short_name || ', ' || ci.long_name AS short_label,
+      ci.id AS course_instance_id,
+      (e.id IS NOT NULL) AS enrolled,
+      users_is_instructor_in_course (u.user_id, c.id) AS instructor_access
+    FROM
+      users AS u
+      CROSS JOIN (
+        course_instances AS ci
+        JOIN pl_courses AS c ON (c.id = ci.course_id)
+      )
+      LEFT JOIN enrollments AS e ON (
+        e.user_id = u.user_id
+        AND e.course_instance_id = ci.id
+      )
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
## Summary

Fixes #1573

This PR adds support for parsing and analyzing parenthesized joined tables in FROM clauses, such as:

```sql
SELECT c.id, ci.id
FROM users AS u
CROSS JOIN (
    course_instances AS ci
    JOIN pl_courses AS c ON c.id = ci.course_id
)
LEFT JOIN enrollments AS e ON e.user_id = u.user_id
```

Previously, sqruff would fail to parse the parenthesized join expression and the RF01 rule would incorrectly report that table aliases like `c` and `ci` were not found in the FROM clause.

## Changes

- Add `JoinTargetGrammar` in ANSI dialect that allows either:
  - `FromExpressionElementSegment` (simple table)
  - `Bracketed(FromExpressionSegment)` (parenthesized joined tables)
- Update `JoinClauseSegment` to use `JoinTargetGrammar` instead of `FromExpressionElementSegment`
- Update `JoinClauseSegment::eventual_aliases()` to extract table aliases from bracketed `FromExpression` segments
- Add test case for the reported issue

## Test plan

- [x] Verified the SQL from the issue now parses correctly
- [x] Verified RF01 no longer reports false positives for table aliases inside parenthesized joins
- [x] Ran `cargo clippy` and `cargo fmt`
- [x] Existing dialect tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)