### PR TITLE
docs: fix missing code fence in LT05 rule documentation

### DIFF
--- a/crates/lib/src/rules/layout/lt05.rs
+++ b/crates/lib/src/rules/layout/lt05.rs
@@ -60,7 +60,8 @@ SELECT
         as my_other_relatively_long_alias,
     my_expression_function(col6, col7 + col8, arg4)
     = col9 + col10 as another_relatively_long_alias
-FROM my_table"#
+FROM my_table
+```"#
     }
 
     fn groups(&self) -> &'static [RuleGroups] {

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -1479,6 +1479,7 @@ SELECT
     my_expression_function(col6, col7 + col8, arg4)
     = col9 + col10 as another_relatively_long_alias
 FROM my_table
+```
 
 ### layout.functions
 


### PR DESCRIPTION
## Summary
- Fixed missing closing code fence (```) in the LT05 (layout.long_lines) rule's "Best practice" section
- The SQL code block was not properly closed, causing markdown rendering issues in `docs/reference/rules.md`

## Test plan
- [x] Verified the regenerated `docs/reference/rules.md` now renders correctly
- [x] The next section (`### layout.functions`) is now properly separated

🤖 Generated with [Claude Code](https://claude.com/claude-code)