### PR TITLE
core(lineage): run test_lineage_union on all dialects

### DIFF
--- a/crates/lineage/src/lib.rs
+++ b/crates/lineage/src/lib.rs
@@ -714,28 +714,39 @@ mod tests {
 
     #[test]
     fn test_lineage_union() {
-        let dialect = sqruff_lib_dialects::ansi::dialect(None);
-        let parser = Parser::new(&dialect, Default::default());
+        for (dialect_name, dialect) in all_dialects() {
+            let parser = Parser::new(&dialect, Default::default());
 
-        let (tables, node) = Lineage::new(
-            parser.clone(),
-            "x",
-            "SELECT ax AS x FROM a UNION SELECT bx FROM b UNION SELECT cx FROM c",
-        )
-        .build();
+            let (tables, node) = Lineage::new(
+                parser.clone(),
+                "x",
+                "SELECT ax AS x FROM a UNION ALL SELECT bx FROM b UNION ALL SELECT cx FROM c",
+            )
+            .build();
 
-        let node_data = &tables.nodes[node];
-        assert_eq!(node_data.downstream.len(), 3);
+            let node_data = &tables.nodes[node];
+            assert_eq!(
+                node_data.downstream.len(),
+                3,
+                "Failed for dialect: {}",
+                dialect_name
+            );
 
-        let (tables, node) = Lineage::new(
-            parser,
-            "x",
-            "SELECT x FROM (SELECT ax AS x FROM a UNION SELECT bx FROM b UNION SELECT cx FROM c)",
-        )
-        .build();
+            let (tables, node) = Lineage::new(
+                parser,
+                "x",
+                "SELECT x FROM (SELECT ax AS x FROM a UNION ALL SELECT bx FROM b UNION ALL SELECT cx FROM c)",
+            )
+            .build();
 
-        let node_data = &tables.nodes[node];
-        assert_eq!(node_data.downstream.len(), 3);
+            let node_data = &tables.nodes[node];
+            assert_eq!(
+                node_data.downstream.len(),
+                3,
+                "Failed for dialect: {}",
+                dialect_name
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Convert `test_lineage_union` to run on all available dialects instead of just ANSI
- Change bare `UNION` to `UNION ALL` since BigQuery requires an explicit modifier (`ALL` or `DISTINCT`)

## Test plan
- [x] `cargo test -p lineage test_lineage_union` passes on all 14 dialects
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)