### PR TITLE
Update CLAUDE.md with current project structure and build commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,20 +19,34 @@ env UPDATE_EXPECT=1 cargo test --no-fail-fast
 # Format code
 cargo fmt --all
 
-# Run all lint checks via Bazel (clippy, rustfmt, prettier, ruff, machete)
+# Run key lint checks via Bazel
 bazel test //:rustfmt_check //:clippy_check //:prettier_check //:ruff_check //:cargo_machete
+
+# Hermetic cargo checks (vendored deps, isolated Rust toolchain)
+bazel test //:cargo_check //:cargo_clippy //:cargo_fmt_check
+
+# Run all tests via Bazel
+bazel test //:cargo_test
+
+# Verify generated docs are up to date
+bazel test //:codegen_docs_check
 ```
 
 ## Project Structure
 
 ```
 crates/
-├── cli/          # CLI binary
-├── lib/          # Core linting rules
-├── lib-core/     # Parser and AST
-├── lib-dialects/ # SQL dialect implementations
-├── lsp/          # Language Server Protocol
-└── lib-wasm/     # WebAssembly bindings
+├── cli/           # CLI binary
+├── cli-lib/       # Shared CLI library
+├── cli-python/    # Python bindings (PyO3)
+├── lib/           # Core linting rules
+├── lib-core/      # Parser and AST
+├── lib-dialects/  # SQL dialect implementations
+├── lib-wasm/      # WebAssembly bindings
+├── lineage/       # SQL lineage tracking
+├── lsp/           # Language Server Protocol
+└── sqlinference/  # SQL inference library
+playground/        # React/TypeScript web playground (WASM-based)
 ```
 
 ## SQLFluff Compatibility
@@ -55,6 +69,5 @@ exclude_rules = AM01,AM02
 
 Do not edit directly - regenerate with `cargo run --bin sqruff -F codegen-docs`:
 - `docs/reference/cli.md`
-- `docs/reference/dialects.md`
 - `docs/reference/rules.md`
 - `docs/reference/templaters.md`


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md developer documentation to reflect the current state of the project, including new crates, updated Bazel commands, and refined project structure.

## Key Changes
- **Build Commands**: Expanded Bazel testing documentation with separate sections for:
  - Key lint checks (rustfmt, clippy, prettier, ruff, cargo_machete)
  - Hermetic cargo checks (cargo_check, cargo_clippy, cargo_fmt_check)
  - All tests via Bazel
  - Generated docs verification

- **Project Structure**: Updated crates directory to include:
  - New `cli-lib/` - Shared CLI library
  - New `cli-python/` - Python bindings (PyO3)
  - New `lineage/` - SQL lineage tracking
  - New `sqlinference/` - SQL inference library
  - New `playground/` - React/TypeScript web playground (WASM-based)
  - Removed `lsp/` from its original position (now listed after lib-wasm)

- **Documentation Generation**: Removed `docs/reference/dialects.md` from the auto-generated docs list, keeping only cli.md, rules.md, and templaters.md

## Notes
These changes reflect the expanded scope of the project with new language bindings, additional analysis capabilities, and a web-based playground interface.

https://claude.ai/code/session_01S5UhFja7QFwAbSxMJGgveR