### PR TITLE
Fix index out of bounds panic in ST09 for non-standard comparison ope…

### DIFF
--- a/crates/lib/src/rules/structure/st09.rs
+++ b/crates/lib/src/rules/structure/st09.rs
@@ -163,6 +163,12 @@ left join bar
 
         let mut fixes = Vec::new();
 
+        // Only reorder subconditions with well-known comparison operators.
+        // Operators like && (overlap), &> etc. are skipped, matching SQLFluff's
+        // _REORDERABLE_OPERATORS whitelist.
+        const REORDERABLE_OPERATORS: &[&str] =
+            &["=", "!=", "<>", "<=>", "<", ">", "<=", ">="];
+
         for subcondition in column_operator_column_subconditions {
             let comparison_operator = subcondition[1].clone();
             let first_column_reference = subcondition[0].clone();
@@ -170,6 +176,23 @@ left join bar
             let raw_comparison_operators: Vec<_> = comparison_operator
                 .children(const { &SyntaxSet::new(&[SyntaxKind::RawComparisonOperator]) })
                 .collect();
+
+            // Extract the operator string: join RawComparisonOperator children
+            // if present, otherwise fall back to the raw text of the
+            // ComparisonOperator node itself.
+            let operator_str: String = if !raw_comparison_operators.is_empty() {
+                raw_comparison_operators
+                    .iter()
+                    .map(|r| r.raw().to_string())
+                    .collect()
+            } else {
+                comparison_operator.raw().trim().to_string()
+            };
+
+            if !REORDERABLE_OPERATORS.contains(&operator_str.as_str()) {
+                continue;
+            }
+
             let first_table_seg = first_column_reference
                 .child(
                     const {

--- a/crates/lib/src/rules/structure/st09.rs
+++ b/crates/lib/src/rules/structure/st09.rs
@@ -234,7 +234,8 @@ left join bar
                     None,
                 ));
 
-                if matches!(raw_comparison_operators[0].raw().as_ref(), "<" | ">")
+                if !raw_comparison_operators.is_empty()
+                    && matches!(raw_comparison_operators[0].raw().as_ref(), "<" | ">")
                     && raw_comparison_operators
                         .iter()
                         .map(|it| it.raw())

--- a/crates/lib/src/rules/structure/st09.rs
+++ b/crates/lib/src/rules/structure/st09.rs
@@ -166,8 +166,7 @@ left join bar
         // Only reorder subconditions with well-known comparison operators.
         // Operators like && (overlap), &> etc. are skipped, matching SQLFluff's
         // _REORDERABLE_OPERATORS whitelist.
-        const REORDERABLE_OPERATORS: &[&str] =
-            &["=", "!=", "<>", "<=>", "<", ">", "<=", ">="];
+        const REORDERABLE_OPERATORS: &[&str] = &["=", "!=", "<>", "<=>", "<", ">", "<=", ">="];
 
         for subcondition in column_operator_column_subconditions {
             let comparison_operator = subcondition[1].clone();

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST09.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST09.yml
@@ -390,6 +390,37 @@ test_fail_later_table_first_brackets_after_from:
                 on foo.a = bar.a
         )
 
+test_pass_postgres_overlap_operator:
+  pass_str: |
+    SELECT
+        *
+    FROM foo AS f
+    INNER JOIN bar AS b
+        ON f.period && b.period
+
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_postgres_overlap_operator:
+  fail_str: |
+    SELECT
+        *
+    FROM foo AS f
+    INNER JOIN bar AS b
+        ON b.period && f.period
+
+  fix_str: |
+    SELECT
+        *
+    FROM foo AS f
+    INNER JOIN bar AS b
+        ON f.period && b.period
+
+  configs:
+    core:
+      dialect: postgres
+
 test_fail_later_table_first_quoted_table_and_column:
   fail_str: |
     select


### PR DESCRIPTION
…rators

The `&&` (overlap) operator in PostgreSQL is parsed as a ComparisonOperator but contains AmpersandSegment children instead of RawComparisonOperator children. ST09 assumed raw_comparison_operators was non-empty when swapping column order, causing a panic on index 0 of an empty vec.

Add an emptiness check before accessing raw_comparison_operators[0].

Fixes #2426

https://claude.ai/code/session_01QzckwNiRjStjnS9c7BZRHQ