### PR TITLE
chore: add Prettier auto-fix to formatting GitHub Action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   autofix:
-    name: Auto-fix Rust formatting
+    name: Auto-fix formatting
     runs-on: ubuntu-latest
     # Don't run on forks (they can't push back) or dependabot PRs
     if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
@@ -31,6 +31,9 @@ jobs:
       - name: Run rustfmt
         run: bazelisk run @rules_rust//:rustfmt
 
+      - name: Run Prettier
+        run: bazelisk run //:prettier_fix
+
       - name: Check for changes
         id: changes
         run: |
@@ -46,5 +49,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore: auto-fix Rust formatting"
+          git commit -m "chore: auto-fix formatting"
           git push

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,6 +77,7 @@ prettier_bin.prettier_binary(
         "//editors/code:prettier_srcs",
         "//playground:prettier_srcs",
     ],
+    env = {"JS_BINARY__CHDIR": "$$BUILD_WORKSPACE_DIRECTORY"},
 )
 
 # ESLint check for all TypeScript packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ make python_install
 
 ### Running Tests
 
-Once you have that the following runs the test suite. 
+Once you have that the following runs the test suite.
 
 #### Rust Tests
 


### PR DESCRIPTION
Fix the prettier_fix Bazel target to write to the real workspace by
setting JS_BINARY__CHDIR to BUILD_WORKSPACE_DIRECTORY, mirroring how
@rules_rust//:rustfmt operates. Add a Prettier step to the autofix
workflow so both Rust and Prettier formatting are auto-fixed on PRs.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
