### PR TITLE
chore: add codegen docs auto-fix to formatting GitHub Action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run ruff
         run: bazelisk run //:ruff_fix
 
+      - name: Regenerate docs
+        run: bazelisk run //:codegen_docs_fix
+
       - name: Check for changes
         id: changes
         run: |

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,7 @@ load("@rules_rust//rust:defs.bzl", "rust_clippy", "rustfmt_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_shellcheck//:def.bzl", "shellcheck_test")
-load(":cargo_build.bzl", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv", "python_venv_provider")
+load(":cargo_build.bzl", "cargo_run", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv", "python_venv_provider")
 
 # Link all npm packages into node_modules
 npm_link_all_packages(name = "node_modules")
@@ -297,6 +297,30 @@ if [ $FAILED -eq 1 ]; then
 fi
 
 echo "All generated docs are up to date"
+""",
+)
+
+# Codegen docs fix - regenerate docs and copy them back to the workspace
+# Uses BUILD_WORKSPACE_DIRECTORY to write to the real workspace, mirroring
+# how @rules_rust//:rustfmt operates.
+cargo_run(
+    name = "codegen_docs_fix",
+    srcs = [
+        ":cargo_srcs",
+        "docs/reference/cli.md",
+        "docs/reference/rules.md",
+        "docs/reference/templaters.md",
+    ],
+    vendor = ":cargo_deps",
+    python_venv = ":python_deps",
+    script = """
+# Build the codegen binary
+cargo build --bin sqruff -F codegen-docs --locked --offline
+
+# Run codegen into the real workspace
+(cd "$BUILD_WORKSPACE_DIRECTORY" && GITHUB_ACTIONS=false "$CARGO_TARGET_DIR/debug/sqruff")
+
+echo "Docs regenerated!"
 """,
 )
 

--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -427,26 +427,34 @@ export CARGO_TARGET_DIR="$WORK_DIR/target"
         runfiles = runfiles,
     )]
 
+_cargo_attrs = {
+    "srcs": attr.label_list(allow_files = True),
+    "vendor": attr.label(
+        mandatory = True,
+        providers = [CargoVendorInfo],
+        doc = "cargo_vendor_provider target with pre-installed toolchain",
+    ),
+    "python_venv": attr.label(
+        default = None,
+        providers = [PythonVenvInfo],
+        doc = "Optional python_venv_provider target for PyO3/maturin tests",
+    ),
+    "tools": attr.label_list(
+        allow_files = True,
+        default = [],
+        doc = "Additional cargo subcommand binaries (e.g. cargo-hack) to symlink into PATH",
+    ),
+    "script": attr.string(mandatory = True),
+}
+
 cargo_test = rule(
     implementation = _cargo_test_impl,
     test = True,
-    attrs = {
-        "srcs": attr.label_list(allow_files = True),
-        "vendor": attr.label(
-            mandatory = True,
-            providers = [CargoVendorInfo],
-            doc = "cargo_vendor_provider target with pre-installed toolchain",
-        ),
-        "python_venv": attr.label(
-            default = None,
-            providers = [PythonVenvInfo],
-            doc = "Optional python_venv_provider target for PyO3/maturin tests",
-        ),
-        "tools": attr.label_list(
-            allow_files = True,
-            default = [],
-            doc = "Additional cargo subcommand binaries (e.g. cargo-hack) to symlink into PATH",
-        ),
-        "script": attr.string(mandatory = True),
-    },
+    attrs = _cargo_attrs,
+)
+
+cargo_run = rule(
+    implementation = _cargo_test_impl,
+    executable = True,
+    attrs = _cargo_attrs,
 )


### PR DESCRIPTION
## Summary
- Add a `cargo_run` rule — a non-test executable variant of `cargo_test` that shares the same implementation but can be used with `bazel run`
- Add a `codegen_docs_fix` target that builds the codegen binary and runs it from `BUILD_WORKSPACE_DIRECTORY` to regenerate reference docs in-place
- Add a "Regenerate docs" step to the autofix workflow

## Test plan
- [x] Verified `bazel run //:codegen_docs_fix` works locally — builds and regenerates docs
- [x] Tested by mangling `docs/reference/cli.md` and confirmed it gets regenerated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)