### PR TITLE
fix(duckdb): trailing comma bug

### DIFF
--- a/crates/lib-dialects/src/duckdb.rs
+++ b/crates/lib-dialects/src/duckdb.rs
@@ -296,7 +296,7 @@ pub fn raw_dialect() -> Dialect {
     );
 
     // DuckDB allows trailing commas in function argument lists, e.g.
-    // `struct_pack(a := 1, b := 2,)`. Mirror the ansi `FunctionContentsGrammar`
+    // `list_value(1, 2, 3,)`. Mirror the ansi `FunctionContentsGrammar`
     // but enable `allow_trailing` on the inner argument `Delimited`.
     duckdb_dialect.replace_grammar(
         "FunctionContentsGrammar",

--- a/crates/lib-dialects/src/duckdb.rs
+++ b/crates/lib-dialects/src/duckdb.rs
@@ -3,7 +3,7 @@ use sqruff_lib_core::dialects::init::DialectKind;
 use sqruff_lib_core::dialects::syntax::SyntaxKind;
 use sqruff_lib_core::helpers::{Config, ToMatchable};
 use sqruff_lib_core::parser::grammar::Ref;
-use sqruff_lib_core::parser::grammar::anyof::one_of;
+use sqruff_lib_core::parser::grammar::anyof::{AnyNumberOf, one_of};
 use sqruff_lib_core::parser::grammar::delimited::Delimited;
 use sqruff_lib_core::parser::grammar::sequence::{Bracketed, Sequence};
 use sqruff_lib_core::parser::lexer::Matcher;
@@ -291,6 +291,83 @@ pub fn raw_dialect() -> Dialect {
             .to_matchable(),
             Ref::new("ColonSegment").to_matchable(),
             Ref::new("BaseExpressionElementGrammar").to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    // DuckDB allows trailing commas in function argument lists, e.g.
+    // `struct_pack(a := 1, b := 2,)`. Mirror the ansi `FunctionContentsGrammar`
+    // but enable `allow_trailing` on the inner argument `Delimited`.
+    duckdb_dialect.replace_grammar(
+        "FunctionContentsGrammar",
+        AnyNumberOf::new(vec![
+            Ref::new("ExpressionSegment").to_matchable(),
+            Sequence::new(vec![
+                Ref::new("ExpressionSegment").to_matchable(),
+                Ref::keyword("AS").to_matchable(),
+                Ref::new("DatatypeSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::new("TrimParametersGrammar").to_matchable(),
+                Ref::new("ExpressionSegment")
+                    .optional()
+                    .exclude(Ref::keyword("FROM"))
+                    .to_matchable(),
+                Ref::keyword("FROM").to_matchable(),
+                Ref::new("ExpressionSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                one_of(vec![
+                    Ref::new("DatetimeUnitSegment").to_matchable(),
+                    Ref::new("ExpressionSegment").to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::keyword("FROM").to_matchable(),
+                Ref::new("ExpressionSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("DISTINCT").optional().to_matchable(),
+                one_of(vec![
+                    Ref::new("StarSegment").to_matchable(),
+                    Delimited::new(vec![
+                        Ref::new("FunctionContentsExpressionGrammar").to_matchable(),
+                    ])
+                    .config(|config| {
+                        config.allow_trailing = true;
+                    })
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Ref::new("AggregateOrderByClause").to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("SEPARATOR").to_matchable(),
+                Ref::new("LiteralGrammar").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                one_of(vec![
+                    Ref::new("QuotedLiteralSegment").to_matchable(),
+                    Ref::new("SingleIdentifierGrammar").to_matchable(),
+                    Ref::new("ColumnReferenceSegment").to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::keyword("IN").to_matchable(),
+                one_of(vec![
+                    Ref::new("QuotedLiteralSegment").to_matchable(),
+                    Ref::new("SingleIdentifierGrammar").to_matchable(),
+                    Ref::new("ColumnReferenceSegment").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Ref::new("IgnoreRespectNullsGrammar").to_matchable(),
+            Ref::new("IndexColumnDefinitionSegment").to_matchable(),
+            Ref::new("EmptyStructLiteralSegment").to_matchable(),
         ])
         .to_matchable(),
     );

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/function_trailing_comma.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/function_trailing_comma.sql
@@ -1,0 +1,4 @@
+SELECT
+    list_value(1, 2, 3,) AS nums,
+    COALESCE(a, b, c,) AS first_non_null
+FROM my_table;

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/function_trailing_comma.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/function_trailing_comma.yml
@@ -1,0 +1,57 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: list_value
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '1'
+              - comma: ','
+              - expression:
+                - numeric_literal: '2'
+              - comma: ','
+              - expression:
+                - numeric_literal: '3'
+              - comma: ','
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: nums
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: COALESCE
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: a
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: b
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: c
+              - comma: ','
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: first_non_null
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: my_table
+- statement_terminator: ;


### PR DESCRIPTION
## Summary
  
  DuckDB's [Friendly SQL][friendly-sql] allows trailing commas in many places, including inside function argument lists (e.g. `list_value(1, 2, 3,)`). sqruff's `duckdb` dialect was inheriting the ansi `FunctionContentsGrammar`
  unchanged, which doesn't set `allow_trailing` on the argument `Delimited` — so a stray trailing comma marks the entire function call as `Unparsable`. LT01 then no longer recognizes the function name and inserts a space before `(`,
  with the failure cascading into any nested calls.
  
  ## Changes

  - `crates/lib-dialects/src/duckdb.rs` — override `FunctionContentsGrammar`, mirroring the ansi grammar but setting `allow_trailing = true` on the inner argument `Delimited`. The two existing `allow_trailing` overrides for `ORDER BY`
  and `GROUP BY` already follow the same pattern.
  - `crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/function_trailing_comma.{sql,yml}` — new fixture parsing `list_value(1, 2, 3,)` and `COALESCE(a, b, c,)` cleanly (no `unparsable` nodes; trailing `comma` token preserved
  before `end_bracket`).

  ## Test plan
  
  - [x] `cargo test -p sqruff-lib-dialects` passes
  - [x] New fixture parses without `unparsable` segments
  - [x] No regressions across other dialect fixtures

  [friendly-sql]: https://duckdb.org/docs/current/sql/dialect/friendly_sql
