### PR TITLE
fix(ci): expose hermetic pytest venv site-packages via PYTHONPATH

### DIFF
--- a/.hacking/scripts/pytest_uv.sh
+++ b/.hacking/scripts/pytest_uv.sh
@@ -20,6 +20,13 @@ export PROJECT_ROOT="$WORKDIR"
 
 PYTHON_BIN="$VENV_DIR/bin/python3"
 
+# The hermetic venv is a copied python-build-standalone install. After Bazel
+# relocates it into the runfiles tree, the interpreter can fail to resolve its
+# own site-packages, surfacing as "No module named pytest". Point PYTHONPATH at
+# the venv's site-packages explicitly so the installed deps are importable.
+SITE_PACKAGES="$(echo "$VENV_DIR"/lib/python*/site-packages)"
+export PYTHONPATH="$SITE_PACKAGES${PYTHONPATH:+:$PYTHONPATH}"
+
 # Run pytest using the cached venv's Python
 echo "Running pytest..."
 "$PYTHON_BIN" -m pytest


### PR DESCRIPTION
## Problem
The Bazel `//:pytest_py{310,311,312,313}` targets (the **Bazel Lint** check) fail intermittently with:

```
Running pytest...
.../pytest_pyXXX_venv_venv/bin/python3: No module named pytest
```

All four fail instantly (before any test runs). It looks flaky but is **deterministically broken**: in the last ~30 PR-Checks runs only **one** passed — the only run whose log shows the bazel disk cache was *restored* (`Failed to restore disk-PR Checks cache` on every failing run). So:

- **cache hit** → a previously-good venv is reused → pass
- **cache miss** → venv is rebuilt → the rebuilt venv's interpreter can't see its own `site-packages` → fail

## Root cause
The hermetic venv (`uv_python_venv` in `cargo_build.bzl`) is a copied python-build-standalone install. The deps (incl. `pytest` from the `test` extra) install correctly into `lib/python*/site-packages`, but after Bazel relocates the venv into the runfiles tree the standalone interpreter can fail to resolve its prefix, so `python3 -m pytest` can't import them.

## Fix
Point `PYTHONPATH` at the venv's `site-packages` explicitly in `.hacking/scripts/pytest_uv.sh`, so the installed deps are importable regardless of how the relocated interpreter resolves its prefix. Minimal, revertible, touches only the test runner.

> Note: verified locally that `--extra test` installs `pytest` into `lib/.../site-packages`; the exact relocation behaviour is Linux/Bazel-specific and couldn't be reproduced on macOS without Bazel, so this PR is primarily to confirm the fix against CI.