### PR TITLE
chore(bazel): exclude _wasm from prettier_srcs glob

### DIFF
--- a/editors/code/BUILD.bazel
+++ b/editors/code/BUILD.bazel
@@ -31,6 +31,7 @@ js_library(
         "dist/**",
         "out/**",
         ".vscode-test/**",
+        "_wasm/**",
     ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Summary
- Exclude `_wasm/**` from the `prettier_srcs` glob pattern to fix Bazel build conflict
- The glob was including files from `_wasm/` which conflicts with the `wasm_pkg` target that outputs to the `_wasm/` directory
- Bazel doesn't allow one output path to be a prefix of another

## Test plan
- [x] Verified `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)