### PR TITLE
chore: add auto-fix GitHub Action for Rust formatting on PRs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,50 @@
+name: Auto-fix
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    name: Auto-fix Rust formatting
+    runs-on: ubuntu-latest
+    # Don't run on forks (they can't push back) or dependabot PRs
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # ratchet:bazel-contrib/setup-bazel@0.18.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Run rustfmt
+        run: bazelisk run @rules_rust//:rustfmt
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push fixes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: auto-fix Rust formatting"
+          git push


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that automatically fixes Rust formatting on PRs by running `bazel run @rules_rust//:rustfmt`
- Commits the fix back to the PR branch if any formatting changes are needed
- Skips forks (can't push back) and dependabot PRs

## Test plan
- [x] Verified `bazel run @rules_rust//:rustfmt` runs successfully locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)