### PR TITLE
ci: Optimize Bazel cache strategy for main branch pushes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
   merge_group:
+  push:
+    branches: ["main"]
 name: PR Checks
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,6 +48,9 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
+          # Only master (push to main) runs update the cache; PRs and merge
+          # group jobs restore it read-only to avoid polluting/contending.
+          cache-save: ${{ github.event_name == 'push' }}
       - name: Build all targets
         run: bazelisk build --config=ci //...
       - name: Run all tests
@@ -60,6 +65,9 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
+          # Only master (push to main) runs update the cache; PRs and merge
+          # group jobs restore it read-only to avoid polluting/contending.
+          cache-save: ${{ github.event_name == 'push' }}
       - name: Update lockfile
         run: bazelisk mod deps --lockfile_mode=update
       - name: Check lockfile is up to date
@@ -71,6 +79,9 @@ jobs:
           fi
   build-binaries:
     name: Build binaries for all platforms
+    # Master pushes only need to refresh the Bazel cache; skip the binary
+    # matrix there since it does not use that cache.
+    if: github.event_name != 'push'
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Optimize the CI workflow to improve cache efficiency by distinguishing between main branch pushes and pull requests. Main branch pushes now update the shared Bazel cache, while PRs and merge group jobs use it read-only to avoid cache pollution and contention.

## Key Changes
- Added `push` trigger for the `main` branch to the workflow
- Configured `cache-save` parameter to only update cache on main branch pushes (`github.event_name == 'push'`)
- Applied cache-save configuration to both the main build job and the lockfile update job
- Skipped the binary build matrix for main branch pushes since it doesn't benefit from the Bazel cache refresh

## Implementation Details
- The `cache-save` parameter is set conditionally: `${{ github.event_name == 'push' }}` ensures only push events (main branch) update the cache
- PR and merge group jobs will restore the cache in read-only mode, preventing cache contention and pollution
- The `build-binaries` job is now skipped for push events with `if: github.event_name != 'push'` since the binary matrix doesn't use the Bazel cache
- Added clarifying comments explaining the cache strategy for maintainability

https://claude.ai/code/session_012gB6eb7F7XnD55JKPfKri5