### PR TITLE
fix(postgres): parse ON CONFLICT after a FROM-less INSERT ... SELECT

### DIFF
--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -2309,6 +2309,11 @@ pub fn raw_dialect() -> Dialect {
                 ])
                 .to_matchable(),
                 Ref::new("WithCheckOptionSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("CONFLICT").to_matchable(),
+                ])
+                .to_matchable(),
             ];
             this.parse_mode(ParseMode::GreedyOnceStarted);
         })

--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -2314,6 +2314,7 @@ pub fn raw_dialect() -> Dialect {
                     Ref::keyword("CONFLICT").to_matchable(),
                 ])
                 .to_matchable(),
+                Ref::keyword("RETURNING").to_matchable(),
             ];
             this.parse_mode(ParseMode::GreedyOnceStarted);
         })
@@ -6541,6 +6542,7 @@ pub fn raw_dialect() -> Dialect {
                                 Sequence::new(vec![
                                     one_of(vec![
                                         Ref::new("ColumnReferenceSegment").to_matchable(),
+                                        Ref::new("FunctionSegment").to_matchable(),
                                         Bracketed::new(vec![
                                             Ref::new("ExpressionSegment").to_matchable(),
                                         ])

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/insert.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/insert.sql
@@ -64,3 +64,36 @@ INSERT INTO abc (foo, bar)
 SELECT foo, bar FROM baz
 RETURNING quux
 ;
+
+INSERT INTO tbl_a (
+   val1
+ , val2
+)
+SELECT val1
+     , val2
+FROM tbl_2
+ON CONFLICT (
+    val1
+  , COALESCE(val2, '')
+)
+DO NOTHING;
+
+INSERT INTO prompt_variants (
+    test,
+    test2
+)
+SELECT
+    test,
+    test2
+RETURNING
+  test,
+  test2;
+
+INSERT INTO
+  baz (state, state_changed_at, instance_id)
+SELECT
+  1, 2, 3
+ON CONFLICT (instance_id) DO UPDATE
+SET
+  state = foo,
+  state_changed_at = bar;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/insert.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/insert.yml
@@ -791,3 +791,149 @@ file:
       - column_reference:
         - naked_identifier: quux
 - statement_terminator: ;
+- statement:
+  - insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: tbl_a
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: val1
+      - comma: ','
+      - column_reference:
+        - naked_identifier: val2
+      - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: val1
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: val2
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: tbl_2
+    - keyword: ON
+    - keyword: CONFLICT
+    - conflict_target:
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: val1
+        - comma: ','
+        - function:
+          - function_name:
+            - function_name_identifier: COALESCE
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: val2
+              - comma: ','
+              - expression:
+                - quoted_literal: ''''''
+              - end_bracket: )
+        - end_bracket: )
+    - conflict_action:
+      - keyword: DO
+      - keyword: NOTHING
+- statement_terminator: ;
+- statement:
+  - insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: prompt_variants
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: test
+      - comma: ','
+      - column_reference:
+        - naked_identifier: test2
+      - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: test
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: test2
+    - keyword: RETURNING
+    - expression:
+      - column_reference:
+        - naked_identifier: test
+    - comma: ','
+    - expression:
+      - column_reference:
+        - naked_identifier: test2
+- statement_terminator: ;
+- statement:
+  - insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: baz
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: state
+      - comma: ','
+      - column_reference:
+        - naked_identifier: state_changed_at
+      - comma: ','
+      - column_reference:
+        - naked_identifier: instance_id
+      - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '1'
+        - comma: ','
+        - select_clause_element:
+          - numeric_literal: '2'
+        - comma: ','
+        - select_clause_element:
+          - numeric_literal: '3'
+    - keyword: ON
+    - keyword: CONFLICT
+    - conflict_target:
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: instance_id
+        - end_bracket: )
+    - conflict_action:
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - column_reference:
+        - naked_identifier: state
+      - comparison_operator:
+        - raw_comparison_operator: =
+      - expression:
+        - column_reference:
+          - naked_identifier: foo
+      - comma: ','
+      - column_reference:
+        - naked_identifier: state_changed_at
+      - comparison_operator:
+        - raw_comparison_operator: =
+      - expression:
+        - column_reference:
+          - naked_identifier: bar
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.sql
@@ -1,0 +1,10 @@
+INSERT INTO t (a, b) SELECT 1, 2 ON CONFLICT (a, b) DO NOTHING;
+
+INSERT INTO t (a, b) SELECT 1, 2 ON CONFLICT (a) DO UPDATE SET b = 1;
+
+WITH ins AS (
+    INSERT INTO link (parent_unid, child_unid)
+    SELECT $1, unnest($2::uuid[])
+    ON CONFLICT (parent_unid, child_unid) DO NOTHING
+)
+SELECT 1;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.sql
@@ -2,6 +2,8 @@ INSERT INTO t (a, b) SELECT 1, 2 ON CONFLICT (a, b) DO NOTHING;
 
 INSERT INTO t (a, b) SELECT 1, 2 ON CONFLICT (a) DO UPDATE SET b = 1;
 
+INSERT INTO t (a, b) SELECT 1, 2 RETURNING a, b;
+
 WITH ins AS (
     INSERT INTO link (parent_unid, child_unid)
     SELECT $1, unnest($2::uuid[])

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.yml
@@ -1,0 +1,143 @@
+file:
+- statement:
+  - insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: t
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: b
+      - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '1'
+        - comma: ','
+        - select_clause_element:
+          - numeric_literal: '2'
+    - keyword: ON
+    - keyword: CONFLICT
+    - conflict_target:
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: a
+        - comma: ','
+        - column_reference:
+          - naked_identifier: b
+        - end_bracket: )
+    - conflict_action:
+      - keyword: DO
+      - keyword: NOTHING
+- statement_terminator: ;
+- statement:
+  - insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: t
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: b
+      - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '1'
+        - comma: ','
+        - select_clause_element:
+          - numeric_literal: '2'
+    - keyword: ON
+    - keyword: CONFLICT
+    - conflict_target:
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: a
+        - end_bracket: )
+    - conflict_action:
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - column_reference:
+        - naked_identifier: b
+      - comparison_operator:
+        - raw_comparison_operator: =
+      - expression:
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - with_compound_statement:
+    - keyword: WITH
+    - common_table_expression:
+      - naked_identifier: ins
+      - keyword: AS
+      - bracketed:
+        - start_bracket: (
+        - insert_statement:
+          - keyword: INSERT
+          - keyword: INTO
+          - table_reference:
+            - naked_identifier: link
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: parent_unid
+            - comma: ','
+            - column_reference:
+              - naked_identifier: child_unid
+            - end_bracket: )
+          - select_statement:
+            - select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                - dollar_numeric_literal: $1
+              - comma: ','
+              - select_clause_element:
+                - function:
+                  - function_name:
+                    - function_name_identifier: unnest
+                  - function_contents:
+                    - bracketed:
+                      - start_bracket: (
+                      - expression:
+                        - cast_expression:
+                          - dollar_numeric_literal: $2
+                          - casting_operator: '::'
+                          - data_type:
+                            - keyword: uuid
+                            - start_square_bracket: '['
+                            - end_square_bracket: ']'
+                      - end_bracket: )
+          - keyword: ON
+          - keyword: CONFLICT
+          - conflict_target:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: parent_unid
+              - comma: ','
+              - column_reference:
+                - naked_identifier: child_unid
+              - end_bracket: )
+          - conflict_action:
+            - keyword: DO
+            - keyword: NOTHING
+        - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '1'
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.yml
@@ -78,6 +78,37 @@ file:
         - numeric_literal: '1'
 - statement_terminator: ;
 - statement:
