### PR TITLE
Refactor imperative loops to functional iterator chains

### DIFF
--- a/crates/lib/src/core/linter/core.rs
+++ b/crates/lib/src/core/linter/core.rs
@@ -124,22 +124,16 @@ impl Linter {
             paths.push(std::env::current_dir().unwrap());
         }
 
-        let mut expanded_paths = Vec::new();
-
-        for path in paths {
-            if path.is_file() {
-                expanded_paths.push(path.to_string_lossy().to_string());
-            } else {
-                expanded_paths.extend(self.paths_from_path(
-                    path,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(ignorer),
-                ));
-            };
-        }
+        let expanded_paths: Vec<String> = paths
+            .into_iter()
+            .flat_map(|path| {
+                if path.is_file() {
+                    vec![path.to_string_lossy().to_string()]
+                } else {
+                    self.paths_from_path(path, None, None, None, None, Some(ignorer))
+                }
+            })
+            .collect();
 
         let paths: Vec<String> = expanded_paths
             .into_iter()

--- a/crates/lib/src/core/linter/linted_file.rs
+++ b/crates/lib/src/core/linter/linted_file.rs
@@ -123,14 +123,11 @@ impl LintedFile {
         patches: Vec<FixPatch>,
         _templated_file: &TemplatedFile,
     ) -> Vec<FixPatch> {
-        let mut filtered_source_patches = Vec::new();
         let mut dedupe_buffer = FxHashSet::default();
-
-        for patch in patches {
-            if dedupe_buffer.insert(patch.dedupe_tuple()) {
-                filtered_source_patches.push(patch);
-            }
-        }
+        let mut filtered_source_patches: Vec<_> = patches
+            .into_iter()
+            .filter(|patch| dedupe_buffer.insert(patch.dedupe_tuple()))
+            .collect();
 
         filtered_source_patches.sort_by_key(|x| x.source_slice.start);
         filtered_source_patches


### PR DESCRIPTION
## Summary
This PR refactors multiple imperative loop patterns across the codebase to use functional iterator chains (map, filter, flat_map, chain, collect). This improves code readability, reduces mutable state, and follows Rust idioms more closely.

## Key Changes

- **Parser segments (from.rs)**: Converted nested loops building `direct_table_children` and `join_clauses` to use `flat_map` and iterator chains for collecting aliases.

- **Query analysis (query.rs)**: Refactored wildcard expression filtering and table alias collection from imperative loops to functional `filter` and `map` operations.

- **Linter core (core.rs)**: Replaced manual path expansion loop with `flat_map` to handle both file and directory cases in a single iterator chain.

- **Linted file (linted_file.rs)**: Simplified deduplication logic using `filter` with a mutable set instead of explicit loop with conditional push.

- **Convention rule CV07 (cv07.rs)**: Converted bracketed statement evaluation from imperative result accumulation to functional `map` over iterator, eliminating intermediate mutable state.

- **References rule RF03 (rf03.rs)**: Refactored query visiting logic to use `chain` and `flat_map` instead of separate conditional blocks and manual accumulation.

- **Structure rules (st07.rs, st09.rs)**: 
  - ST07: Replaced join condition generation loop with `map` and `intersperse_with` for cleaner segment building.
  - ST09: Converted table alias and condition collection from imperative loops to functional `chain`, `map`, and `flat_map` operations.

## Implementation Details

- All changes maintain identical functionality while improving code clarity
- Mutable buffers and intermediate collections are eliminated where possible
- Iterator chains are preferred over explicit loops for better composability
- Type annotations are added where needed for clarity (e.g., `Vec<_>` with turbofish)

https://claude.ai/code/session_01SNpQou2mZFfF36kMHpwAbH