### PR TITLE
fix(templater): handle multi-byte UTF-8 characters in Python bridge

### DIFF
--- a/crates/lib-core/src/templaters.rs
+++ b/crates/lib-core/src/templaters.rs
@@ -640,14 +640,18 @@ pub fn char_to_byte_indices(s: &str) -> Vec<usize> {
 /// Convert a character-based index to a byte-based index using a precomputed
 /// mapping table from [`char_to_byte_indices`].
 ///
-/// Returns the index unchanged if it's out of bounds (defensive fallback for
-/// ASCII-only strings where char index == byte index).
+/// # Panics
+///
+/// Panics if `char_idx` is greater than or equal to `char_to_byte.len()`.
+/// This indicates a bug in the caller (e.g. using an index that is not
+/// derived from the same string used to build `char_to_byte`).
 pub fn char_idx_to_byte_idx(char_to_byte: &[usize], char_idx: usize) -> usize {
-    if char_idx < char_to_byte.len() {
-        char_to_byte[char_idx]
-    } else {
-        char_idx
-    }
+    assert!(
+        char_idx < char_to_byte.len(),
+        "char_idx_to_byte_idx: char_idx {char_idx} out of bounds for mapping of length {}",
+        char_to_byte.len()
+    );
+    char_to_byte[char_idx]
 }
 
 #[cfg(test)]
@@ -694,12 +698,6 @@ mod tests {
         assert_eq!(char_idx_to_byte_idx(&indices, 1), 1);
         assert_eq!(char_idx_to_byte_idx(&indices, 2), 4);
         assert_eq!(char_idx_to_byte_idx(&indices, 3), 5);
-    }
-
-    #[test]
-    fn test_char_idx_to_byte_idx_out_of_bounds() {
-        let indices = char_to_byte_indices("ab");
-        assert_eq!(char_idx_to_byte_idx(&indices, 10), 10);
     }
 
     #[test]

--- a/crates/lib/src/templaters/python.rs
+++ b/crates/lib/src/templaters/python.rs
@@ -200,15 +200,19 @@ impl PythonTemplatedFile {
                             char_idx_to_byte_idx(&source_char_to_byte, s.source_slice.start);
                         let source_end =
                             char_idx_to_byte_idx(&source_char_to_byte, s.source_slice.end);
-                        let (templated_start, templated_end) =
-                            if let Some(ref t_map) = templated_char_to_byte {
-                                (
-                                    char_idx_to_byte_idx(t_map, s.templated_slice.start),
-                                    char_idx_to_byte_idx(t_map, s.templated_slice.end),
-                                )
-                            } else {
-                                (s.templated_slice.start, s.templated_slice.end)
-                            };
+                        let (templated_start, templated_end) = if let Some(ref t_map) =
+                            templated_char_to_byte
+                        {
+                            (
+                                char_idx_to_byte_idx(t_map, s.templated_slice.start),
+                                char_idx_to_byte_idx(t_map, s.templated_slice.end),
+                            )
+                        } else {
+                            (
+                                char_idx_to_byte_idx(&source_char_to_byte, s.templated_slice.start),
+                                char_idx_to_byte_idx(&source_char_to_byte, s.templated_slice.end),
+                            )
+                        };
                         TemplatedFileSlice::new(
                             &s.slice_type,
                             source_start..source_end,


### PR DESCRIPTION
## Summary
- Add `char_to_byte_indices()` and `char_idx_to_byte_idx()` helper functions to `lib-core` for converting Python's character-based indices to Rust's byte-based indices
- Update `PythonTemplatedFile::to_templated_file()` to convert all `source_idx`, `source_slice`, and `templated_slice` indices from character coordinates to byte coordinates before constructing the `TemplatedFile`
- Remove unused `to_templated_file_slice()` and `to_raw_file_slice()` methods
- Add regression tests in `lib-core` that verify `TemplatedFile` consistency checks pass with multi-byte characters, including a `should_panic` test that proves unconverted char indices cause the bug

## Context
When SQL files contain multi-byte UTF-8 characters (e.g. Japanese comments, accented characters), the Python templater (dbt/jinja/python) panics with:

```
TemplatedFile. Consistency fail on running source length. 1321 != 1281
```

**Root cause**: Python's `len()` returns character count (Unicode code points), while Rust's `String::len()` returns byte count (UTF-8). For example, `あ` is 1 character in Python but 3 bytes in Rust. The `PythonTemplatedFile::to_templated_file()` was passing Python's character-based indices directly to Rust without conversion, causing the consistency check to fail.

Closes #2318
Related: #1328, #1431

## Test plan
- [x] `cargo test --package sqruff-lib-core` — all 28 tests pass (including 10 new: 7 for index conversion helpers, 3 for TemplatedFile multi-byte regression)
- [x] `cargo test --package sqruff-lib --lib` — all 49 tests pass (no regressions)
- [x] `cargo fmt --all -- --check` — passes
- [x] `should_panic` test confirms that unconverted Python char indices trigger the exact panic being fixed