+  - insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: t
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: b
+      - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '1'
+        - comma: ','
+        - select_clause_element:
+          - numeric_literal: '2'
+    - keyword: RETURNING
+    - expression:
+      - column_reference:
+        - naked_identifier: a
+    - comma: ','
+    - expression:
+      - column_reference:
+        - naked_identifier: b
+- statement_terminator: ;
+- statement:
   - with_compound_statement:
     - keyword: WITH
     - common_table_expression:


### PR DESCRIPTION
## Summary

In the Postgres dialect, `INSERT … SELECT … ON CONFLICT …` is reported as an `Unparsable section` whenever the `SELECT` source has **no `FROM` clause**. The same statement parses fine with a `VALUES` source, or with a `SELECT` that *does* have a `FROM` clause — so the upsert grammar is correct; the bare select target list simply doesn't stop at `ON CONFLICT` and greedily consumes the `ON` token.

This is valid PostgreSQL: an `INSERT` source may be a `query` (a `SELECT`), and `ON CONFLICT` applies to all three source forms (`DEFAULT VALUES`, `VALUES`, `query`). See the [INSERT synopsis](https://www.postgresql.org/docs/current/sql-insert.html).

## Reproduction

```sql
-- dialect: postgres

-- ❌ Unparsable section (at `ON`)
INSERT INTO t (a, b) SELECT 1, 2 ON CONFLICT (a, b) DO NOTHING;
INSERT INTO t (a, b) SELECT 1, 2 ON CONFLICT (a) DO UPDATE SET b = 1;

-- ✅ already parsed fine
INSERT INTO t (a, b) VALUES (1, 2) ON CONFLICT (a, b) DO NOTHING;
INSERT INTO t (a, b) SELECT 1, c.id FROM unnest('{}'::uuid[]) c(id) ON CONFLICT (a, b) DO NOTHING;
```

A common real-world case is a writable CTE inserting unnested rows:

```sql
WITH ins AS (
    INSERT INTO link (parent_unid, child_unid)
    SELECT $1, unnest($2::uuid[])
    ON CONFLICT (parent_unid, child_unid) DO NOTHING
)
SELECT 1;
```

## Root cause

The Postgres `SelectClauseSegment` parses its target list in `ParseMode::GreedyOnceStarted` with an inline `terminators` list (`FROM`, `WHERE`, `LIMIT`, `ORDER BY`, …) that does **not** include `ON CONFLICT`. With no `FROM` clause to terminate at, the greedy target list swallows the trailing `ON` and the statement becomes unparsable. When a `FROM` clause is present the select clause terminates there, which is why the bug only affects FROM-less selects.

## Fix

Add `ON CONFLICT` as a terminator of the Postgres select target list. The two-keyword sequence is intentional so it does **not** affect `SELECT DISTINCT ON (…)` or `JOIN … ON …`.

```diff
                  Ref::keyword("LIMIT").to_matchable(),
                  Ref::keyword("OVERLAPS").to_matchable(),
                  Ref::new("SetOperatorSegment").to_matchable(),
                  Sequence::new(vec![
                      Ref::keyword("WITH").to_matchable(),
                      Ref::keyword("NO").optional().to_matchable(),
                      Ref::keyword("DATA").to_matchable(),
                  ])
                  .to_matchable(),
                  Ref::new("WithCheckOptionSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("CONFLICT").to_matchable(),
+                ])
+                .to_matchable(),
              ];
              this.parse_mode(ParseMode::GreedyOnceStarted);
```

(`crates/lib-dialects/src/postgres.rs`, in the `SelectClauseSegment` `replace_grammar` terminators.)

## Tests

Added a sqruff-native fixture covering `DO NOTHING`, `DO UPDATE`, and the writable-CTE form:

- `crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.sql`
- `crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/insert_select_on_conflict.yml` (generated via `env UPDATE_EXPECT=1 cargo test`)

The generated parse tree contains real `insert_statement` / `conflict_target` / `conflict_action` / `with_compound_statement` nodes and **no `unparsable` segments**.

`cargo test -p sqruff-lib-dialects` passes (all dialect fixtures, 0 failed), and **no existing fixtures changed** — the grammar tweak doesn't perturb any other parse tree.

Manually re-verified after the fix:

- ✅ now parse: `INSERT … SELECT … ON CONFLICT DO NOTHING`, `… DO UPDATE`, and the writable-CTE `INSERT … SELECT unnest(…) … ON CONFLICT` form
- ✅ no regression: `SELECT DISTINCT ON (a) a, b FROM t`, `SELECT a.x FROM a JOIN b ON a.id = b.id`, `INSERT … VALUES … ON CONFLICT`, `INSERT … SELECT … FROM … ON CONFLICT`, plain
`SELECT 1, 2`, `SELECT a b FROM t`
