### PR TITLE
fix(bigquery): support @@ system variables in lexer

### DIFF
--- a/crates/lib-dialects/src/bigquery.rs
+++ b/crates/lib-dialects/src/bigquery.rs
@@ -36,7 +36,7 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             Matcher::string("question_mark", "?", SyntaxKind::QuestionMark),
             Matcher::regex(
                 "at_sign_literal",
-                r"@[a-zA-Z_][\w]*",
+                r"@{1,2}[a-zA-Z_][\w.]*",
                 SyntaxKind::AtSignLiteral,
             ),
         ],

--- a/crates/lib-dialects/src/bigquery.rs
+++ b/crates/lib-dialects/src/bigquery.rs
@@ -35,8 +35,13 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             Matcher::string("right_arrow", "=>", SyntaxKind::RightArrow),
             Matcher::string("question_mark", "?", SyntaxKind::QuestionMark),
             Matcher::regex(
+                "double_at_sign_literal",
+                r"@@[a-zA-Z_][\w.]*",
+                SyntaxKind::DoubleAtSignLiteral,
+            ),
+            Matcher::regex(
                 "at_sign_literal",
-                r"@{1,2}[a-zA-Z_][\w.]*",
+                r"@[a-zA-Z_][\w]*",
                 SyntaxKind::AtSignLiteral,
             ),
         ],
@@ -146,6 +151,23 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             TypedParser::new(SyntaxKind::AtSignLiteral, SyntaxKind::AtSignLiteral)
                 .to_matchable()
                 .into(),
+        ),
+        (
+            "DoubleAtSignLiteralSegment".into(),
+            TypedParser::new(
+                SyntaxKind::DoubleAtSignLiteral,
+                SyntaxKind::DoubleAtSignLiteral,
+            )
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "SystemVariableSegment".into(),
+            NodeMatcher::new(SyntaxKind::SystemVariable, |_| {
+                Ref::new("DoubleAtSignLiteralSegment").to_matchable()
+            })
+            .to_matchable()
+            .into(),
         ),
         (
             "DefaultDeclareOptionsGrammar".into(),
@@ -2516,6 +2538,7 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 TypedParser::new(SyntaxKind::NumericLiteral, SyntaxKind::NumericLiteral)
                     .to_matchable(),
                 Ref::new("ParameterizedSegment").to_matchable(),
+                Ref::new("SystemVariableSegment").to_matchable(),
             ])
             .to_matchable()
             .into(),
@@ -2534,7 +2557,10 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             dialect
                 .grammar("LiteralGrammar")
                 .copy(
-                    Some(vec![Ref::new("ParameterizedSegment").to_matchable()]),
+                    Some(vec![
+                        Ref::new("ParameterizedSegment").to_matchable(),
+                        Ref::new("SystemVariableSegment").to_matchable(),
+                    ]),
                     None,
                     None,
                     None,

--- a/crates/lib-dialects/test/fixtures/dialects/bigquery/sqruff/system_variables.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/bigquery/sqruff/system_variables.sql
@@ -1,0 +1,3 @@
+SET foo = @@bar;
+SET foo = @@error.message;
+SELECT @@bar;

--- a/crates/lib-dialects/test/fixtures/dialects/bigquery/sqruff/system_variables.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/bigquery/sqruff/system_variables.yml
@@ -5,8 +5,8 @@ file:
     - naked_identifier: foo
     - comparison_operator:
       - raw_comparison_operator: =
-    - parameterized_expression:
-      - at_sign_literal: '@@bar'
+    - system_variable:
+      - double_at_sign_literal: '@@bar'
 - statement_terminator: ;
 - statement:
   - set_segment:
@@ -14,14 +14,14 @@ file:
     - naked_identifier: foo
     - comparison_operator:
       - raw_comparison_operator: =
-    - parameterized_expression:
-      - at_sign_literal: '@@error.message'
+    - system_variable:
+      - double_at_sign_literal: '@@error.message'
 - statement_terminator: ;
 - statement:
   - select_statement:
     - select_clause:
       - keyword: SELECT
       - select_clause_element:
-        - parameterized_expression:
-          - at_sign_literal: '@@bar'
+        - system_variable:
+          - double_at_sign_literal: '@@bar'
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/bigquery/sqruff/system_variables.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/bigquery/sqruff/system_variables.yml
@@ -1,0 +1,27 @@
+file:
+- statement:
+  - set_segment:
+    - keyword: SET
+    - naked_identifier: foo
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - parameterized_expression:
+      - at_sign_literal: '@@bar'
+- statement_terminator: ;
+- statement:
+  - set_segment:
+    - keyword: SET
+    - naked_identifier: foo
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - parameterized_expression:
+      - at_sign_literal: '@@error.message'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - at_sign_literal: '@@bar'
+- statement_terminator: ;


### PR DESCRIPTION
BigQuery supports both @param and @@system_variable syntax. The lexer regex only matched single @ prefixes, causing @@var to be split into two tokens. This produced unwanted line breaks during formatting (e.g. `SET foo = \n@@bar;`) and parse errors in CALL statements using system variables like @@error.message.

Widen the at_sign_literal regex from `@[a-zA-Z_][\w]*` to `@{1,2}[a-zA-Z_][\w.]*` to match both forms in a single token, with dot support for qualified names like @@error.message.