### PR TITLE
fix: add bounds check for adjacent element access in rebreak

### DIFF
--- a/crates/lib/src/utils/reflow/rebreak.rs
+++ b/crates/lib/src/utils/reflow/rebreak.rs
@@ -44,10 +44,18 @@ impl RebreakIndices {
         while (dir == 1 && newline_point_idx < limit as isize)
             || (dir == -1 && newline_point_idx >= 0)
         {
+            // Check bounds for the adjacent element access. When traversing
+            // backward (dir=-1) and reaching index 0, (idx + dir) would be -1
+            // which wraps to usize::MAX causing a panic. Break here as we've
+            // reached the boundary - there's nothing further in this direction.
+            let adjacent_idx = newline_point_idx + dir as isize;
+            if adjacent_idx < 0 || adjacent_idx >= elements.len() as isize {
+                break;
+            }
             if elements[newline_point_idx as usize]
                 .class_types()
                 .contains(SyntaxKind::Newline)
-                || elements[(newline_point_idx + dir as isize) as usize]
+                || elements[adjacent_idx as usize]
                     .segments()
                     .iter()
                     .any(|seg| seg.is_code())
@@ -61,7 +69,12 @@ impl RebreakIndices {
         while (dir == 1 && pre_code_point_idx < limit as isize)
             || (dir == -1 && pre_code_point_idx >= 0)
         {
-            if elements[(pre_code_point_idx + dir as isize) as usize]
+            // Same bounds check as above for the adjacent element access.
+            let adjacent_idx = pre_code_point_idx + dir as isize;
+            if adjacent_idx < 0 || adjacent_idx >= elements.len() as isize {
+                break;
+            }
+            if elements[adjacent_idx as usize]
                 .segments()
                 .iter()
                 .any(|seg| seg.is_code())


### PR DESCRIPTION
## Summary

Fixes a potential out-of-bounds panic in `RebreakIndices::from_elements` when traversing backward through elements.

## The Bug

When `dir=-1` (backward traversal), the loops in `from_elements` access `elements[idx + dir]` to check the adjacent element. The loop condition guards `idx >= 0`, but the adjacent access `idx + dir` can go to -1:

```rust
while (dir == -1 && newline_point_idx >= 0) {
    // When newline_point_idx = 0 and dir = -1:
    // This accesses elements[-1] which wraps to usize::MAX
    elements[(newline_point_idx + dir as isize) as usize]  // PANIC!
}
```

### Trigger Condition

The bug is triggered when `start_idx` is odd >= 3. The loop decrements by 2 each iteration:
- `start_idx=3`: adj=2 → sequence 2 → 0 → -2, accesses `elements[-1]` when at 0
- `start_idx=5`: adj=4 → sequence 4 → 2 → 0 → -2, same issue

### SQLFluff Comparison

The equivalent Python code in SQLFluff has the **same bug**, but Python's negative indexing silently wraps `elements[-1]` to the last element instead of crashing. This produces incorrect results (checking the wrong element) rather than a panic - a logic bug that went unnoticed.

## The Fix

Add bounds checking before accessing the adjacent element. When the boundary is reached, break out of the loop since there's nothing further to find in that direction.

```rust
let adjacent_idx = newline_point_idx + dir as isize;
if adjacent_idx < 0 || adjacent_idx >= elements.len() as isize {
    break;
}
```

## Testing

- All existing rebreak and reflow tests pass
- The fix is defensive - it prevents the panic while maintaining correct semantics (stop searching when you hit the boundary)

## Related

This was discovered while investigating #2289 (capacity overflow in reindent). That issue involves a different bug pattern (`isize` cast to `usize` for `str::repeat()`), but both stem from signed/unsigned arithmetic edge cases.

---

🤖 Generated with [Claude Code](https://claude.ai/code)