### PR TITLE
Add docstring to public module 'functional'

### DIFF
--- a/crates/lib/src/utils.rs
+++ b/crates/lib/src/utils.rs
@@ -1,3 +1,4 @@
+/// Provides functional programming utilities and helper functions for the linter.
 pub mod functional;
 pub mod identifers;
 pub mod reflow;


### PR DESCRIPTION
## Problem Background
The public module `functional` in `crates/lib/src/utils.rs` was missing documentation comments, which reduced code readability and maintainability. For an open-source project like sqruff, clear documentation is essential for contributors and users to understand module purposes.

## Changes Made
Added a docstring to the `pub mod functional;` declaration to describe it as providing functional programming utilities and helper functions for the linter. This aligns with the project's existing code style and improves documentation coverage.

## Verification
- Verified by running `cargo build` and `cargo test` to ensure no compilation errors or test failures.
- The change is purely documentation and does not alter functionality, API, or behavior, ensuring backward compatibility.