### PR TITLE
chore: add validation for SQLFluff SHA advancement in prs

### DIFF
--- a/.github/workflows/sqlfluff-sha-advance.yml
+++ b/.github/workflows/sqlfluff-sha-advance.yml
@@ -1,0 +1,28 @@
+on:
+  pull_request:
+    paths:
+      - .sqlfluff-sha
+name: SQLFluff SHA Advance Check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  sqlfluff-sha-advance:
+    name: Validate .sqlfluff-sha advances one commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Validate SHA advance
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # The SHA on the PR's base branch (before this change).
+          OLD=$(git show "${BASE_SHA}:.sqlfluff-sha" | tr -d '[:space:]')
+          # The SHA proposed by this PR.
+          NEW=$(tr -d '[:space:]' < .sqlfluff-sha)
+          echo "Base .sqlfluff-sha: ${OLD}"
+          echo "PR   .sqlfluff-sha: ${NEW}"
+          ./.hacking/scripts/check_sqlfluff_sha_advance.sh "$OLD" "$NEW"

--- a/.hacking/scripts/check_sqlfluff_sha_advance.sh
+++ b/.hacking/scripts/check_sqlfluff_sha_advance.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Verifies that an update to .sqlfluff-sha moves the SHA exactly one commit
+# forward along sqlfluff/sqlfluff's main branch (first-parent only, matching
+# the "next-sqlfluff" porting workflow).
+#
+# Usage: check_sqlfluff_sha_advance.sh <old-sha> <new-sha>
+#
+# Exits 0 when <new-sha> is the immediate next first-parent commit after
+# <old-sha> on main, and non-zero otherwise (e.g. it skips commits, goes
+# backwards, or either SHA is unknown to sqlfluff).
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <old-sha> <new-sha>" >&2
+    exit 2
+fi
+
+OLD=$(echo "$1" | tr -d '[:space:]')
+NEW=$(echo "$2" | tr -d '[:space:]')
+
+for var in OLD NEW; do
+    value="${!var}"
+    if ! echo "$value" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "ERROR: ${var} is not a valid 40-character hex SHA: '${value}'" >&2
+        exit 1
+    fi
+done
+
+if [ "$OLD" = "$NEW" ]; then
+    echo "OK: .sqlfluff-sha is unchanged (${NEW}); nothing to validate"
+    exit 0
+fi
+
+# Obtain a clone of sqlfluff with full history. Reuse an existing checkout at
+# ./sqlfluff if present (e.g. local runs), otherwise clone into a temp dir.
+if [ -d "sqlfluff/.git" ]; then
+    REPO="sqlfluff"
+    git -C "$REPO" fetch --quiet origin main
+else
+    REPO=$(mktemp -d)
+    trap 'rm -rf "$REPO"' EXIT
+    git clone --quiet https://github.com/sqlfluff/sqlfluff.git "$REPO"
+fi
+
+# Determine main's ref (origin/main when fetched, main otherwise).
+if git -C "$REPO" rev-parse --verify --quiet origin/main >/dev/null; then
+    MAIN="origin/main"
+else
+    MAIN="main"
+fi
+
+if ! git -C "$REPO" cat-file -e "${OLD}^{commit}" 2>/dev/null; then
+    echo "ERROR: old SHA ${OLD} does not exist in sqlfluff/sqlfluff" >&2
+    exit 1
+fi
+
+if ! git -C "$REPO" cat-file -e "${NEW}^{commit}" 2>/dev/null; then
+    echo "ERROR: new SHA ${NEW} does not exist in sqlfluff/sqlfluff" >&2
+    exit 1
+fi
+
+# The next commit after OLD on main, following first parents only (so merge
+# commits are followed but side-branch commits are skipped). This mirrors
+# `git log --reverse --first-parent <SHA>..main | head -n 1` from the
+# next-sqlfluff workflow.
+#
+# pipefail is disabled for this pipeline only: `head -n 1` closes the pipe
+# early, sending SIGPIPE to `git log` (exit 141), which is expected here.
+set +o pipefail
+EXPECTED=$(git -C "$REPO" log --reverse --first-parent --format="%H" "${OLD}..${MAIN}" | head -n 1)
+set -o pipefail
+
+if [ -z "$EXPECTED" ]; then
+    echo "ERROR: old SHA ${OLD} is already at (or ahead of) main; there is no next commit to advance to." >&2
+    echo "  Is ${OLD} on main's first-parent history?" >&2
+    exit 1
+fi
+
+if [ "$NEW" = "$EXPECTED" ]; then
+    echo "OK: .sqlfluff-sha advances exactly one commit on main:"
+    echo "  ${OLD} -> ${NEW}"
+    exit 0
+fi
+
+echo "ERROR: .sqlfluff-sha must advance exactly one commit forward on sqlfluff main." >&2
+echo "  old:      ${OLD}" >&2
+echo "  new:      ${NEW}" >&2
+echo "  expected: ${EXPECTED}" >&2
+echo "" >&2
+
+# Provide a helpful diagnosis of why it failed.
+if git -C "$REPO" merge-base --is-ancestor "$NEW" "$OLD" 2>/dev/null; then
+    echo "  The new SHA is an ancestor of the old SHA (the update goes backwards)." >&2
+elif git -C "$REPO" merge-base --is-ancestor "$OLD" "$NEW" 2>/dev/null; then
+    COUNT=$(git -C "$REPO" rev-list --count --first-parent "${OLD}..${NEW}" 2>/dev/null || echo "?")
+    echo "  The new SHA is ${COUNT} first-parent commits ahead of the old SHA; only one step is allowed." >&2
+    echo "  Set .sqlfluff-sha to ${EXPECTED} to advance a single commit." >&2
+else
+    echo "  The new SHA is not on main's first-parent history after the old SHA." >&2
+    echo "  Set .sqlfluff-sha to ${EXPECTED} to advance a single commit." >&2
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

This PR adds automated validation to ensure that updates to the `.sqlfluff-sha` file advance the SQLFluff dependency by exactly one commit on the main branch, following the first-parent history (matching the "next-sqlfluff" porting workflow).

## Changes

- **`.hacking/scripts/check_sqlfluff_sha_advance.sh`**: New bash script that validates SHA advancement
  - Verifies that a new SHA is the immediate next first-parent commit after the old SHA on sqlfluff/sqlfluff's main branch
  - Handles both local and temporary clones of the sqlfluff repository
  - Provides detailed error messages diagnosing why an update failed (backwards movement, skipped commits, off-branch commits)
  - Exits with status 0 for valid advances or unchanged SHAs, non-zero otherwise

- **`.github/workflows/sqlfluff-sha-advance.yml`**: New GitHub Actions workflow
  - Triggers on pull requests that modify `.sqlfluff-sha`
  - Extracts the old SHA from the base branch and new SHA from the PR
  - Runs the validation script to ensure the advance is exactly one commit

## Implementation Details

The validation script uses `git log --reverse --first-parent` to find the expected next commit, mirroring the workflow used in the "next-sqlfluff" porting process. This ensures that only linear, single-step advances along the main branch's first-parent history are allowed, preventing accidental skips or merges of multiple commits.

https://claude.ai/code/session_013tCSUXps5wAHzsa2f24GEE