### PR TITLE
fix: three bugs in Jinja templater Python bridge

### DIFF
--- a/crates/cli-python/python/sqruff/templaters/jinja_templater.py
+++ b/crates/cli-python/python/sqruff/templaters/jinja_templater.py
@@ -1231,6 +1231,6 @@ def process_from_rust(
     except Exception as e:
         print("Error: ", e)
         raise e
-    if errors != []:
+    if errors != [] and not config.jinja_ignore_templating:
         raise ValueError
     return output

--- a/crates/cli-python/python/sqruff/templaters/python_templater.py
+++ b/crates/cli-python/python/sqruff/templaters/python_templater.py
@@ -44,8 +44,10 @@ class FormatterInterface:
 
 
 class SQLTemplaterError(Exception):
-    def __init__(self, message):
+    def __init__(self, message, line_no: Optional[int] = None, line_pos: Optional[int] = None):
         self.message = message
+        self.line_no = line_no
+        self.line_pos = line_pos
 
 
 def zero_slice(i: int) -> slice:

--- a/crates/lib/src/templaters/python_shared.rs
+++ b/crates/lib/src/templaters/python_shared.rs
@@ -12,7 +12,7 @@ pub struct PythonFluffConfig {
     templater_unwrap_wrapped_queries: bool,
 
     jinja_templater_paths: Vec<String>,
-    jinja_loader_search_path: Option<String>,
+    jinja_loader_search_path: Vec<String>,
     jinja_apply_dbt_builtins: bool,
     jinja_ignore_templating: Option<bool>,
     jinja_library_paths: Vec<String>,
@@ -51,8 +51,18 @@ impl From<&FluffConfig> for PythonFluffConfig {
                 .unwrap_or_default(),
             jinja_loader_search_path: value
                 .templater_value(TemplaterKind::Jinja, "loader_search_path")
-                .and_then(|value| value.as_string())
-                .map(ToString::to_string),
+                .map(|value| {
+                    if let Some(arr) = value.as_array() {
+                        arr.iter()
+                            .filter_map(|v| v.as_string().map(ToString::to_string))
+                            .collect()
+                    } else if let Some(s) = value.as_string() {
+                        vec![s.to_string()]
+                    } else {
+                        vec![]
+                    }
+                })
+                .unwrap_or_default(),
             jinja_apply_dbt_builtins: value
                 .templater_value(TemplaterKind::Jinja, "apply_dbt_builtins")
                 .and_then(|value| value.as_bool())
@@ -137,7 +147,10 @@ mod tests {
             python_fluff_config.jinja_templater_paths,
             Vec::<String>::new()
         );
-        assert_eq!(python_fluff_config.jinja_loader_search_path, None);
+        assert_eq!(
+            python_fluff_config.jinja_loader_search_path,
+            Vec::<String>::new()
+        );
         assert!(python_fluff_config.jinja_apply_dbt_builtins);
         assert_eq!(python_fluff_config.jinja_ignore_templating, None);
     }


### PR DESCRIPTION
## Summary

This PR fixes three bugs in the Python Jinja templater that cause runtime errors when using loader_search_path or ignore_templating with the Jinja templater.

## Fixes
### jinja_loader_search_path type mismatch between Rust and Python (python_shared.rs)

The PythonFluffConfig Rust struct serialised jinja_loader_search_path as Option<String> (i.e. null or a bare JSON string). However, the Python FluffConfig NamedTuple declares the field as List[str], so deserialisation via FluffConfig(**json.loads(...)) raised a TypeError at runtime whenever a loader_search_path was configured.

_Fix_: Changed the Rust field to Vec<String> and updated the From<&FluffConfig> conversion to collect the config value into a vec, handling both single-string and array config values gracefully. Updated the unit test assertion accordingly.

### process_from_rust raises ValueError even when ignore_templating = true (jinja_templater.py)

process_from_rust raised ValueError unconditionally whenever the templater returned any errors, ignoring the user's ignore_templating configuration. This made it impossible to lint Jinja templates that produce templating warnings (e.g. undefined variables used inside conditional blocks) even when the user had explicitly opted in to ignoring such warnings.

_Fix_: Added a check against config.jinja_ignore_templating before raising, so templating errors are only fatal when the user has not configured them to be ignored.

### SQLTemplaterError does not accept line_no / line_pos (python_templater.py)

jinja_templater.py constructs SQLTemplaterError with line_no=1, line_pos=1 arguments, but `SQLTemplaterError.__init__` only accepted message, causing a `TypeError`.

_Fix_: Added optional line_no and line_pos parameters to `SQLTemplaterError.__init__`.