### PR TITLE
Prevent newlines before statement terminators in clause formatting

### DIFF
--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT14.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT14.yml
@@ -107,6 +107,29 @@ test_pass_multiple_newlines_are_allowed:
 
       WHERE a = 1
 
+# Statement terminator should stay on the same line as the last clause.
+test_pass_clauses_with_semicolon:
+  pass_str: |
+      SELECT
+          id,
+          name
+      FROM foo
+      WHERE name = 'bar';
+
+# All on one line with semicolon - no violation (non-strict).
+test_pass_all_on_one_line_with_semicolon:
+  pass_str: "SELECT a FROM foo WHERE a = 1;"
+
+# Partial newlines with semicolon: fix should not move it to a new line.
+test_fail_where_on_same_line_with_semicolon:
+  fail_str: |
+      SELECT a
+      FROM foo WHERE name = 'bar';
+  fix_str: |
+      SELECT a
+      FROM foo
+      WHERE name = 'bar';
+
 # alone:strict forces newlines even when all on one line.
 test_fail_all_on_one_line_strict:
   configs:


### PR DESCRIPTION
## Summary
Fixed an issue where statement terminators (semicolons) could be moved to a new line when reformatting SQL clauses marked as "Alone" position. Statement terminators should remain on the same line as the preceding clause content.

## Key Changes
- Added logic to detect when the next element is a statement terminator (semicolon)
- Skip adding a newline before statement terminators even when the "Alone" position would normally require one
- Refactored newline requirement checks into explicit boolean variables for clarity
- Added test cases covering:
  - Clauses with semicolons on the same line (pass case)
  - All-on-one-line statements with semicolons (pass case)
  - Partial newlines with semicolons where the terminator should stay attached (fail/fix case)

## Implementation Details
- Introduced `skip_next_newline` flag that prevents newline insertion when both conditions are met:
  1. A newline would normally be added before the next element
  2. The next element is a statement terminator
- Early exit with `continue` when neither previous nor next newlines are needed
- Extracted `needs_next_newline` and `needs_prev_newline` checks to improve code readability and reduce redundant lookups

https://claude.ai/code/session_01DLixYaeBsNqGNqxmwd2JT6