### PR TITLE
chore: move cargo_check to bazel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,14 +12,6 @@ env:
   RUST_BACKTRACE: short
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
 jobs:
-  check:
-    name: Rust Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v5
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # ratchet:Swatinem/rust-cache@v2
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # ratchet:dtolnay/rust-toolchain@stable
-      - run: cargo check --all --all-features --tests --benches
   compile:
     name: Compile
     runs-on: ubuntu-latest

--- a/.hacking/scripts/cargo_check.sh
+++ b/.hacking/scripts/cargo_check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Run cargo check with all features, tests, and benches.
+# This replicates the "Rust Check" GitHub action job.
+set -eo pipefail
+
+cd "$RUNFILES_DIR/_main"
+CARGO_BIN="$RUNFILES_DIR/$CARGO"
+
+# Create a temp bin directory with cargo symlink
+BINDIR=$(mktemp -d)
+ln -s "$CARGO_BIN" "$BINDIR/cargo"
+export PATH="$BINDIR:$PATH"
+
+# Run cargo check with all features, tests, and benches
+cargo check --all --all-features --tests --benches --locked

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -229,6 +229,34 @@ sh_test(
     },
 )
 
+# Cargo check - type-check all crates with all features, tests, and benches
+# This replicates the "Rust Check" GitHub action job
+# Note: Runs without sandbox to allow cargo to access ~/.cargo cache
+sh_test(
+    name = "cargo_check",
+    size = "large",
+    srcs = [".hacking/scripts/cargo_check.sh"],
+    data = [
+        "Cargo.lock",
+        "Cargo.toml",
+        "//crates/cli:machete_srcs",
+        "//crates/cli-lib:machete_srcs",
+        "//crates/cli-python:machete_srcs",
+        "//crates/lib:machete_srcs",
+        "//crates/lib-core:machete_srcs",
+        "//crates/lib-dialects:machete_srcs",
+        "//crates/lib-wasm:machete_srcs",
+        "//crates/lineage:machete_srcs",
+        "//crates/lsp:machete_srcs",
+        "//crates/sqlinference:machete_srcs",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+    ],
+    env = {
+        "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
+    },
+    tags = ["no-sandbox"],
+)
+
 # Zensical docs build - verify documentation builds successfully
 sh_test(
     name = "zensical_build",

--- a/crates/cli-lib/BUILD.bazel
+++ b/crates/cli-lib/BUILD.bazel
@@ -46,6 +46,7 @@ filegroup(
     srcs = glob(
         [
             "src/**/*.rs",
+            "src/**/*.md",
             "tests/**/*.rs",
             "benches/**/*.rs",
         ],

--- a/crates/lib/BUILD.bazel
+++ b/crates/lib/BUILD.bazel
@@ -82,6 +82,7 @@ filegroup(
     srcs = glob(
         [
             "src/**/*.rs",
+            "src/**/*.cfg",
             "tests/**/*.rs",
             "benches/**/*.rs",
         ],


### PR DESCRIPTION
## Summary

- Adds a new bazel test target `//:cargo_check` that runs `cargo check --all --all-features --tests --benches --locked`
- Removes the "Rust Check" job from `.github/workflows/pr.yml` since it's now covered by bazel
- Removes the `polonius-the-crab` dependency from the `lineage` crate by refactoring `selects_mut` to avoid the borrow checker workaround
- Updates `machete_srcs` filegroups to include `.cfg` and `.md` files needed by `include_str!` macros

The polonius-the-crab removal was necessary because its transitive dependencies (`never-say-never`, `higher-kinded-types`) caused issues with the Bazel-provided cargo toolchain - their build scripts invoked rustup to download old Rust toolchains.

## Test plan

- [x] `bazel test //:cargo_check` passes
- [x] `cargo test -p lineage` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)