### PR TITLE
fix: run pytest bazel targets exclusively

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -564,6 +564,7 @@ sh_test(
         env = {
             "PYTHON_VENV": "$(rlocationpath :pytest_py{}_venv)".format(version.replace(".", "")),
         },
+        tags = ["exclusive"],
     )
     for version in [
         "3.10",


### PR DESCRIPTION
## Summary
- Adds `tags = ["exclusive"]` to the pytest `sh_test` targets in `BUILD.bazel`
- Prevents Bazel from running Python tests in parallel, which was causing CI failures

## Test plan
- [ ] Verify pytest targets pass in CI without parallel conflict errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)