### PR TITLE
Enable CI workflow for merge queue events

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "main"
   pull_request:
-  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "main"
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,6 +13,7 @@ on:
     tags:
       - "*"
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Add support for GitHub merge queue events in the Python CI workflow, allowing automated checks to run when pull requests are queued for merging.

## Changes
- Added `merge_group` trigger to the CI workflow alongside existing `pull_request` and `push` triggers

## Details
This enables the CI pipeline to validate code changes when they enter the merge queue, ensuring that queued PRs meet all quality standards before being merged. This is particularly useful for repositories using GitHub's merge queue feature to manage concurrent merges and prevent integration issues.

https://claude.ai/code/session_01G49NjjpGZL87aKYwcWDC5a