### PR TITLE
chore: bump react-resizable-panels from 3.0.6 to 4.0.16

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -23,7 +23,7 @@
     "monaco-editor": "^0.55.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-resizable-panels": "^3.0.6"
+    "react-resizable-panels": "^4.0.16"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/playground/src/Editor/Editor.tsx
+++ b/playground/src/Editor/Editor.tsx
@@ -1,5 +1,5 @@
 import { useDeferredValue, useMemo, useState } from "react";
-import { Panel, PanelGroup } from "react-resizable-panels";
+import { Group, Panel } from "react-resizable-panels";
 import { Linter, Result } from "../pkg";
 import PrimarySideBar from "./PrimarySideBar";
 import { HorizontalResizeHandle } from "./ResizeHandle";
@@ -74,9 +74,9 @@ export default function Editor({
 
   return (
     <>
-      <PanelGroup direction="horizontal" autoSaveId="main">
+      <Group orientation="horizontal" className="flex-1">
         <PrimarySideBar onSelectTool={(tool) => setTab(tool)} selected={tab} />
-        <Panel id="main" order={0} className="my-2" minSize={10}>
+        <Panel id="main" className="my-2" minSize={10}>
           <SourceEditor
             visible={tab === "Source"}
             source={source.sqlSource}
@@ -92,12 +92,7 @@ export default function Editor({
         {secondaryTool != null && (
           <>
             <HorizontalResizeHandle />
-            <Panel
-              id="secondary-panel"
-              order={1}
-              className={"my-2"}
-              minSize={10}
-            >
+            <Panel id="secondary-panel" className={"my-2"} minSize={10}>
               <SecondaryPanel
                 tool={secondaryTool}
                 result={checkResult.secondary}
@@ -109,7 +104,7 @@ export default function Editor({
           selected={secondaryTool}
           onSelected={handleSecondaryToolSelected}
         />
-      </PanelGroup>
+      </Group>
     </>
   );
 }

--- a/playground/src/Editor/ResizeHandle.tsx
+++ b/playground/src/Editor/ResizeHandle.tsx
@@ -1,13 +1,13 @@
-import { PanelResizeHandle } from "react-resizable-panels";
+import { Separator } from "react-resizable-panels";
 
 export function HorizontalResizeHandle() {
   return (
-    <PanelResizeHandle className="cursor-ew-resize w-0.5 bg-gray-200 hover:bg-gray-300"></PanelResizeHandle>
+    <Separator className="cursor-ew-resize w-0.5 bg-gray-200 hover:bg-gray-300"></Separator>
   );
 }
 
 export function VerticalResizeHandle() {
   return (
-    <PanelResizeHandle className="cursor-eh-resize h-0.5 bg-gray-200 hover:bg-gray-300"></PanelResizeHandle>
+    <Separator className="cursor-eh-resize h-0.5 bg-gray-200 hover:bg-gray-300"></Separator>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-resizable-panels:
-        specifier: ^3.0.6
-        version: 3.0.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^4.0.16
+        version: 4.0.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -3302,11 +3302,11 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-resizable-panels@3.0.6:
-    resolution: {integrity: sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==}
+  react-resizable-panels@4.0.16:
+    resolution: {integrity: sha512-xhU02yogk3lD1f353oNAGm419pov2imCtxegHJN6FclXtGrfLglkl/h4K/RBHBxsGtR79lp12Zmz3Bbi/BoHpA==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -7507,7 +7507,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-resizable-panels@3.0.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-resizable-panels@4.0.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)


### PR DESCRIPTION
## Summary
- Bumps `react-resizable-panels` from 3.0.6 to 4.0.16 in the playground
- Migrates to the v4 API: `PanelGroup` → `Group` (with `orientation` instead of `direction`), `PanelResizeHandle` → `Separator`, and drops the now-unused `order` prop on `Panel`
- Adds `flex-1` to the `Group` element — v4's `Group` no longer auto-fills its parent the way v3's `PanelGroup` did, which collapsed both editor panels to 0 width

Supersedes #2104 (the Dependabot PR), which couldn't merge without the API migration.

Note: v3's `autoSaveId="main"` (which persisted the split layout to localStorage) is dropped — v4 replaces it with a `useDefaultLayout` hook. Not restored here to keep the change minimal; happy to add follow-up if we want it back.

## Test plan
- [x] `bazelisk test //:rustfmt_check //:clippy_check //:prettier_check //:ruff_check //:cargo_machete //:cargo_check //:cargo_clippy //:cargo_fmt_check //:cargo_test //:codegen_docs_check //playground:typescript_check //playground:playwright_test //playground:eslint_check` — all 12 green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)