### PR TITLE
chore: enable fail-fast for tests to stop early on failure

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,5 +22,5 @@ test:ci --test_output=errors
 test:ci --test_summary=detailed
 test:ci --verbose_failures
 
-# Keep tests running even if some fail to show all failures at once
-test:ci --keep_going
+# Fail fast - stop on first test failure
+test:ci --nokeep_going

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Run necessary tests
         run: |
           (cd crates/cli-python && maturin develop)
-          cargo test --no-fail-fast --manifest-path ./crates/cli/Cargo.toml
-          cargo test --no-fail-fast --all --all-features --exclude sqruff
+          cargo test --manifest-path ./crates/cli/Cargo.toml
+          cargo test --all --all-features --exclude sqruff
       - name: Check for diffs
         run: git diff --quiet || exit 1
 

--- a/.hacking/scripts/cargo_test.sh
+++ b/.hacking/scripts/cargo_test.sh
@@ -54,5 +54,5 @@ export LD_LIBRARY_PATH="${UV_PYTHON_DIR:-}:${LD_LIBRARY_PATH:-}"
 (cd crates/cli-python && maturin develop --uv)
 
 # Run cargo tests (same as GitHub Action)
-cargo test --no-fail-fast --manifest-path ./crates/cli/Cargo.toml
-cargo test --no-fail-fast --all --all-features --exclude sqruff
+cargo test --manifest-path ./crates/cli/Cargo.toml
+cargo test --all --all-features --exclude sqruff

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@ cargo run -- lint <file.sql>
 cargo run -- fix <file.sql>
 
 # Run tests
-cargo test --no-fail-fast
+cargo test
 
 # Update test fixtures
-env UPDATE_EXPECT=1 cargo test --no-fail-fast
+env UPDATE_EXPECT=1 cargo test
 
 # Format code
 cargo fmt --all
@@ -52,6 +52,7 @@ playground/        # React/TypeScript web playground (WASM-based)
 ## SQLFluff Compatibility
 
 Sqruff is designed to be compatible with SQLFluff:
+
 - **Check SQLFluff first** when implementing rules or dialects
 - **Copy SQLFluff tests** - use their test cases as starting points
 - Rules are in `crates/lib/src/rules/`, dialects in `crates/lib-dialects/src/`
@@ -59,6 +60,7 @@ Sqruff is designed to be compatible with SQLFluff:
 ## Configuration
 
 `.sqruff` file (INI format):
+
 ```ini
 [sqruff]
 dialect = snowflake
@@ -68,6 +70,7 @@ exclude_rules = AM01,AM02
 ## Auto-Generated Docs
 
 Do not edit directly - regenerate with `cargo run --bin sqruff -F codegen-docs`:
+
 - `docs/reference/cli.md`
 - `docs/reference/rules.md`
 - `docs/reference/templaters.md`


### PR DESCRIPTION
## Summary
- Remove `--no-fail-fast` from `cargo test` invocations in the CI workflow (`.github/workflows/pr.yml`), Bazel test script (`.hacking/scripts/cargo_test.sh`), and developer instructions (`CLAUDE.md`)
- Change Bazel CI config from `--keep_going` to `--nokeep_going` in `.bazelrc`

Previously a single test failure would still run all remaining tests, wasting CI time and memory. Now tests stop on first failure.