### PR TITLE
docs: reference existing Zed extension in community projects

### DIFF
--- a/docs/community/community-projects.md
+++ b/docs/community/community-projects.md
@@ -3,3 +3,4 @@
 If your project is not listed here and you would like it to be, please feel free to create a PR.
 
 - [`cargo-sqruff`](https://github.com/gvozdvmozgu/cargo-sqruff): Use `cargo-sqruff`, implemented as a dylint plugin, to lint SQL queries that run through `sqlx`.
+- [`sqruff-zed`](https://github.com/gvozdvmozgu/sqruff-zed): A Zed editor extension that integrates `sqruff` as a language server, available in the Zed extension store.


### PR DESCRIPTION
## Summary
Adds a reference to the existing, already-published [`sqruff-zed`](https://github.com/gvozdvmozgu/sqruff-zed) Zed editor extension on the community projects page.

This surfaces the Zed extension for discoverability, since it was previously undocumented. It's an alternative to merging #2611, which adds a new in-repo Zed extension that is largely redundant with the published one (per the [collaborator comment there](https://github.com/quarylabs/sqruff/pull/2611#issuecomment-4529728086)).

## Changes
- Add `sqruff-zed` to `docs/community/community-projects.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_013xt3gnsG3Y4iLYzH2uCkcc)_