### PR TITLE
Upgrade pnpm from 10.0.0 to 10.28.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ use_repo(npm, "npm")
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 pnpm.pnpm(
     name = "pnpm",
-    pnpm_version = "10.0.0",
+    pnpm_version = "10.28.2",
 )
 use_repo(pnpm, "pnpm")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -352,11 +352,11 @@
             "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
             "attributes": {
               "package": "pnpm",
-              "version": "10.0.0",
+              "version": "10.28.2",
               "root_package": "",
               "link_workspace": "",
               "link_packages": {},
-              "integrity": "sha512-uP71SUvT/ky9Ttq9B0XfLuW+PksLiwj6ZDqj5MZwLMwPANaPqKjJhYpzWgAySFpEmQ7SgQUmyHXkFvABsX3xKw==",
+              "integrity": "sha512-QYcvA3rSL3NI47Heu69+hnz9RI8nJtnPdMCPGVB8MdLI56EVJbmD/rwt9kC1Q43uYCPrsfhO1DzC1lTSvDJiZA==",
               "url": "",
               "commit": "",
               "patch_args": [
@@ -378,7 +378,7 @@
             "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
             "attributes": {
               "package": "pnpm",
-              "version": "10.0.0",
+              "version": "10.28.2",
               "dev": false,
               "root_package": "",
               "link_packages": {},


### PR DESCRIPTION
## Summary
This pull request upgrades the pnpm package manager version from 10.0.0 to 10.28.2 in the Bazel build configuration.

## Changes
- Updated `pnpm_version` in `MODULE.bazel` from `10.0.0` to `10.28.2`
- Updated the corresponding integrity hash in `MODULE.bazel.lock` to match the new version
- Updated version references in the lock file's npm import configuration

## Details
This is a minor version bump that brings in the latest pnpm 10.x release with bug fixes and improvements. The integrity hash has been updated to ensure the correct package is downloaded and verified.

https://claude.ai/code/session_01JRcXU3SvLvEKnxeZtbuivy