### PR TITLE
chore(bazel): add cargo-based lint checks

### DIFF
--- a/.hacking/scripts/cargo_clippy.sh
+++ b/.hacking/scripts/cargo_clippy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Run cargo clippy with all features and treat warnings as errors.
+set -eo pipefail
+
+cd "$RUNFILES_DIR/_main"
+CARGO_BIN="$RUNFILES_DIR/$CARGO"
+
+# Create a temp bin directory with cargo symlink
+BINDIR=$(mktemp -d)
+ln -s "$CARGO_BIN" "$BINDIR/cargo"
+export PATH="$BINDIR:$PATH"
+
+# Run cargo clippy
+cargo clippy --all --all-features -- -D warnings

--- a/.hacking/scripts/cargo_fmt_check.sh
+++ b/.hacking/scripts/cargo_fmt_check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Run cargo fmt check to verify code formatting.
+set -eo pipefail
+
+cd "$RUNFILES_DIR/_main"
+CARGO_BIN="$RUNFILES_DIR/$CARGO"
+
+# Create a temp bin directory with cargo symlink
+BINDIR=$(mktemp -d)
+ln -s "$CARGO_BIN" "$BINDIR/cargo"
+export PATH="$BINDIR:$PATH"
+
+# Run cargo fmt check
+cargo fmt --all -- --check

--- a/.hacking/scripts/cargo_hack_check.sh
+++ b/.hacking/scripts/cargo_hack_check.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
+# Run cargo hack check --each-feature to verify all feature combinations compile.
+# This ensures individual features don't break when enabled in isolation.
 set -eo pipefail
 
-# Find workspace root - works for both bazel run and bazel test (with local=True)
-if [[ -n "$BUILD_WORKSPACE_DIRECTORY" ]]; then
-    cd "$BUILD_WORKSPACE_DIRECTORY"
-elif [[ -f "Cargo.toml" ]]; then
-    : # Already in workspace root
-else
-    # Navigate from script location
-    cd "$(dirname "$0")/../.."
-fi
+cd "$RUNFILES_DIR/_main"
+CARGO_BIN="$RUNFILES_DIR/$CARGO"
+CARGO_HACK_BIN="$RUNFILES_DIR/$CARGO_HACK"
 
+# Create a temp bin directory with symlinks so cargo can find cargo-hack as a subcommand
+BINDIR=$(mktemp -d)
+ln -s "$CARGO_BIN" "$BINDIR/cargo"
+ln -s "$CARGO_HACK_BIN" "$BINDIR/cargo-hack"
+export PATH="$BINDIR:$PATH"
+
+# Run cargo hack check --each-feature
 cargo hack check --each-feature --exclude-features=codegen-docs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -173,7 +173,7 @@ RUST_TARGETS = [
 ]
 
 # Common Cargo source files for cargo-based checks
