### PR TITLE
fix: skip templated references in RF03 to avoid false positives

### DIFF
--- a/crates/lib/src/rules/references/rf03.rs
+++ b/crates/lib/src/rules/references/rf03.rs
@@ -199,6 +199,10 @@ fn validate_one_reference(
         return None;
     }
 
+    if ref_.0.is_templated() {
+        return None;
+    }
+
     if standalone_aliases.contains(ref_.0.raw()) {
         return None;
     }

--- a/crates/lib/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -328,3 +328,17 @@ fail_but_dont_fix_templated_table_name_qualified:
     rules:
       references.consistent:
         single_table_references: qualified
+
+test_pass_pyformat_placeholder:
+  pass_str: |
+    SELECT
+        usr.name,
+        %(key)s AS key_val
+    FROM auth_user AS usr
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: pyformat
+        key: key


### PR DESCRIPTION
## Summary

- Add `is_templated()` check in RF03's `validate_one_reference()` to skip template-originated references (e.g. `%(key)s` via placeholder templater)
- Add test case for `pyformat` placeholder style confirming RF03 no longer flags templated references

## Context

Closes #2019

When using `templater = placeholder` with `param_style = pyformat`, the placeholder templater replaces `%(key)s` with `key` and marks the segment as `slice_type: "templated"`. The parser then recognizes `key` as an `ObjectReference`, but RF03's `validate_one_reference()` was not checking `is_templated()`, causing false positive "unqualified reference" warnings.

This follows the same pattern used in CP01 (`cp01.rs:197`) to skip templated segments.

## Test plan

- [x] Verified the test fails without the fix (RF03 reports `Unqualified reference 'key' found in single table select`)
- [x] Verified the test passes with the fix
- [x] All existing RF03 tests continue to pass