### PR TITLE
test(CV03): add test for unquoted multibyte identifiers

### DIFF
--- a/crates/lib/test/fixtures/rules/std_rule_cases/CV03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CV03.yml
@@ -31,6 +31,20 @@ test_forbid_fail:
       convention.select_trailing_comma:
         select_clause_trailing_comma: forbid
 
+# Test that unquoted multibyte identifiers don't cause panics
+# https://github.com/quarylabs/sqruff/issues/2067
+test_pass_unquoted_multibyte_identifier:
+  pass_str: |
+    SELECT
+        日本語
+    FROM foo
+  configs:
+    core:
+      dialect: duckdb
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: forbid
+
 #test_fail_templated:
 #  # NOTE: Check no fix, because it's not safe.
 #  fail_str: |


### PR DESCRIPTION
## Summary

Fixes #2067

Adds a regression test for the issue where unquoted multibyte identifiers (e.g., `日本語`) would cause a panic in the CV03 rule:

```
thread 'main' panicked at crates/lib/src/rules/convention/cv03.rs:85:14:
called `Option::unwrap()` on a `None` value
```

The underlying issue was fixed in previous refactoring (the code now properly handles identifiers without position markers), but there was no test coverage to prevent regression.

## Test plan

- [x] Added test case `test_pass_unquoted_multibyte_identifier` with DuckDB dialect
- [x] Verified the test passes locally

🤖 Generated with [Claude Code](https://claude.ai/code)