### PR TITLE
fix(ST03): exempt data-modifying CTEs from unused_cte

### DIFF
--- a/crates/lib/src/rules/structure/st03.rs
+++ b/crates/lib/src/rules/structure/st03.rs
@@ -89,6 +89,32 @@ FROM cte1
         for name in remaining_ctes.values() {
             let tmp = RefCell::borrow(&query.inner);
             let cte = RefCell::borrow(&tmp.ctes[name].inner);
+
+            // Data-modifying CTEs (INSERT/UPDATE/DELETE/MERGE) are executed for
+            // their side effects in dialects like Postgres, whether or not the
+            // primary query references them, so they are never "unused".
+            // Mirrors SQLFluff ST03's `_is_data_modifying_cte` exemption.
+            if let Some(def) = &cte.cte_definition_segment {
+                let is_data_modifying = !def
+                    .recursive_crawl(
+                        const {
+                            &SyntaxSet::new(&[
+                                SyntaxKind::InsertStatement,
+                                SyntaxKind::UpdateStatement,
+                                SyntaxKind::DeleteStatement,
+                                SyntaxKind::MergeStatement,
+                            ])
+                        },
+                        true,
+                        const { &SyntaxSet::EMPTY },
+                        true,
+                    )
+                    .is_empty();
+                if is_data_modifying {
+                    continue;
+                }
+            }
+
             result.push(LintResult::new(
                 cte.cte_name_segment.clone(),
                 Vec::new(),

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST03.yml
@@ -402,3 +402,72 @@ test_fail_nested_query_in_from_clause:
         *
     FROM
         stage
+
+test_pass_postgres_data_modifying_delete_cte:
+  # Data-modifying CTEs run for their side effects regardless of whether the
+  # primary query references them, so an unreferenced DELETE CTE is not unused.
+  pass_str: |
+    WITH deleted_children AS (
+        DELETE FROM child
+        WHERE parent_id = 1
+    )
+    DELETE FROM parent
+    WHERE id = 1
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_postgres_data_modifying_multiple_delete_ctes:
+  pass_str: |
+    WITH deleted_a AS (
+        DELETE FROM child_a
+        WHERE parent_id = 1
+    ),
+    deleted_b AS (
+        DELETE FROM child_b
+        WHERE parent_id = 1
+    )
+    DELETE FROM parent
+    WHERE id = 1
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_postgres_data_modifying_insert_cte:
+  pass_str: |
+    WITH archived AS (
+        INSERT INTO archive (id)
+        SELECT id FROM staging
+    )
+    DELETE FROM staging
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_postgres_data_modifying_update_cte:
+  pass_str: |
+    WITH bumped AS (
+        UPDATE counter
+        SET value = value + 1
+    )
+    SELECT 1
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_postgres_unused_select_cte_alongside_data_modifying:
+  # A genuinely unused SELECT CTE must still be flagged even when a sibling
+  # data-modifying CTE is exempt.
+  fail_str: |
+    WITH deleted_children AS (
+        DELETE FROM child
+        WHERE parent_id = 1
+    ),
+    unused AS (
+        SELECT id FROM other
+    )
+    DELETE FROM parent
+    WHERE id = 1
+  configs:
+    core:
+      dialect: postgres

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST03.yml
@@ -471,3 +471,27 @@ test_fail_postgres_unused_select_cte_alongside_data_modifying:
   configs:
     core:
       dialect: postgres
+
+test_fail_postgres_dml_ctes_not_flagged:
+  desc: Data-modifying CTEs should not be flagged in Postgres; only SELECT CTE is unused.
+  fail_str: |
+    WITH
+    cte_select AS (
+        SELECT foo FROM t
+    ),
+    cte_insert AS (
+        INSERT INTO t (foo) VALUES (1)
+    ),
+    cte_update AS (
+        UPDATE t SET foo = 2
+    ),
+    cte_delete AS (
+        DELETE FROM t
+    )
+
+    SELECT 1
+  configs:
+    core:
+      dialect: postgres
+  line_numbers:
+    - 2

--- a/crates/lib/tests/rules.rs
+++ b/crates/lib/tests/rules.rs
@@ -37,6 +37,7 @@ struct TestCase {
     #[serde(rename = "$key$")]
     name: String,
     ignored: Option<String>,
+    line_numbers: Option<Vec<usize>>,
     #[serde(flatten)]
     kind: TestCaseKind,
     #[serde(default)]
@@ -245,7 +246,19 @@ dialect = {dialect}
             }
             TestCaseKind::Fail { fail_str } => {
                 let file = state.linter.lint_string_wrapped(&fail_str, false).unwrap();
-                assert_ne!(&file.violations(), &[])
+                assert_ne!(&file.violations(), &[]);
+                if let Some(expected_line_numbers) = &case.line_numbers {
+                    let actual_line_numbers = file
+                        .violations()
+                        .iter()
+                        .map(|violation| violation.line_no)
+                        .collect::<Vec<_>>();
+                    assert_eq!(
+                        &actual_line_numbers, expected_line_numbers,
+                        "Unexpected violation lines in case '{}'",
+                        case.name
+                    );
+                }
             }
             TestCaseKind::Fix { fail_str, fix_str } => {
                 assert_ne!(
@@ -254,6 +267,18 @@ dialect = {dialect}
                 );
 
                 let linted = state.linter.lint_string_wrapped(&fail_str, true).unwrap();
+                if let Some(expected_line_numbers) = &case.line_numbers {
+                    let actual_line_numbers = linted
+                        .violations()
+                        .iter()
+                        .map(|violation| violation.line_no)
+                        .collect::<Vec<_>>();
+                    assert_eq!(
+                        &actual_line_numbers, expected_line_numbers,
+                        "Unexpected violation lines in case '{}'",
+                        case.name
+                    );
+                }
                 let actual = linted.fix_string();
 
                 pretty_assertions::assert_eq!(actual, fix_str);


### PR DESCRIPTION
## What

ST03 (`structure.unused_cte`) reported a violation for any CTE whose name never appears in a `TableReference`, even when the CTE body is a data-modifying statement (`INSERT` / `UPDATE` / `DELETE` / `MERGE`). In Postgres a data-modifying CTE is executed for its side effects whether or not the primary query references it, so such a CTE is never "unused".

This is a false positive on a common, idiomatic pattern: running several deletes/inserts as one atomic statement / round-trip.

```sql
WITH deleted_a AS (
    DELETE FROM child_a WHERE parent_id = 1
),
deleted_b AS (
    DELETE FROM child_b WHERE parent_id = 1
)
DELETE FROM parent WHERE id = 1
```

Before this change all three of these CTEs were reported as unused, and there is no inline way to silence it.

## Why

SQLFluff (which sqruff tracks for rule behaviour) already exempts these via `_is_data_modifying_cte`. sqruff simply never ported that exemption. This PR brings sqruff in line.

## How

In `RuleST03::eval`, before pushing a violation for a remaining CTE, inspect its `cte_definition_segment` with `recursive_crawl` for `InsertStatement` / `UpdateStatement` / `DeleteStatement` / `MergeStatement`. If found, skip the CTE.

## Tests

Added Postgres fixtures to `ST03.yml`:

- `test_pass_postgres_data_modifying_delete_cte` — single unreferenced DELETE CTE passes.
- `test_pass_postgres_data_modifying_multiple_delete_ctes` — several unreferenced DELETE CTEs in one statement pass.
- `test_pass_postgres_data_modifying_insert_cte` — unreferenced INSERT CTE passes.
- `test_pass_postgres_data_modifying_update_cte` — unreferenced UPDATE CTE passes.
- `test_fail_postgres_unused_select_cte_alongside_data_modifying` — a genuinely unused SELECT CTE next to an exempt data-modifying CTE is still flagged, so the exemption does not over-reach.

All existing ST03 cases continue to pass.
