### PR TITLE
fix: LT01 alias alignment with multi-byte literals (#2605)

### DIFF
--- a/crates/lib-core/src/parser/markers.rs
+++ b/crates/lib-core/src/parser/markers.rs
@@ -175,9 +175,9 @@ impl PositionMarker {
         (
             line_no + (split.len() - 1),
             if split.len() == 1 {
-                line_pos + raw.len()
+                line_pos + raw.chars().count()
             } else {
-                split.last().unwrap().len() + 1
+                split.last().unwrap().chars().count() + 1
             },
         )
     }
@@ -339,6 +339,12 @@ mod tests {
                 raw: "\nfoo".to_string(),
                 start: 2..2,
                 end: (3, 4),
+            },
+            // Multi-byte UTF-8: positions count characters, not bytes.
+            Test {
+                raw: "'наличные'".to_string(),
+                start: 0..0,
+                end: (0, 10),
             },
         ];
 

--- a/crates/lib-core/src/templaters.rs
+++ b/crates/lib-core/src/templaters.rs
@@ -309,26 +309,42 @@ impl TemplatedFileInner {
 
     /// Get the line number and position of a point in the source file.
     /// Args:
-    ///  - char_pos: The character position in the relevant file.
+    ///  - char_pos: The byte position in the relevant file.
     ///  - source: Are we checking the source file (as opposed to the templated
     ///    file)
     ///
-    /// Returns: line_number, line_position
+    /// Returns: line_number, line_position (1-indexed; the position is counted
+    /// in Unicode characters, not bytes, to match SQLFluff's behavior).
     pub fn get_line_pos_of_char_pos(&self, char_pos: usize, source: bool) -> (usize, usize) {
-        let ref_str = if source {
-            &self.source_newlines
+        let (ref_str, file_str) = if source {
+            (&self.source_newlines, self.source_str.as_str())
         } else {
-            &self.templated_newlines
+            (
+                &self.templated_newlines,
+                self.templated_str.as_deref().unwrap_or(&self.source_str),
+            )
         };
         match ref_str.binary_search(&char_pos) {
             Ok(nl_idx) | Err(nl_idx) => {
-                if nl_idx > 0 {
-                    (nl_idx + 1, char_pos - ref_str[nl_idx - 1])
+                let line_start_byte = if nl_idx > 0 {
+                    ref_str[nl_idx - 1] + 1
                 } else {
-                    // NB: line_pos is char_pos + 1 because character position is 0-indexed,
-                    // but the line position is 1-indexed.
-                    (1, char_pos + 1)
-                }
+                    0
+                };
+                let line_no = nl_idx + 1;
+                // Count chars between the line start and char_pos. If char_pos is
+                // out of bounds (e.g. for positions in templated content that don't
+                // map cleanly to the underlying string), fall back to byte
+                // arithmetic for that segment.
+                let line_pos = if char_pos <= file_str.len()
+                    && file_str.is_char_boundary(line_start_byte)
+                    && file_str.is_char_boundary(char_pos)
+                {
+                    file_str[line_start_byte..char_pos].chars().count() + 1
+                } else {
+                    char_pos.saturating_sub(line_start_byte) + 1
+                };
+                (line_no, line_pos)
             }
         }
     }

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -366,6 +366,34 @@ test_align_multiple_all:
           spacing_before: align
           align_within: create_table_statement
 
+test_align_alias_multibyte_literals:
+  # https://github.com/quarylabs/sqruff/issues/2605
+  # Multi-byte UTF-8 literals (Cyrillic) should be padded by character
+  # width, not byte length. Previously this overshot the column and
+  # produced misaligned output that sqruff lint would keep flagging.
+  fail_str: |
+    SELECT
+        'cash' AS a,
+        'наличные' AS b,
+        'нет' AS c,
+        'plain' AS d
+    FROM t
+  fix_str: |
+    SELECT
+        'cash'     AS a,
+        'наличные' AS b,
+        'нет'      AS c,
+        'plain'    AS d
+    FROM t
+  configs:
+    core:
+      dialect: mysql
+    layout:
+      type:
+        alias_expression:
+          spacing_before: align
+          align_within: select_clause
+
 test_align_multiple_operators:
   # Unrealistic but more stretching with several lines which
   # have different numbers of the same target.


### PR DESCRIPTION
## Summary
- `infer_next_position` advanced column positions by **byte** length; for multi-byte UTF-8 literals (Cyrillic, CJK, …) this overshot the column, so the LT01 fix engine produced visibly misaligned padding (issue #2605).
- `get_line_pos_of_char_pos` also returned byte-indexed columns, so segment `working_line_pos` disagreed with `infer_next_position` after the fix — `sqruff lint` kept flagging fixed files.
- Both helpers now count Unicode characters, matching SQLFluff's `len(str)` semantics. Falls back to byte arithmetic when the requested position is outside the underlying string (templated content can pin positions beyond the source slice).
- Added a regression case to `test_markers_infer_next_position` covering a Cyrillic literal.

## Test plan
- [x] `bazelisk test //...` (all 31 tests pass)
- [x] Reproduced issue #2605 locally; after fix, the file matches the expected SQLFluff output and a subsequent `sqruff lint` is clean:

```sql
SELECT
    'cash'     AS a,
    'наличные' AS b,
    'нет'      AS c,
    'plain'    AS d
FROM t
```

Fixes #2605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)