-# Used by cargo_machete, cargo_check
+# Used by cargo_machete, cargo_check, cargo_hack_check, rust_lint
 filegroup(
     name = "cargo_srcs",
     srcs = [
@@ -251,6 +251,57 @@ sh_test(
     ],
     env = {
         "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
+    },
+    tags = ["no-sandbox"],
+)
+
+# Cargo clippy - run clippy with all features
+# Note: Runs without sandbox to allow cargo to access ~/.cargo cache
+sh_test(
+    name = "cargo_clippy",
+    size = "large",
+    srcs = [".hacking/scripts/cargo_clippy.sh"],
+    data = [
+        ":cargo_srcs",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+    ],
+    env = {
+        "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
+    },
+    tags = ["no-sandbox"],
+)
+
+# Cargo fmt check - verify code formatting
+# Note: Runs without sandbox to allow cargo to access ~/.cargo cache
+sh_test(
+    name = "cargo_fmt_check",
+    size = "medium",
+    srcs = [".hacking/scripts/cargo_fmt_check.sh"],
+    data = [
+        ":cargo_srcs",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+    ],
+    env = {
+        "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
+    },
+    tags = ["no-sandbox"],
+)
+
+# Cargo hack check - verify each feature compiles in isolation
+# This ensures no feature combination is broken
+# Note: Runs without sandbox to allow cargo to access ~/.cargo cache
+sh_test(
+    name = "cargo_hack_check",
+    size = "large",
+    srcs = [".hacking/scripts/cargo_hack_check.sh"],
+    data = [
+        ":cargo_srcs",
+        "@cargo_hack//:cargo-hack",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+    ],
+    env = {
+        "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
+        "CARGO_HACK": "$(rlocationpath @cargo_hack//:cargo-hack)",
     },
     tags = ["no-sandbox"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,9 +7,9 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.0")
 
-# Platform-aware tool downloads (ratchet, cargo-machete, uv)
+# Platform-aware tool downloads (ratchet, cargo-machete, cargo-hack, uv)
 tools = use_extension("//:tools.bzl", "tools")
-use_repo(tools, "cargo_machete", "ratchet", "uv")
+use_repo(tools, "cargo_hack", "cargo_machete", "ratchet", "uv")
 
 bazel_dep(name = "aspect_rules_js", version = "2.3.7")
 bazel_dep(name = "rules_nodejs", version = "6.3.4")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -251,7 +251,7 @@
   "moduleExtensions": {
     "//:tools.bzl%tools": {
       "general": {
-        "bzlTransitiveDigest": "VveJK9yxuaoXfRw2Wp506Uft9ndUkr0IQQipOliaMlA=",
+        "bzlTransitiveDigest": "7egann2c8H9XO2HbHf73NO04omFRlviENL9DHCclq78=",
         "usagesDigest": "Im2V7yPlYEv4GHExi3pryxLYa0SN3bEhv6+M92OPojA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -263,6 +263,10 @@
           },
           "cargo_machete": {
             "repoRuleId": "@@//:tools.bzl%_cargo_machete_repo",
+            "attributes": {}
+          },
+          "cargo_hack": {
+            "repoRuleId": "@@//:tools.bzl%_cargo_hack_repo",
             "attributes": {}
           },
           "uv": {

--- a/tools.bzl
+++ b/tools.bzl
@@ -45,6 +45,26 @@ _MACHETE_PLATFORMS = {
     },
 }
 
+_CARGO_HACK_VERSION = "0.6.41"
+_CARGO_HACK_PLATFORMS = {
+    "linux_amd64": {
+        "url": "https://github.com/taiki-e/cargo-hack/releases/download/v{version}/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
+        "sha256": "c69dbf348263856cdb8d8c8c835b906360fb6eccb73b56716dd0e451082b6145",
+    },
+    "linux_arm64": {
+        "url": "https://github.com/taiki-e/cargo-hack/releases/download/v{version}/cargo-hack-aarch64-unknown-linux-gnu.tar.gz",
+        "sha256": "f6a5357b3c4a1f3cd95c1ba769c71e0a0c833aa3007ddf3873863f149da84dcd",
+    },
+    "darwin_amd64": {
+        "url": "https://github.com/taiki-e/cargo-hack/releases/download/v{version}/cargo-hack-x86_64-apple-darwin.tar.gz",
+        "sha256": "4b35c8dbe6d24bd81c05ade55d19fd7fc9b142d46b07bb7da1b92dfa55877adf",
+    },
+    "darwin_arm64": {
+        "url": "https://github.com/taiki-e/cargo-hack/releases/download/v{version}/cargo-hack-aarch64-apple-darwin.tar.gz",
+        "sha256": "146bce8ed728b5dc46edb2dc4f4cfca4bf77f729bbbb4be785b5e89f5cac3aae",
+    },
+}
+
 _UV_VERSION = "0.9.22"
 _UV_PLATFORMS = {
     "linux_amd64": {
@@ -130,6 +150,25 @@ _cargo_machete_repo = repository_rule(
     attrs = {},
 )
 
+def _cargo_hack_repo_impl(repository_ctx):
+    platform = _get_platform(repository_ctx)
+    config = _CARGO_HACK_PLATFORMS.get(platform)
+    if not config:
+        fail("Unsupported platform for cargo-hack: {}".format(platform))
+
+    url = config["url"].format(version = _CARGO_HACK_VERSION)
+
+    repository_ctx.download_and_extract(
+        url = url,
+        sha256 = config["sha256"],
+    )
+    repository_ctx.file("BUILD.bazel", 'exports_files(["cargo-hack"])')
+
+_cargo_hack_repo = repository_rule(
+    implementation = _cargo_hack_repo_impl,
+    attrs = {},
+)
+
 def _uv_repo_impl(repository_ctx):
     platform = _get_platform(repository_ctx)
     config = _UV_PLATFORMS.get(platform)
@@ -154,6 +193,7 @@ _uv_repo = repository_rule(
 def _tools_impl(module_ctx):
     _ratchet_repo(name = "ratchet")
     _cargo_machete_repo(name = "cargo_machete")
+    _cargo_hack_repo(name = "cargo_hack")
     _uv_repo(name = "uv")
 
 tools = module_extension(


### PR DESCRIPTION
## Summary

Add individual Bazel targets for each cargo lint check, replicating what `make rust_lint` does:

- `//:cargo_fmt_check` - `cargo fmt --all -- --check`
- `//:cargo_clippy` - `cargo clippy --all --all-features -- -D warnings`
- `//:cargo_machete` - `cargo machete` (already existed)
- `//:cargo_hack_check` - `cargo hack check --each-feature`

Changes:
- Add `cargo-hack` tool to `tools.bzl` (v0.6.41)
- Add `cargo_clippy.sh` and `cargo_fmt_check.sh` scripts
- Update `cargo_hack_check.sh` to use Bazel runfiles
- Add Bazel targets for `cargo_clippy`, `cargo_fmt_check`, `cargo_hack_check`

All checks run via `bazel test //...` with no-sandbox mode to allow cargo to access the system cache.

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (23 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)