### PR TITLE
feat(postgres): add identity/schema niladic functions to bare_functions

### DIFF
--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -412,6 +412,13 @@ pub fn raw_dialect() -> Dialect {
         "CURRENT_DATE",
         "LOCALTIME",
         "LOCALTIMESTAMP",
+        "CURRENT_CATALOG",
+        "CURRENT_ROLE",
+        "CURRENT_SCHEMA",
+        "CURRENT_USER",
+        "SESSION_USER",
+        "SYSTEM_USER",
+        "USER",
     ]);
 
     // Postgres doesn't have a dateadd function

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_policy.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_policy.yml
@@ -106,8 +106,7 @@ file:
           - naked_identifier: username
         - comparison_operator:
           - raw_comparison_operator: =
-        - column_reference:
-          - naked_identifier: current_user
+        - bare_function: current_user
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -128,11 +127,9 @@ file:
           - naked_identifier: sales_rep
         - comparison_operator:
           - raw_comparison_operator: =
-        - column_reference:
-          - naked_identifier: CURRENT_USER
+        - bare_function: CURRENT_USER
         - binary_operator: AND
-        - column_reference:
-          - naked_identifier: CURRENT_USER
+        - bare_function: CURRENT_USER
         - keyword: IN
         - bracketed:
           - start_bracket: (

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/bare_functions.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/bare_functions.sql
@@ -3,5 +3,11 @@ SELECT
   current_timestamp AS col2,
   current_time as col3,
   localtime as col4,
-  localtimestamp as col5
+  localtimestamp as col5,
+  current_role as col6,
+  current_schema as col7,
+  current_user as col8,
+  session_user as col9,
+  system_user as col10,
+  user as col11
 ;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/bare_functions.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/bare_functions.yml
@@ -32,4 +32,40 @@ file:
         - alias_expression:
           - keyword: as
           - naked_identifier: col5
+      - comma: ','
+      - select_clause_element:
+        - bare_function: current_role
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col6
+      - comma: ','
+      - select_clause_element:
+        - bare_function: current_schema
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col7
+      - comma: ','
+      - select_clause_element:
+        - bare_function: current_user
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col8
+      - comma: ','
+      - select_clause_element:
+        - bare_function: session_user
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col9
+      - comma: ','
+      - select_clause_element:
+        - bare_function: system_user
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col10
+      - comma: ','
+      - select_clause_element:
+        - bare_function: user
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col11
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_policy.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_policy.yml
@@ -144,7 +144,6 @@ file:
           - naked_identifier: username
         - comparison_operator:
           - raw_comparison_operator: =
-        - column_reference:
-          - naked_identifier: current_user
+        - bare_function: current_user
       - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
## Summary

PostgreSQL allows a set of SQL-standard *niladic* functions to be called **without** parentheses — `current_schema`, `current_user`, `current_catalog`, `current_role`, `session_user`, `system_user`, and `user`. sqruff's `postgres` dialect only registered the date/time niladic functions (`current_timestamp`, `current_time`, `current_date`, `localtime`, `localtimestamp`) in its `bare_functions` set, so the identity/schema ones were not recognised as functions in general expression positions.

As a result, perfectly valid PostgreSQL was flagged as an unparsable section whenever one of these appeared as a function argument or in a multi-item select list:

```sql
-- flagged "Unparsable section" before this change
SELECT some_function(current_schema, 'x');
SELECT current_user, session_user;
```

while the parenthesised form parsed fine:

```sql
SELECT current_schema();   -- ok (parsed as an ordinary function call)
```

This change adds the missing niladic functions to the `postgres` `bare_functions` set so they parse correctly everywhere.

## Motivation / reference

The fix aligns the `postgres` dialect with SQLFluff, which lists all of these in its postgres `bare_functions` set:

- SQLFluff `dialect_postgres.py` — `bare_functions` update: [src/sqlfluff/dialects/dialect_postgres.py](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/dialects/dialect_postgres.py)

PostgreSQL documentation confirms these have special syntactic status and are spelled without trailing parentheses:

> `current_catalog`, `current_role`, `current_schema`, `current_user`, `session_user`, and `user` have special syntactic status in SQL: they must be called without trailing parentheses. (In PostgreSQL, parentheses can optionally be used with `current_schema`, but not with the others.)

— [PostgreSQL: System Information Functions](https://www.postgresql.org/docs/current/functions-info.html)

## Changes

- **`crates/lib-dialects/src/postgres.rs`** — extend the `postgres` `bare_functions` set with `CURRENT_CATALOG`, `CURRENT_ROLE`, `CURRENT_SCHEMA`, `CURRENT_USER`, `SESSION_USER`, `SYSTEM_USER`, and `USER`.
- **`crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/bare_functions.sql`** — extend the fixture to cover the newly supported functions (mirrors the equivalent SQLFluff fixture).
- **`.../postgres/sqlfluff/bare_functions.yml`** — regenerated expected parse tree; the new columns now parse as `bare_function`.
- **`.../postgres/sqlfluff/alter_policy.yml`** and **`.../postgres/sqlfluff/create_policy.yml`** — regenerated. These existing fixtures use `current_user` inside policy `USING (...)` clauses; it was previously parsed as `column_reference → naked_identifier` and is now correctly classified as `bare_function`. No SQL fixture input changed — only the expected trees, reflecting the improved parse.

## Testing

- Regenerated fixtures with `env UPDATE_EXPECT=1 cargo test -p sqruff-lib-dialects --test dialects`.
- Full dialect parse suite passes (`cargo test -p sqruff-lib-dialects --test dialects`), including all postgres fixtures — no unparsable segments and no regressions (notably, adding `user` did not break `FROM user` / `user.col` parses across the existing fixture corpus).
- Verified end-to-end that previously-unparsable expressions such as `SELECT f(current_schema, ...)` and `SELECT current_user, session_user` now lint without any unparsable-section findings.
