### PR TITLE
chore: add ruff auto-fix to formatting GitHub Action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run Prettier
         run: bazelisk run //:prettier_fix
 
+      - name: Run ruff
+        run: bazelisk run //:ruff_fix
+
       - name: Check for changes
         id: changes
         run: |

--- a/.hacking/scripts/ruff_fix.sh
+++ b/.hacking/scripts/ruff_fix.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Fix Python code with ruff (format and lint).
+set -eo pipefail
+
+cd "$BUILD_WORKSPACE_DIRECTORY"
+RUFF_BIN="$0.runfiles/$RUFF"
+
+# Run ruff format
+echo "Formatting Python with ruff..."
+"$RUFF_BIN" format .
+
+# Run ruff linter with --fix
+echo "Running ruff linter with --fix..."
+"$RUFF_BIN" check --fix .
+
+echo "All ruff fixes applied!"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -161,6 +161,20 @@ sh_test(
     },
 )
 
+# Python ruff fix - format and lint fix (for fixing locally and in CI)
+sh_binary(
+    name = "ruff_fix",
+    srcs = [".hacking/scripts/ruff_fix.sh"],
+    data = [
+        "pyproject.toml",
+        "//crates/cli-python:python_srcs",
+        "@aspect_rules_lint//lint:ruff_bin",
+    ] + glob([".hacking/**/*.py"]),
+    env = {
+        "RUFF": "$(rlocationpath @aspect_rules_lint//lint:ruff_bin)",
+    },
+)
+
 # All Rust targets for linting
 RUST_TARGETS = [
     "//crates/cli:sqruff",


### PR DESCRIPTION
## Summary
- Add a `ruff_fix` Bazel target (`sh_binary`) that runs `ruff format` and `ruff check --fix` against the real workspace using `BUILD_WORKSPACE_DIRECTORY`, matching the pattern used by `@rules_rust//:rustfmt` and `//:prettier_fix`
- Add a "Run ruff" step to the autofix workflow so Python formatting is auto-fixed on PRs alongside Rust and Prettier

## Test plan
- [x] Verified `bazel run //:ruff_fix` works locally — formats and lint-fixes Python files in-place
- [x] Tested with intentionally mangled Python formatting and confirmed it gets corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)