### PR TITLE
fix: allow KEY as identifier in SQLite dialect

### DIFF
--- a/crates/lib-dialects/src/sqlite_keywords.rs
+++ b/crates/lib-dialects/src/sqlite_keywords.rs
@@ -82,7 +82,6 @@ pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
     "IS",
     "ISNULL",
     "JOIN",
-    "KEY",
     "LAST",
     "LEFT",
     "LIKE",
@@ -153,6 +152,7 @@ pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
 ];
 
 pub(crate) const UNRESERVED_KEYWORDS: &[&str] = &[
+    "KEY",
     "INT",
     "INTEGER",
     "TINYINT",

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_table_keyword_identifier.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_table_keyword_identifier.sql
@@ -1,0 +1,3 @@
+CREATE TABLE properties (
+    key TEXT
+);

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_table_keyword_identifier.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_table_keyword_identifier.yml
@@ -1,0 +1,15 @@
+file:
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: properties
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - naked_identifier: key
+        - data_type:
+          - data_type_identifier: TEXT
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
## Summary
- SQLite [allows keywords as identifiers](https://sqlite.org/quirks.html#keywords_can_often_be_used_as_identifiers) where unambiguous. Sqruff classified `KEY` as a reserved keyword, so `CREATE TABLE properties (key TEXT);` failed to parse (the LT01/LT02 lint hits in the issue are downstream of the parse failure).
- SQLFluff treats `KEY` as unreserved in its sqlite dialect — moving `KEY` from `RESERVED_KEYWORDS` to `UNRESERVED_KEYWORDS` in `crates/lib-dialects/src/sqlite_keywords.rs` to match.
- Added a parser fixture (`create_table_keyword_identifier.sql/.yml`) to lock in the fix.

Note: this is a targeted fix for the reported example. Sqruff's sqlite keyword classification has a few other small drifts vs. sqlfluff (`ACTION`, `TIES`, missing `STORED`), and the broader "any keyword in unambiguous position" quirk isn't fully implemented in either tool — those are left for follow-up.

Fixes #2601

## Test plan
- [x] `cargo run -- lint --dialect=sqlite` on the issue's example now parses cleanly (no LT01/LT02)
- [x] `cargo test --test dialects sqlite` passes
- [x] `cargo test --test dialect_configs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)