### PR TITLE
chore: switch cargo publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,47 +162,47 @@ jobs:
     name: Publish to Cargo
     runs-on: ubuntu-latest
     needs: [convert_release_to_not_draft]
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v5
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # ratchet:actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # ratchet:rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish sqruff-lib-core to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-lib-core
+        run: cargo publish -p sqruff-lib-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish sqruff-lib-dialects to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-lib-dialects
+        run: cargo publish -p sqruff-lib-dialects
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish sqruff-lib to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-lib
+        run: cargo publish -p sqruff-lib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish sqruff-lsp to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-lsp
+        run: cargo publish -p sqruff-lsp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish sqruff-cli-lib to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-cli-lib
+        run: cargo publish -p sqruff-cli-lib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish sqruff to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff
+        run: cargo publish -p sqruff
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish sqruff-sqlinference to Cargo
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_TOKEN }} -p sqruff-sqlinference
+        run: cargo publish -p sqruff-sqlinference
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
   publish-to-marketplace:
     name: Publish VSIX to VSCode Marketplace
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace token-based auth (`CARGO_API_TOKEN` secret) with OIDC trusted publishing via `rust-lang/crates-io-auth-action@v1`
- Add `id-token: write` permission and `release` environment to the `publish-to-cargo` job
- Replace deprecated `actions-rs/cargo` action with direct `cargo publish` commands

## Prerequisites
Trusted publishers must be configured on crates.io for each crate:
- `sqruff-lib-core`
- `sqruff-lib-dialects`
- `sqruff-lib`
- `sqruff-lsp`
- `sqruff-cli-lib`
- `sqruff`
- `sqruff-sqlinference`

Settings: workflow filename `release.yml`, environment `release`.

A `release` environment also needs to be created in the GitHub repo settings.

## Test plan
- [ ] Verify trusted publishers are configured on crates.io for all 7 crates
- [ ] Verify `release` environment exists in GitHub repo settings
- [ ] Test on next tag push release

🤖 Generated with [Claude Code](https://claude.com/claude-code)