### PR TITLE
ci: add bazel test verifying uv.lock is up to date

### DIFF
--- a/.hacking/scripts/uv_lock_check.sh
+++ b/.hacking/scripts/uv_lock_check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verify that uv.lock is up to date with pyproject.toml.
+#
+# Runs `uv lock --locked`, which asserts the lockfile would remain unchanged and
+# fails when uv.lock no longer matches pyproject.toml (for example after a
+# dependency bump that forgot to regenerate the lockfile).
+#
+# The project files are copied into a writable temp directory because Bazel
+# runfiles are read-only symlinks and uv wants a writable tree.
+set -euo pipefail
+
+UV_BIN="$RUNFILES_DIR/$UV"
+
+# Create a temp directory for uv cache and a writable workspace.
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Copy only the files that determine the resolved lockfile (use -L to follow
+# symlinks from runfiles).
+cp -L "$RUNFILES_DIR/_main/pyproject.toml" "$WORKDIR/"
+cp -L "$RUNFILES_DIR/_main/uv.lock" "$WORKDIR/"
+
+cd "$WORKDIR"
+
+# Set uv directories to temp locations to avoid read-only filesystem errors in
+# the sandbox.
+export UV_CACHE_DIR="$WORKDIR/.uv-cache"
+export UV_PYTHON_INSTALL_DIR="$WORKDIR/.uv-python"
+
+if ! "$UV_BIN" lock --locked; then
+    echo ""
+    echo "ERROR: uv.lock is out of date with pyproject.toml."
+    echo "Run 'uv lock' and commit the updated uv.lock."
+    exit 1
+fi
+
+echo "OK: uv.lock is up to date"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -174,6 +174,22 @@ sh_test(
     tags = ["requires-network"],
 )
 
+# Check that uv.lock is up to date with pyproject.toml
+sh_test(
+    name = "uv_lock_check",
+    size = "small",
+    srcs = [".hacking/scripts/uv_lock_check.sh"],
+    data = [
+        "pyproject.toml",
+        "uv.lock",
+        "@uv//:uv",
+    ],
+    env = {
+        "UV": "$(rlocationpath @uv//:uv)",
+    },
+    tags = ["requires-network"],
+)
+
 # Python ruff check - format and lint
 sh_test(
     name = "ruff_check",


### PR DESCRIPTION
Mirror the existing `pnpm_lock_check` by adding a `uv_lock_check` Bazel test that keeps `uv.lock` in sync with `pyproject.toml`.

## What's added

- **`.hacking/scripts/uv_lock_check.sh`** — copies `pyproject.toml` and `uv.lock` into a writable temp dir (Bazel runfiles are read-only symlinks) and runs `uv lock --locked`, which asserts the lockfile would remain unchanged and fails if it's stale, printing a clear "run `uv lock`" message.
- **`BUILD.bazel`** — a new `uv_lock_check` `sh_test` target placed next to the other lock/lint checks. It reuses the already-vendored `@uv//:uv` tool and is tagged `requires-network` like `pnpm_lock_check`.

## Verification

Bazel isn't available in the dev environment, so the script logic was validated directly with `uv`:
- In-sync lock → `uv lock --locked` exits 0
- Out-of-date lock (simulated by bumping a constraint) → exits 1 with `The lockfile at uv.lock needs to be updated`

https://claude.ai/code/session_012yLqBEgqqRhJXE9TvfeJFo

---
_Generated by [Claude Code](https://claude.ai/code/session_012yLqBEgqqRhJXE9TvfeJFo)_