### PR TITLE
feat: add semantic token highlighting to the playground and VS Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sqruff-lib",
+ "sqruff-lib-core",
  "wasm-bindgen",
 ]
 
@@ -1673,6 +1674,7 @@ dependencies = [
  "serde_yaml",
  "sqruff-lib",
  "sqruff-lib-core",
+ "sqruff-lsp",
  "wasm-bindgen",
 ]
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2633,7 +2633,7 @@
           "REPO_MAPPING:rules_rust+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
           "REPO_MAPPING:rules_rust+,rules_rust rules_rust+",
-          "FILE:@@//Cargo.lock 150b02313c2eb533fb325c71cb33d7641df46bbea77f3568d3f225ea4a82061f",
+          "FILE:@@//Cargo.lock 005369c6144d4199b9442ff543dbe99fff9cb4be15fd2df7c4c655481425afae",
           "FILE:@@//Cargo.toml 8fbb9d9ad8bd861d59b023729fe884865690704382155a6e2bf0cb01c97c6c16",
           "FILE:@@//crates/cli/Cargo.toml 69789bdb7a1ada8e986afa284402986c9a6e64055744c4af2f209941e1525a27",
           "FILE:@@//crates/cli-lib/Cargo.toml da8973e7cfcfbbddcf7e1f506ae090a6ec3bdc7a8a9631950549a094ed8e5746",
@@ -2641,9 +2641,9 @@
           "FILE:@@//crates/lib/Cargo.toml b1bd368c680328446744ab3c1469e16499d4adc1487feb9e996ea8d08179aa84",
           "FILE:@@//crates/lib-core/Cargo.toml dac961d744f0406b0cb2b12a40e979fde8e768ff584cfbac63edff3bce8af0a4",
           "FILE:@@//crates/lib-dialects/Cargo.toml 65f14eef0fd90412fdb48dbcd7ad7060aec5891bad7cd200d8e241ff19d544a9",
-          "FILE:@@//crates/lib-wasm/Cargo.toml dcafc87d240f6567664317913da006a8e786a195a1c0d7e93263b6ef7fa10874",
+          "FILE:@@//crates/lib-wasm/Cargo.toml b30295c41e74e6f1cb5b93e9eb1d4c542578c0c53dd3afededd0edc93a804b8f",
           "FILE:@@//crates/lineage/Cargo.toml d26ee434e736f8dd310937ca3dad5a5090d207ecf3e553dd627b4bdc576d82bb",
-          "FILE:@@//crates/lsp/Cargo.toml 778e793284fd699e5170e18ecd56ab246a82ae6dfd3229a36cdd10a83fced904",
+          "FILE:@@//crates/lsp/Cargo.toml e4ecdd69a8c609d6cbb24a500ba0d07c39d73f0d56a77cdf5e3f2ff7000f3373",
           "FILE:@@//crates/sqlinference/Cargo.toml 019ec868ee5b87094d99a7cc47cd51950d75095d7025e05133ed1b69dbea0809"
         ],
         "generatedRepoSpecs": {

--- a/crates/lib-wasm/BUILD.bazel
+++ b/crates/lib-wasm/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
     deps = all_crate_deps(normal = True) + [
         "//crates/lib:sqruff-lib",
         "//crates/lib-core:sqruff-lib-core",
+        "//crates/lsp:sqruff-lsp",
         "//crates/lineage:lineage",
     ],
 )
@@ -34,6 +35,7 @@ rust_shared_library(
     deps = crate_deps(WASM_CRATE_NAMES) + [
         "//crates/lib:sqruff-lib-for-wasm",
         "//crates/lib-core:sqruff-lib-core",
+        "//crates/lsp:sqruff-lsp-for-wasm",
         "//crates/lineage:lineage",
     ],
 )

--- a/crates/lib-wasm/Cargo.toml
+++ b/crates/lib-wasm/Cargo.toml
@@ -18,5 +18,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 sqruff-lib.workspace = true
 sqruff-lib-core = { workspace = true, features = ["stringify"] }
+sqruff-lsp.workspace = true
 wasm-bindgen = "0.2"
 lineage = { path = "../lineage" }

--- a/crates/lib-wasm/src/lib.rs
+++ b/crates/lib-wasm/src/lib.rs
@@ -158,6 +158,22 @@ impl Linter {
             secondary,
         }
     }
+
+    #[wasm_bindgen(js_name = semanticTokens)]
+    pub fn semantic_tokens(&self, sql: &str) -> Vec<u32> {
+        sqruff_lsp::semantic::semantic_tokens(&self.base, sql, None)
+            .into_iter()
+            .flat_map(|token| {
+                [
+                    token.delta_line,
+                    token.delta_start,
+                    token.length,
+                    token.token_type,
+                    token.token_modifiers_bitset,
+                ]
+            })
+            .collect()
+    }
 }
 
 fn print_tree(

--- a/crates/lsp/BUILD.bazel
+++ b/crates/lsp/BUILD.bazel
@@ -8,6 +8,7 @@ rust_library(
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True) + [
+        "//crates/lib-core:sqruff-lib-core",
         "//crates/lib:sqruff-lib",
     ],
 )
@@ -24,6 +25,17 @@ LSP_WASM_CRATE_NAMES = [
     "wasm-bindgen",
 ]
 
+rust_library(
+    name = "sqruff-lsp-for-wasm",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "sqruff_lsp",
+    visibility = ["//visibility:public"],
+    deps = crate_deps(LSP_WASM_CRATE_NAMES) + [
+        "//crates/lib-core:sqruff-lib-core",
+        "//crates/lib:sqruff-lib-for-wasm",
+    ],
+)
+
 # WASM shared library target for wasm-bindgen
 # This builds the crate as a cdylib for wasm32-unknown-unknown
 # Dependencies are automatically cross-compiled for WASM due to platform attribute
@@ -34,6 +46,7 @@ rust_shared_library(
     platform = "@rules_rust//rust/platform:wasm",
     visibility = ["//visibility:public"],
     deps = crate_deps(LSP_WASM_CRATE_NAMES) + [
+        "//crates/lib-core:sqruff-lib-core",
         "//crates/lib:sqruff-lib-for-wasm",
     ],
 )

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -22,4 +22,5 @@ lsp-types = "0.97"
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.150"
 sqruff-lib.workspace = true
+sqruff-lib-core.workspace = true
 wasm-bindgen.workspace = true

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod semantic;
+
 use std::path::{Path, PathBuf};
 
 use hashbrown::HashMap;
@@ -6,13 +8,15 @@ use lsp_types::notification::{
     DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, DidSaveTextDocument,
     Notification, PublishDiagnostics,
 };
-use lsp_types::request::{Formatting, Request as _};
+use lsp_types::request::{Formatting, Request as _, SemanticTokensFullRequest};
 use lsp_types::{
     Diagnostic, DiagnosticSeverity, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams,
     InitializeParams, InitializeResult, NumberOrString, OneOf, Position, PublishDiagnosticsParams,
-    Registration, ServerCapabilities, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentSyncCapability, TextDocumentSyncKind, Uri, VersionedTextDocumentIdentifier,
+    Registration, SemanticTokens, SemanticTokensOptions, SemanticTokensParams,
+    SemanticTokensResult, SemanticTokensServerCapabilities, ServerCapabilities,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentSyncCapability, TextDocumentSyncKind,
+    Uri, VersionedTextDocumentIdentifier,
 };
 use serde_json::Value;
 #[cfg(not(target_arch = "wasm32"))]
@@ -47,6 +51,14 @@ fn server_initialize_result() -> InitializeResult {
         capabilities: ServerCapabilities {
             text_document_sync: TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL).into(),
             document_formatting_provider: OneOf::Left(true).into(),
+            semantic_tokens_provider: Some(
+                SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
+                    legend: semantic::legend(),
+                    full: Some(lsp_types::SemanticTokensFullOptions::Bool(true)),
+                    range: Some(false),
+                    ..Default::default()
+                }),
+            ),
             ..Default::default()
         },
         server_info: None,
@@ -115,6 +127,13 @@ impl Wasm {
     pub fn format_source(&mut self, source: &str) -> String {
         self.0.format_source(source, None)
     }
+
+    #[wasm_bindgen(js_name = semanticTokens)]
+    pub fn semantic_tokens(&self, uri: JsValue) -> JsValue {
+        let uri = serde_wasm_bindgen::from_value(uri).unwrap();
+        let tokens = self.0.semantic_tokens(&uri);
+        serde_wasm_bindgen::to_value(&tokens).unwrap()
+    }
 }
 
 impl LanguageServer {
@@ -162,7 +181,33 @@ impl LanguageServer {
                 let edits = self.format(uri);
                 Some(Response::new_ok(id, edits))
             }
+            SemanticTokensFullRequest::METHOD => {
+                let SemanticTokensParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    ..
+                } = serde_json::from_value(params).unwrap();
+
+                let tokens = self.semantic_tokens(&uri);
+                Some(Response::new_ok(id, SemanticTokensResult::Tokens(tokens)))
+            }
             _ => None,
+        }
+    }
+
+    fn semantic_tokens(&self, uri: &Uri) -> SemanticTokens {
+        if self.is_ignored(uri) {
+            return SemanticTokens::default();
+        }
+
+        let Some(text) = self.documents.get(uri) else {
+            return SemanticTokens::default();
+        };
+
+        let filename = file_uri_to_path(uri).map(|path| path.to_string_lossy().to_string());
+        let data = semantic::semantic_tokens(&self.linter, text, filename);
+        SemanticTokens {
+            result_id: None,
+            data,
         }
     }
 

--- a/crates/lsp/src/semantic.rs
+++ b/crates/lsp/src/semantic.rs
@@ -1,0 +1,1437 @@
+//! Builds LSP semantic tokens from sqruff's concrete syntax tree.
+//!
+//! sqruff's parser already disambiguates the grammar while parsing, emitting a
+//! distinct [`SyntaxKind`] for each leaf segment (keyword, literal, operator,
+//! function name, ...). That means highlighting reduces to a flat
+//! `SyntaxKind -> Highlight` lookup ([`classify`]) over the leaf segments, with
+//! no separate query language. Kinds without syntax highlighting are explicitly
+//! listed so new dialect kinds require a deliberate classification.
+
+use lsp_types::{SemanticToken, SemanticTokenType, SemanticTokensLegend};
+use sqruff_lib::core::linter::core::Linter;
+use sqruff_lib_core::dialects::syntax::SyntaxKind;
+use sqruff_lib_core::parser::segments::{ErasedSegment, Tables};
+
+/// The highlight buckets we collapse the ~1000 [`SyntaxKind`] variants into.
+///
+/// The order of this list defines the indices used on the wire, and it must
+/// stay in sync with [`legend`] (which maps each bucket to an LSP
+/// [`SemanticTokenType`]).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Highlight {
+    Keyword,
+    String,
+    Number,
+    Comment,
+    Operator,
+    Function,
+    Type,
+    Variable,
+    Parameter,
+    Property,
+    Macro,
+}
+
+/// All highlight buckets, in wire order.
+const HIGHLIGHTS: [Highlight; 11] = [
+    Highlight::Keyword,
+    Highlight::String,
+    Highlight::Number,
+    Highlight::Comment,
+    Highlight::Operator,
+    Highlight::Function,
+    Highlight::Type,
+    Highlight::Variable,
+    Highlight::Parameter,
+    Highlight::Property,
+    Highlight::Macro,
+];
+
+impl Highlight {
+    /// Index of this bucket in the legend / on the wire.
+    fn token_type(self) -> u32 {
+        HIGHLIGHTS.iter().position(|&h| h == self).unwrap() as u32
+    }
+
+    fn semantic_token_type(self) -> SemanticTokenType {
+        match self {
+            Highlight::Keyword => SemanticTokenType::KEYWORD,
+            Highlight::String => SemanticTokenType::STRING,
+            Highlight::Number => SemanticTokenType::NUMBER,
+            Highlight::Comment => SemanticTokenType::COMMENT,
+            Highlight::Operator => SemanticTokenType::OPERATOR,
+            Highlight::Function => SemanticTokenType::FUNCTION,
+            Highlight::Type => SemanticTokenType::TYPE,
+            Highlight::Variable => SemanticTokenType::VARIABLE,
+            Highlight::Parameter => SemanticTokenType::PARAMETER,
+            Highlight::Property => SemanticTokenType::PROPERTY,
+            Highlight::Macro => SemanticTokenType::MACRO,
+        }
+    }
+}
+
+/// The legend advertised at initialize time. The token type ordering matches
+/// [`HIGHLIGHTS`]; we expose no modifiers yet.
+pub fn legend() -> SemanticTokensLegend {
+    SemanticTokensLegend {
+        token_types: HIGHLIGHTS.iter().map(|h| h.semantic_token_type()).collect(),
+        token_modifiers: Vec::new(),
+    }
+}
+
+/// Map a leaf [`SyntaxKind`] to a highlight bucket, or `None` to leave it
+/// un-highlighted.
+pub(crate) fn classify(kind: SyntaxKind) -> Option<Highlight> {
+    use SyntaxKind::*;
+
+    let highlight = match kind {
+        // Keywords and keyword-like constants.
+        Keyword | BareFunction | NullLiteral | BooleanLiteral | DatePart | DatePartWeek => {
+            Highlight::Keyword
+        }
+
+        // Numeric literals.
+        NumericLiteral | IntegerLiteral | DollarNumericLiteral | BitStringLiteral => {
+            Highlight::Number
+        }
+
+        // String / quoted literals.
+        QuotedLiteral
+        | RawQuotedLiteral
+        | BytesQuotedLiteral
+        | SignedQuotedLiteral
+        | DateConstructorLiteral
+        | FileLiteral
+        | DollarLiteral
+        | AtSignLiteral => Highlight::String,
+
+        // Comments.
+        Comment | InlineComment | BlockComment => Highlight::Comment,
+
+        // Operators.
+        BinaryOperator
+        | ComparisonOperator
+        | RawComparisonOperator
+        | AssignmentOperator
+        | CastingOperator
+        | LikeOperator
+        | WalrusOperator
+        | JsonOperator
+        | ParameterAssigner
+        | FunctionAssigner
+        | SignIndicator
+        | Plus
+        | Minus
+        | Divide
+        | DoubleDivide
+        | Star
+        | Percent
+        | Caret
+        | Tilde
+        | Ampersand
+        | Pipe
+        | VerticalBar
+        | Not
+        | RightArrow
+        | Lambda
+        | Dash => Highlight::Operator,
+
+        // Function / procedure names.
+        FunctionNameIdentifier | ProcedureNameIdentifier | SystemFunctionName => {
+            Highlight::Function
+        }
+
+        // Type names.
+        DataTypeIdentifier | PrimitiveType => Highlight::Type,
+
+        // Parameters.
+        Parameter => Highlight::Parameter,
+
+        // Variables / placeholders.
+        Variable | TsqlVariable | Placeholder => Highlight::Macro,
+
+        // Property-style identifiers.
+        PropertyNameIdentifier | PropertiesNakedIdentifier | WidgetNameIdentifier => {
+            Highlight::Property
+        }
+
+        // Generic identifiers (column / table / object references resolve to
+        // these at the leaf level).
+        NakedIdentifier | QuotedIdentifier | Identifier | NakedIdentifierAll => Highlight::Variable,
+
+        // Explicitly un-highlighted (punctuation, brackets, structural nodes,
+        // meta, and grammar-only nodes). New SyntaxKind variants must be added
+        // here or classified above.
+        Unparsable
+        | File
+        | ColumnReference
+        | ObjectReference
+        | Expression
+        | WildcardIdentifier
+        | Function
+        | FunctionContents
+        | HavingClause
+        | PathSegment
+        | LimitClause
+        | CubeRollupClause
+        | GroupingSetsClause
+        | GroupingExpressionList
+        | SetClause
+        | FetchClause
+        | FunctionDefinition
+        | AlterSequenceOptionsSegment
+        | RoleReference
+        | TablespaceReference
+        | ExtensionReference
+        | TagReference
+        | ColumnDefinition
+        | ColumnConstraintSegment
+        | CommentClause
+        | TableEndClause
+        | MergeMatch
+        | MergeWhenNotMatchedClause
+        | MergeInsertClause
+        | MergeUpdateClause
+        | MergeDeleteClause
+        | MergeTreeOrderByClause
+        | SetClauseList
+        | TableReference
+        | GroupbyClause
+        | FrameClause
+        | WithCompoundStatement
+        | CommonTableExpression
+        | CTEColumnList
+        | ReferencedColumnList
+        | TriggerReference
+        | TableConstraint
+        | JoinOnCondition
+        | DatabaseReference
+        | CollationReference
+        | OverClause
+        | NamedWindow
+        | WindowSpecification
+        | PartitionbyClause
+        | JoinClause
+        | DropTriggerStatement
+        | SampleExpression
+        | TableExpression
+        | CreateTriggerStatement
+        | DropModelStatement
+        | DescribeStatement
+        | UseStatement
+        | ExplainStatement
+        | CreateSequenceStatement
+        | CreateSequenceOptionsSegment
+        | AlterSequenceStatement
+        | DropSequenceStatement
+        | DropCastStatement
+        | CreateFunctionStatement
+        | DropFunctionStatement
+        | CreateModelStatement
+        | CreateViewStatement
+        | DeleteStatement
+        | UpdateStatement
+        | CreateCastStatement
+        | CreateRoleStatement
+        | DropRoleStatement
+        | AlterTableStatement
+        | CreateSchemaStatement
+        | SetSchemaStatement
+        | DropSchemaStatement
+        | DropTypeStatement
+        | CreateDatabaseStatement
+        | DropDatabaseStatement
+        | FunctionParameterList
+        | CreateIndexStatement
+        | DropIndexStatement
+        | CreateTableStatement
+        | AccessStatement
+        | InsertStatement
+        | TransactionStatement
+        | DropTableStatement
+        | DropViewStatement
+        | CreateUserStatement
+        | DropUserStatement
+        | ArrayExpression
+        | LocalAlias
+        | MergeStatement
+        | IndexColumnDefinition
+        | AggregateOrderByClause
+        | FunctionName
+        | CaseExpression
+        | WhenClause
+        | ElseClause
+        | PreWhereClause
+        | WhereClause
+        | SetOperator
+        | ValuesClause
+        | EmptyStructLiteral
+        | ObjectLiteral
+        | ObjectLiteralElement
+        | TimeZoneGrammar
+        | BracketedArguments
+        | DataType
+        | AliasExpression
+        | ArrayAccessor
+        | ArrayLiteral
+        | TypedArrayLiteral
+        | StructType
+        | StructLiteral
+        | TypedStructLiteral
+        | IntervalExpression
+        | ArrayType
+        | SizedArrayType
+        | SelectStatement
+        | OverlapsClause
+        | SelectClause
+        | Statement
+        | WithNoSchemaBindingClause
+        | WithDataClause
+        | SetExpression
+        | FromClause
+        | EmptyStructLiteralBrackets
+        | WildcardExpression
+        | OrderbyClause
+        | TruncateStatement
+        | FromExpression
+        | FromExpressionElement
+        | SelectClauseModifier
+        | NamedWindowExpression
+        | SelectClauseElement
+        | QualifyClause
+        | MultiStatementSegment
+        | AssertStatement
+        | ForInStatements
+        | ForInStatement
+        | RepeatStatements
+        | RepeatStatement
+        | IfStatements
+        | IfStatement
+        | LoopStatements
+        | LoopStatement
+        | WhileStatements
+        | WhileStatement
+        | SelectExceptClause
+        | SelectReplaceClause
+        | StructTypeSchema
+        | Tuple
+        | NamedArgument
+        | DeclareSegment
+        | SetSegment
+        | PartitionBySegment
+        | ClusterBySegment
+        | OptionsSegment
+        | CreateExternalTableStatement
+        | AlterViewStatement
+        | CreateMaterializedViewStatement
+        | AlterMaterializedViewSetOptionsStatement
+        | DropMaterializedViewStatement
+        | ParameterizedExpression
+        | PivotForClause
+        | FromPivotExpression
+        | UnpivotClause
+        | FromUnpivotExpression
+        | NotMatchedByTargetClause
+        | MergeWhenMatchedClause
+        | ProcedureName
+        | ExportStatement
+        | ProcedureParameterList
+        | ProcedureStatements
+        | CallStatement
+        | ReturnStatement
+        | BreakStatement
+        | LeaveStatement
+        | ContinueStatement
+        | RaiseStatement
+        | PsqlVariable
+        | DatetimeTypeIdentifier
+        | DatetimeLiteral
+        | IndexAccessMethod
+        | OperatorClassReference
+        | DefinitionParameter
+        | DefinitionParameters
+        | RelationOption
+        | RelationOptions
+        | AlterFunctionActionSegment
+        | AlterProcedureActionSegment
+        | AlterProcedureStatement
+        | DropProcedureStatement
+        | WktGeometryType
+        | IntoClause
+        | ForClause
+        | AlterRoleStatement
+        | ExplainOption
+        | CreateTableAsStatement
+        | AlterPublicationStatement
+        | CreatePublicationStatement
+        | PublicationObjects
+        | PublicationTable
+        | PublicationReference
+        | DropExtensionStatement
+        | CreateExtensionStatement
+        | VersionIdentifier
+        | AlterTableActionSegment
+        | DropPublicationStatement
+        | AlterMaterializedViewStatement
+        | AlterMaterializedViewActionSegment
+        | RefreshMaterializedViewStatement
+        | WithCheckOption
+        | AlterPolicyStatement
+        | AlterDatabaseStatement
+        | VacuumStatement
+        | LikeOptionSegment
+        | PartitionBoundSpec
+        | IndexParameters
+        | ReferentialActionSegment
+        | IndexElement
+        | ExclusionConstraintElement
+        | AlterDefaultPrivilegesStatement
+        | AlterDefaultPrivilegesObjectPrivilege
+        | AlterDefaultPrivilegesSchemaObject
+        | AlterDefaultPrivilegesToFromRoles
+        | AlterDefaultPrivilegesGrant
+        | DropOwnedStatement
+        | ReassignOwnedStatement
+        | IndexElementOptions
+        | AlterDefaultPrivilegesRevoke
+        | AlterIndexStatement
+        | ReindexStatementSegment
+        | AnalyzeStatement
+        | AlterTrigger
+        | OperationClassReference
+        | ConflictAction
+        | ConflictTarget
+        | SetStatement
+        | CreatePolicyStatement
+        | CreateDomainStatement
+        | AlterDomainStatement
+        | DropDomainStatement
+        | DropPolicyStatement
+        | LoadStatement
+        | ResetStatement
+        | ListenStatement
+        | NotifyStatement
+        | UnlistenStatement
+        | ClusterStatement
+        | LanguageClause
+        | DoStatement
+        | CreateUserMappingStatement
+        | ImportForeignSchemaStatement
+        | CreateServerStatement
+        | CreateCollationStatement
+        | AlterTypeStatement
+        | CreateTypeStatement
+        | LockTableStatement
+        | CopyStatement
+        | DiscardStatement
+        | AlterSchemaStatement
+        | ServerReference
+        | ArrayJoinClause
+        | TableEngineFunction
+        | OnClusterClause
+        | Engine
+        | EngineFunction
+        | DatabaseEngine
+        | ColumnTtlSegment
+        | TableTtlSegment
+        | DropDictionaryStatement
+        | DropQuotaStatement
+        | DropSettingProfileStatement
+        | SystemMergesSegment
+        | SystemTtlMergesSegment
+        | SystemMovesSegment
+        | SystemReplicaSegment
+        | SystemFilesystemSegment
+        | SystemReplicatedSegment
+        | SystemReplicationSegment
+        | SystemFetchesSegment
+        | SystemDistributedSegment
+        | SystemModelSegment
+        | SystemFileSegment
+        | SystemUnfreezeSegment
+        | SystemStatement
+        | ConnectbyClause
+        | CallSegment
+        | WithingroupClause
+        | PatternExpression
+        | MatchRecognizeClause
+        | ChangesClause
+        | MatchConditionClause
+        | FromAtExpression
+        | FromBeforeExpression
+        | SnowflakeKeywordExpression
+        | SemiStructuredExpression
+        | SelectExcludeClause
+        | SelectRenameClause
+        | AlterTableTableColumnAction
+        | AlterTableClusteringAction
+        | AlterTableConstraintAction
+        | AlterWarehouseStatement
+        | AlterShareStatement
+        | AlterStorageIntegrationStatement
+        | AlterExternalTableStatement
+        | CommentEqualsClause
+        | TagBracketedEquals
+        | TagEquals
+        | CreateCloneStatement
+        | CreateDatabaseFromShareStatement
+        | CreateProcedureStatement
+        | ScriptingBlockStatement
+        | ScriptingLetStatement
+        | AlterFunctionStatement
+        | CreateExternalFunctionStatement
+        | WarehouseObjectProperties
+        | ConstraintPropertiesSegment
+        | CopyOptions
+        | SchemaObjectProperties
+        | CreateTaskStatement
+        | SnowflakeTaskExpressionSegment
+        | CreateStatement
+        | CreateFileFormatSegment
+        | AlterFileFormatSegment
+        | CsvFileFormatTypeParameters
+        | JsonFileFormatTypeParameters
+        | AvroFileFormatTypeParameters
+        | OrcFileFormatTypeParameters
+        | ParquetFileFormatTypeParameters
+        | XmlFileFormatTypeParameters
+        | AlterPipeSegment
+        | FileFormatSegment
+        | FormatTypeOptions
+        | CopyIntoLocationStatement
+        | CopyIntoTableStatement
+        | StorageLocation
+        | StageParameters
+        | S3ExternalStageParameters
+        | GcsExternalStageParameters
+        | AzureBlobStorageExternalStageParameters
+        | CreateStageStatement
+        | AlterStageStatement
+        | CreateStreamStatement
+        | AlterStreamStatement
+        | ShowStatement
+        | AlterUserStatement
+        | AlterSessionStatement
+        | AlterSessionSetStatement
+        | AlterSessionUnsetClause
+        | AlterTaskStatement
+        | AlterTaskSpecialSetClause
+        | AlterTaskSetClause
+        | AlterTaskUnsetClause
+        | ExecuteTaskClause
+        | UndropStatement
+        | CommentStatement
+        | DropExternalTableStatement
+        | ListStatement
+        | GetStatement
+        | PutStatement
+        | RemoveStatement
+        | CastExpression
+        | DropObjectStatement
+        | UnsetStatement
+        | SqlConfOption
+        | CreateWidgetStatement
+        | ReplaceTableStatement
+        | RemoveWidgetStatement
+        | UseDatabaseStatement
+        | InsertOverwriteDirectoryStatement
+        | InsertOverwriteDirectoryHiveFmtStatement
+        | LoadDataStatement
+        | ClusterByClause
+        | DistributeByClause
+        | HintFunction
+        | SelectHint
+        | WithCubeRollupClause
+        | SortByClause
+        | LateralViewClause
+        | PivotClause
+        | TransformClause
+        | AddFileStatement
+        | AddJarStatement
+        | AnalyzeTableStatement
+        | CacheTable
+        | ClearCache
+        | ListFileStatement
+        | ListJarStatement
+        | RefreshStatement
+        | UncacheTable
+        | FileReference
+        | GeneratedColumnDefinition
+        | IntervalLiteral
+        | DescribeHistoryStatement
+        | DescribeDetailStatement
+        | GenerateManifestFileStatement
+        | ConvertToDeltaStatement
+        | RestoreTableStatement
+        | ConstraintStatement
+        | ApplyChangesIntoStatement
+        | UsingClause
+        | DataSourceFormat
+        | IcebergTransformation
+        | MsckRepairTableStatement
+        | RowFormatClause
+        | SkewedByClause
+        | Bracketed
+        | EndOfFile
+        | Whitespace
+        | Newline
+        | Unlexable
+        | StartBracket
+        | EndBracket
+        | Raw
+        | Dot
+        | Comma
+        | EmitsSegment
+        | Literal
+        | Meta
+        | Colon
+        | StatementTerminator
+        | StartSquareBracket
+        | EndSquareBracket
+        | StartCurlyBracket
+        | Word
+        | DoubleQuote
+        | SingleQuote
+        | Semicolon
+        | BackQuote
+        | DollarQuote
+        | Question
+        | EndCurlyBracket
+        | Dedent
+        | Indent
+        | Implicit
+        | QuestionMark
+        | UdfBody
+        | StartAngleBracket
+        | EndAngleBracket
+        | ProcedureOption
+        | ExportOption
+        | Symbol
+        | ExecuteScriptStatement
+        | Batch
+        | PivotColumnReference
+        | IntoTableClause
+        | PasswordAuth
+        | ExecuteAsClause
+        | ExecuteImmediateClause
+        | UnicodeSingleQuote
+        | EscapedSingleQuote
+        | UnicodeDoubleQuote
+        | At
+        | FileKeyword
+        | SemiStructuredElement
+        | BytesDoubleQuote
+        | BytesSingleQuote
+        | FileFormat
+        | FileType
+        | StartHint
+        | EndHint
+        | UnquotedFilePath
+        | Dollar
+        | StageEncryptionOption
+        | BucketPath
+        | QuotedStar
+        | StagePath
+        | ColumnSelector
+        | ExcludeBracketClose
+        | WarehouseSize
+        | ExcludeBracketOpen
+        | SymlinkFormatManifest
+        | StartExcludeBracket
+        | CompressionType
+        | CopyOnErrorOption
+        | ColumnIndexIdentifierSegment
+        | ScalingPolicy
+        | ValidationModeOption
+        | EndExcludeBracket
+        | IdentifierList
+        | TemplateLoop
+        | ColonDelimiter
+        | SqlcmdOperator
+        | Slice
+        | TableEndClauseSegment
+        | PragmaStatement
+        | PragmaReference
+        | Slash
+        | DataFormatSegment
+        | AuthorizationSegment
+        | ColumnAttributeSegment
+        | ShowModelStatement
+        | CreateExternalSchemaStatement
+        | CreateLibraryStatement
+        | UnloadStatement
+        | DeclareStatement
+        | FetchStatement
+        | CloseStatement
+        | CreateDatashareStatement
+        | DescDatashareStatement
+        | DropDatashareStatement
+        | ShowDatasharesStatement
+        | GrantDatashareStatement
+        | CreateRlsPolicyStatement
+        | ManageRlsPolicyStatement
+        | DropRlsPolicyStatement
+        | AnalyzeCompressionStatement
+        | PartitionedBySegment
+        | RowFormatDelimitedSegment
+        | ObjectUnpivoting
+        | ArrayUnnesting
+        | AlterGroup
+        | CreateGroup
+        | ListaggOverflowClauseSegment
+        | UnorderedSelectStatementSegment
+        | MapType
+        | MapTypeSchema
+        | PrepareStatement
+        | ExecuteStatement
+        | RenameTableStatement
+        | ActionParameter
+        | AggregateClause
+        | AggregateOrderBy
+        | AliasOperator
+        | AllowConnections
+        | AlterAccountStatement
+        | AlterAggregateStatement
+        | AlterBiCapacityStatement
+        | AlterCapacityStatement
+        | AlterCatalogStatement
+        | AlterDynamicTableStatement
+        | AlterEventStatement
+        | AlterExtensionStatement
+        | AlterExternalVolumeStatement
+        | AlterForeignTableActionSegment
+        | AlterForeignTableStatement
+        | AlterMaskingPolicy
+        | AlterMasterKeyStatement
+        | AlterNetworkPolicyStatement
+        | AlterOptionSegment
+        | AlterOrganizationStatement
+        | AlterPartitionFunctionStatement
+        | AlterPartitionSchemeStatement
+        | AlterPasswordPolicyStatement
+        | AlterProjectStatement
+        | AlterReservationStatement
+        | AlterResourceMonitorStatement
+        | AlterRowAccessPolicyStatement
+        | AlterSecurityPolicyStatement
+        | AlterStatisticsStatement
+        | AlterStreamlitStatement
+        | AlterSubscription
+        | AlterTableSwitchStatement
+        | AlterTagStatement
+        | AlterTextSearchConfigurationStatement
+        | AlterVolumeStatement
+        | ArnCatalogSchemaSegment
+        | ArrayTypeSchema
+        | AtSign
+        | AtomicBeginEndBlock
+        | Atsign
+        | AutoOption
+        | BackupStorageRedundancy
+        | BeginEndBlock
+        | BeginStatement
+        | BinaryLiteral
+        | BindVariable
+        | BitValueLiteral
+        | BracketedIndexColumnListGrammar
+        | BulkInsertStatement
+        | BulkInsertWithSegment
+        | ByteLengthLiteral
+        | CallOperator
+        | CatalogReference
+        | CharacteristicStatement
+        | CheckConstraintGrammar
+        | CheckTableStatement
+        | ChecksumTableStatement
+        | CloseCursorStatement
+        | ClusterbyClause
+        | Code
+        | CollationClause
+        | ColonLiteral
+        | ColonPrefix
+        | ColumnPathOperator
+        | ColumnPropertiesSegment
+        | ColumnTypeReference
+        | ColumnsExpression
+        | Command
+        | CompatibilityLevel
+        | CompositeValueExpansion
+        | ComputedColumnDefinition
+        | ConflictClause
+        | ConnectionConstraintGrammar
+        | ConnectionLimitSegment
+        | CopyFilesIntoLocationStatement
+        | CreateAggregateStatement
+        | CreateAssignmentStatement
+        | CreateAuthenticationPolicySegment
+        | CreateCapacityStatement
+        | CreateCatalogStatement
+        | CreateColumnstoreIndexStatement
+        | CreateCortexSearchServiceStatement
+        | CreateDatabaseRoleStatement
+        | CreateDatabaseScopedCredentialStatement
+        | CreateDatabaseWithOptions
+        | CreateEventStatement
+        | CreateEventTableStatement
+        | CreateExternalDataSourceStatement
+        | CreateExternalFileFormat
+        | CreateExternalVolumeStatement
+        | CreateForeignDataWrapper
+        | CreateForeignTableStatement
+        | CreateFulltextCatalogStatement
+        | CreateFulltextIndexStatement
+        | CreateLoginStatement
+        | CreateMasterKeyStatement
+        | CreateMaterializedViewAsReplicaOfStatement
+        | CreateOperatorStatement
+        | CreateOptionSegment
+        | CreatePartitionFunctionStatement
+        | CreatePartitionSchemeStatement
+        | CreatePasswordPolicyStatement
+        | CreateReservationStatement
+        | CreateResourceMonitorStatement
+        | CreateRowAccessPolicyStatement
+        | CreateSearchIndexStatement
+        | CreateSecurityPolicyStatement
+        | CreateServerRoleStatement
+        | CreateSnapshotTableStatement
+        | CreateSqlFunctionStatement
+        | CreateStatisticsStatement
+        | CreateStreamlitStatement
+        | CreateSubscription
+        | CreateSynonymStatement
+        | CreateTableAsSelectStatement
+        | CreateTableFunctionStatement
+        | CreateTableGraphStatement
+        | CreateTableUsingStatement
+        | CreateTextSearchConfigurationStatement
+        | CreateTrigger
+        | CreateVectorIndexStatement
+        | CreateVirtualTableStatement
+        | CreateVolumeStatement
+        | CursorDefinition
+        | CursorFetchSegment
+        | CursorOpenCloseSegment
+        | DataGovernancePolicyTagActionSegment
+        | DatabaseRoleReference
+        | DateFormat
+        | DeallocateCursorStatement
+        | DeallocateSegment
+        | DeallocateStatement
+        | DeclareOrReplaceVariableStatement
+        | DefaultCollate
+        | DefinerSegment
+        | DeleteTargetTable
+        | DelimiterStatement
+        | DisableTrigger
+        | DistributebyClause
+        | DoubleAmpersand
+        | DoubleAtSignLiteral
+        | DoubleVerticalBar
+        | DropAggregateStatement
+        | DropAssignmentStatement
+        | DropCapacityStatement
+        | DropCatalogStatement
+        | DropCollationStatement
+        | DropColumnClause
+        | DropDynamicTableSegment
+        | DropEventStatement
+        | DropExternalVolumeStatement
+        | DropForeignTableStatement
+        | DropIcebergTableStatement
+        | DropMasterKeyStatement
+        | DropModelstatement
+        | DropPasswordPolicyStatement
+        | DropReservationStatement
+        | DropResourceMonitorStatement
+        | DropRowAccessPolicyStatement
+        | DropSearchIndexStatement
+        | DropSecurityPolicy
+        | DropStatement
+        | DropStatisticsStatement
+        | DropSubscription
+        | DropSynonymStatement
+        | DropTableFunctionStatement
+        | DropTextSearchConfigurationStatement
+        | DropTrigger
+        | DropVectorIndexStatement
+        | DropVolumeStatement
+        | DynamicTableLagIntervalSegment
+        | DynamicTableOptions
+        | Edition
+        | EncryptedWithGrammar
+        | ExceptionBlockStatement
+        | ExceptionCode
+        | ExecuteArrow
+        | ExecuteImmediate
+        | ExecuteOption
+        | ExecuteSegment
+        | ExtendClause
+        | ExternalAccessIntegrationEquals
+        | ExternalFileDelimitedTextClause
+        | ExternalFileDelimitedTextFormatOptionsClause
+        | ExternalFileDeltaClause
+        | ExternalFileJsonClause
+        | ExternalFileOrcClause
+        | ExternalFileParquetClause
+        | ExternalFileRcClause
+        | ExternalLocation
+        | ExternalVolumeReference
+        | FatRightArrow
+        | FetchCursorStatement
+        | FileCompression
+        | FileEncoding
+        | FileSpec
+        | FileSpecFileGrowth
+        | FileSpecFileName
+        | FileSpecMaxSize
+        | FileSpecNewName
+        | FileSpecSize
+        | FileSpecWithoutBracket
+        | FilegroupClause
+        | FilegroupName
+        | FilestreamOnOptionStatement
+        | FlushStatement
+        | ForSystemTimeAsOfSegment
+        | FormatClause
+        | FromDatashareClause
+        | FromIntegrationClause
+        | FullTextSearchOperator
+        | FunctionOptionSegment
+        | FunctionParameterListWithComments
+        | GetDiagnosticsSegment
+        | GlobOperator
+        | GoStatement
+        | GotoStatement
+        | GrantToSegment
+        | GraphTableConstraint
+        | GroupAndOrderbyClause
+        | HashIdentifier
+        | HashPrefix
+        | HelpStatement
+        | HexadecimalLiteral
+        | IamRoleClause
+        | IcebergTableOptions
+        | IdentifierClauseSegment
+        | IdentityGrammar
+        | IfClause
+        | IfThenStatement
+        | IndexHintClause
+        | IndexOption
+        | IndexReference
+        | IndexType
+        | InitializeType
+        | InlineDollarSign
+        | InlinePathOperator
+        | InsertRowAlias
+        | IntoOutfileClause
+        | IsolationLevelClause
+        | IterateStatement
+        | JsonPath
+        | LabelSegment
+        | LambdaArrow
+        | LambdaFunction
+        | LeadingDot
+        | LimitClauseComponent
+        | ListComprehension
+        | ListaggOverflowClause
+        | LocalAliasSegment
+        | LogLevelEquals
+        | LogicalFileName
+        | LoginUserSegment
+        | MagicCellSegment
+        | MagicLine
+        | MagicSingleLine
+        | MagicStart
+        | MaskStatement
+        | MasterKeyEncryptionOption
+        | MatchCondition
+        | MaxDuration
+        | MaxLiteral
+        | MetaCommand
+        | MetaCommandQueryBuffer
+        | MetaCommandStatement
+        | MlTableExpression
+        | MsckTableStatement
+        | NotOperator
+        | NotebookStart
+        | ObevoAnnotation
+        | OffsetClause
+        | OnPartitionOrFilegroupStatement
+        | OnPartitionsClause
+        | OpenCursorStatement
+        | OpenSymmetricKeyStatement
+        | OpenjsonSegment
+        | OpenjsonWithClause
+        | OpenquerySegment
+        | OpenrowsetSegment
+        | OpenrowsetWithClause
+        | OpenxmlSegment
+        | Operator
+        | OptimizeTableStatement
+        | Option
+        | OptionClause
+        | OptionIndicator
+        | OutputClause
+        | ParameterDirection
+        | PartitionClause
+        | PartitionSchemeClause
+        | PartitionSchemeName
+        | PasswordPolicyOptions
+        | PasswordPolicyReference
+        | PeriodSegment
+        | PgTrgmOperator
+        | PgvectorOperator
+        | PipeOperator
+        | PipeOperatorClause
+        | PipeStatement
+        | PivotOperator
+        | PostTableExpression
+        | PostgisOperator
+        | PrepareSegment
+        | PrewhereClause
+        | PrintStatement
+        | ProcedureStatement
+        | PurgeBinaryLogsStatement
+        | QualifiedOperator
+        | QueryHintSegment
+        | QuestionLiteral
+        | RaiserrorStatement
+        | RawDoubleQuote
+        | RawSingleQuote
+        | ReconfigureStatement
+        | ReferencesConstraintGrammar
+        | RelationalIndexOptions
+        | RenameColumnClause
+        | RenameStatement
+        | RepairTableStatement
+        | ReplaceStatement
+        | ResetMasterStatement
+        | ResetSessionAuthorizationStatement
+        | ResignalSegment
+        | ResourceConstraint
+        | ResourceMonitorOptions
+        | ReturnSegment
+        | ReturningClause
+        | SchemaReference
+        | ScriptingDeclareStatement
+        | ScriptingIfStatement
+        | ScriptingRaiseStatement
+        | SearchOptimizationAction
+        | SecurityLabelStatement
+        | SelectVariableAssignment
+        | SequenceNextValue
+        | SequenceReference
+        | SerdeMethod
+        | ServiceObjective
+        | SetConstraintStatement
+        | SetContextInfoStatement
+        | SetLanguageStatement
+        | SetLocalVariableSegment
+        | SetNamesStatement
+        | SetOperatorClause
+        | SetSessionAuthorizationStatement
+        | SetSessionStatement
+        | SetTimezoneStatement
+        | SetTransactionStatement
+        | SetVariableStatement
+        | SettingsClause
+        | SimplifiedPivot
+        | SimplifiedUnpivot
+        | SingleQuoteWithN
+        | SizeLiteral
+        | SortbyClause
+        | SqlcmdCommandSegment
+        | SquareQuote
+        | StatisticsReference
+        | StoringSegment
+        | SubscriptionReference
+        | SynonymReference
+        | SystemVariable
+        | TableClausesSegment
+        | TableClusterByClause
+        | TableColumnCommentAction
+        | TableDistributionClause
+        | TableDistributionIndexClause
+        | TableIndexClause
+        | TableIndexSegment
+        | TableLocationClause
+        | TableOptionStatement
+        | TableSpecificationSegment
+        | TagStatement
+        | TemporalQuery
+        | TextimageOnOptionStatement
+        | ThrowStatement
+        | TraceLevelEquals
+        | TruncateTable
+        | TryCatch
+        | TupleTypeSchema
+        | UndropSchemaStatement
+        | UnpivotMultiColumn
+        | UnpivotOperator
+        | UnpivotSingleColumn
+        | UnquotedRelativeSqlFilePath
+        | UpdateStatisticsStatement
+        | UpsertClause
+        | UpsertClauseList
+        | UseCatalogStatement
+        | VolumeReference
+        | WaitforStatement
+        | WildcardExclude
+        | WildcardPatternMatching
+        | WildcardRename
+        | WildcardReplace
+        | WithCheckOptions
+        | WithFill
+        | WithRollupClause
+        | WithinGroupClause
+        | WithordinalityClause
+        | OracleAtSign
+        | OraclePowerOperator
+        | OracleAssignmentOperator
+        | HierarchicalQueryClause
+        | PivotSegment
+        | UnpivotSegment
+        | TriggerCorrelationName
+        | OracleBindVariable
+        | AlterTableProperties
+        | AlterTableColumnClauses
+        | AlterTableConstraintClauses
+        | IndexTypeReference
+        | ExecuteFileStatement
+        | SlashBufferExecutor
+        | OracleBatch
+        | OracleCommentStatement
+        | OracleCreateProcedureStatement
+        | OracleDropProcedureStatement
+        | OracleDeclareSegment
+        | OracleColumnTypeReference
+        | OracleRowTypeReference
+        | CollectionType
+        | RecordType
+        | RefCursorType
+        | DeclareCursorVariable
+        | OracleExecuteImmediateStatement
+        | OracleBeginEndBlock
+        | OracleCreateFunctionStatement
+        | OracleAlterFunctionStatement
+        | OracleCreateTypeStatement
+        | OracleTypeReference
+        | OracleCreateTypeBodyStatement
+        | OracleCreatePackageStatement
+        | OraclePackageReference
+        | OracleAlterPackageStatement
+        | OracleDropPackageStatement
+        | OracleCreateTriggerStatement
+        | DmlEventClause
+        | OracleReferencingClause
+        | CompoundTriggerStatement
+        | TimingPointSection
+        | OracleAlterTriggerStatement
+        | AssignmentSegmentStatement
+        | OracleIfThenStatement
+        | OracleIfClause
+        | OracleCaseExpression
+        | OracleWhenClause
+        | OracleElseClause
+        | OracleNullStatement
+        | ForLoopStatement
+        | WhileLoopStatement
+        | OracleLoopStatement
+        | ForallStatement
+        | OracleOpenStatement
+        | OracleOpenForStatement
+        | OracleFetchStatement
+        | OracleIntoClause
+        | BulkCollectIntoClause
+        | OracleExitStatement
+        | OracleReturnStatement
+        | OracleCreateUserStatement
+        | OracleReturningClause
+        | DatabaseLinkReference
+        | OracleCreateDatabaseLinkStatement
+        | OracleDropDatabaseLinkStatement
+        | OracleAlterDatabaseLinkStatement
+        | OracleCreateSynonymStatement
+        | OracleDropSynonymStatement
+        | OracleAlterSynonymStatement
+        | OracleWithinGroupClause
+        | OracleListaggOverflowClause
+        | OracleNamedArgument
+        | OracleCreateTableStatement
+        | OracleColumnDefinition
+        | OracleSqlplusVariable
+        | StartwithClause
+        | OracleTableReference
+        | OracleCreateViewStatement
+        | OracleAlterIndexStatement
+        | OracleAlterTableStatement
+        | OracleAlterSessionStatement
+        | JsonTableColumnDefinition
+        | JsonTableColumnsClause
+        | JsonTableFunctionContents
+        | OracleMergeUpdateClause
+        | OracleInsertStatement
+        | OracleUpdateStatement
+        | OracleDeleteStatement
+        | OracleTransactionStatement
+        | OracleValuesClause
+        | OracleTableConstraint
+        | OracleFunctionName
+        | OracleOrderByClause
+        | EngineType
+        | PartitionSegment
+        | DistributionSegment
+        | IndexDefinition
+        | CreateRoutineLoadStatement
+        | RoutineLoadProperties
+        | RoutineLoadDataSourceProperties
+        | StopRoutineLoadStatement
+        | PauseRoutineLoadStatement
+        | ResumeRoutineLoadStatement
+        | InsertOverwriteStatement => return None,
+    };
+
+    Some(highlight)
+}
+
+/// Parse `source` with `linter` and produce LSP semantic tokens for it.
+///
+/// Returns an empty list if the source fails to parse.
+pub fn semantic_tokens(
+    linter: &Linter,
+    source: &str,
+    filename: Option<String>,
+) -> Vec<SemanticToken> {
+    let tables = Tables::default();
+    match linter.parse_string(&tables, source, filename) {
+        Ok(parsed) => parsed
+            .tree
+            .map(|tree| build_semantic_tokens(&tree, source))
+            .unwrap_or_default(),
+        Err(e) => {
+            eprintln!("Failed to parse for semantic tokens: {}", e.value);
+            Vec::new()
+        }
+    }
+}
+
+/// Build delta-encoded LSP semantic tokens from a parsed `tree` over `source`.
+pub(crate) fn build_semantic_tokens(tree: &ErasedSegment, source: &str) -> Vec<SemanticToken> {
+    let line_index = LineIndex::new(source);
+    let mut tokens: Vec<RawToken> = Vec::new();
+
+    for segment in tree.get_raw_segments() {
+        let Some(highlight) = classify(segment.get_type()) else {
+            continue;
+        };
+        let Some(marker) = segment.get_position_marker() else {
+            continue;
+        };
+
+        let range = marker.source_slice.clone();
+        if range.is_empty() || range.end > source.len() {
+            continue;
+        }
+        let text = &source[range.clone()];
+        let token_type = highlight.token_type();
+
+        // The LSP wire format cannot represent a token spanning multiple lines,
+        // so split block comments / multi-line strings into one token per line.
+        line_index.split_lines(range.start, text, |line, start, length| {
+            tokens.push(RawToken {
+                line,
+                start,
+                length,
+                token_type,
+            });
+        });
+    }
+
+    // The CST walk yields source order, but the multi-line split can interleave,
+    // so re-sort before delta encoding.
+    tokens.sort_by_key(|t| (t.line, t.start));
+
+    let mut data = Vec::with_capacity(tokens.len());
+    let mut prev_line = 0;
+    let mut prev_start = 0;
+    for token in tokens {
+        let delta_line = token.line - prev_line;
+        let delta_start = if delta_line == 0 {
+            token.start - prev_start
+        } else {
+            token.start
+        };
+        data.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length: token.length,
+            token_type: token.token_type,
+            token_modifiers_bitset: 0,
+        });
+        prev_line = token.line;
+        prev_start = token.start;
+    }
+
+    data
+}
+
+/// A token before delta encoding: absolute line + UTF-16 start column + length.
+struct RawToken {
+    line: u32,
+    start: u32,
+    length: u32,
+    token_type: u32,
+}
+
+/// Maps byte offsets in the source to LSP `(line, character)` positions, where
+/// `character` is counted in UTF-16 code units (the LSP default encoding).
+struct LineIndex<'a> {
+    source: &'a str,
+    /// Byte offset of the start of each line.
+    line_starts: Vec<usize>,
+}
+
+impl<'a> LineIndex<'a> {
+    fn new(source: &'a str) -> Self {
+        let mut line_starts = vec![0];
+        for (offset, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(offset + 1);
+            }
+        }
+        Self {
+            source,
+            line_starts,
+        }
+    }
+
+    /// Resolve a byte offset to `(line, utf16_column)`.
+    fn position(&self, offset: usize) -> (u32, u32) {
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(line) => line,
+            Err(next) => next - 1,
+        };
+        let line_start = self.line_starts[line];
+        let column = utf16_len(&self.source[line_start..offset]);
+        (line as u32, column)
+    }
+
+    /// Split `text` (which starts at byte `start` in the source) into one entry
+    /// per line, invoking `emit(line, start_col, len)` with UTF-16 columns and
+    /// lengths. Trailing newline / carriage-return characters are excluded.
+    fn split_lines(&self, start: usize, text: &str, mut emit: impl FnMut(u32, u32, u32)) {
+        let mut offset = start;
+        for piece in text.split_inclusive('\n') {
+            // Strip the line terminator (`\n`, and a preceding `\r` if present).
+            let content = piece.strip_suffix('\n').unwrap_or(piece);
+            let content = content.strip_suffix('\r').unwrap_or(content);
+            if !content.is_empty() {
+                let (line, column) = self.position(offset);
+                emit(line, column, utf16_len(content));
+            }
+            offset += piece.len();
+        }
+    }
+}
+
+/// Count the number of UTF-16 code units in `text`.
+fn utf16_len(text: &str) -> u32 {
+    text.chars().map(|c| c.len_utf16() as u32).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqruff_lib::core::config::FluffConfig;
+
+    fn linter() -> Linter {
+        let config = FluffConfig::from_source("[sqruff]\ndialect = ansi\n", None);
+        Linter::new(config, None, None, false).unwrap()
+    }
+
+    /// Decode the delta-encoded wire format back into absolute
+    /// `(line, start, length, token_type)` tuples for readable assertions.
+    fn decode(tokens: &[SemanticToken]) -> Vec<(u32, u32, u32, u32)> {
+        let mut line = 0;
+        let mut start = 0;
+        let mut out = Vec::new();
+        for token in tokens {
+            if token.delta_line == 0 {
+                start += token.delta_start;
+            } else {
+                line += token.delta_line;
+                start = token.delta_start;
+            }
+            out.push((line, start, token.length, token.token_type));
+        }
+        out
+    }
+
+    fn tokens(sql: &str) -> Vec<(u32, u32, u32, u32)> {
+        decode(&semantic_tokens(&linter(), sql, None))
+    }
+
+    #[test]
+    fn highlights_keywords_identifiers_and_literals() {
+        // SELECT a, 1, 'x' FROM t
+        let decoded = tokens("SELECT a, 1, 'x' FROM t");
+        let kw = Highlight::Keyword.token_type();
+        let var = Highlight::Variable.token_type();
+        let num = Highlight::Number.token_type();
+        let string = Highlight::String.token_type();
+
+        assert_eq!(
+            decoded,
+            vec![
+                (0, 0, 6, kw),      // SELECT
+                (0, 7, 1, var),     // a
+                (0, 10, 1, num),    // 1
+                (0, 13, 3, string), // 'x'
+                (0, 17, 4, kw),     // FROM
+                (0, 22, 1, var),    // t
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_whitespace_and_punctuation() {
+        // Commas / whitespace must not produce tokens.
+        let decoded = tokens("SELECT a, b");
+        assert!(decoded.iter().all(|&(_, _, len, _)| len > 0));
+        // SELECT, a, b => exactly three tokens.
+        assert_eq!(decoded.len(), 3);
+    }
+
+    #[test]
+    fn splits_block_comment_across_lines() {
+        let decoded = tokens("SELECT 1 /* line one\nline two */ FROM t");
+        let comment = Highlight::Comment.token_type();
+        let comment_tokens: Vec<_> = decoded
+            .iter()
+            .filter(|&&(_, _, _, ty)| ty == comment)
+            .collect();
+        // The block comment spans two lines => two comment tokens, one per line.
+        assert_eq!(comment_tokens.len(), 2);
+        assert_eq!(comment_tokens[0].0, 0);
+        assert_eq!(comment_tokens[1].0, 1);
+    }
+
+    #[test]
+    fn utf16_columns_after_non_ascii() {
+        // A non-ASCII char in a string shifts later columns; ensure we count
+        // UTF-16 code units, not bytes.
+        let sql = "SELECT 'é' AS a";
+        let decoded = tokens(sql);
+        let var = Highlight::Variable.token_type();
+        // `a` is the alias identifier; in UTF-16 it sits at column 14.
+        // S E L E C T _ ' é ' _ A S _ a
+        // 0 1 2 3 4 5 6 7 8 9 ...
+        let alias = decoded
+            .iter()
+            .rev()
+            .find(|&&(_, _, _, ty)| ty == var)
+            .unwrap();
+        assert_eq!(alias.1, 14);
+    }
+}

--- a/editors/code/BUILD.bazel
+++ b/editors/code/BUILD.bazel
@@ -212,6 +212,7 @@ playwright_test_bin.playwright_test(
     ],
     chdir = package_name(),
     data = [
+        ":esbuild_bundle",
         ":node_modules/@playwright/test",
         ":node_modules/code-server",
         ":vscode_extension",

--- a/editors/code/src/lsp-worker.ts
+++ b/editors/code/src/lsp-worker.ts
@@ -7,6 +7,7 @@ import {
   BrowserMessageWriter,
   PublishDiagnosticsParams,
   DocumentFormattingParams,
+  SemanticTokensParams,
 } from "vscode-languageserver/browser";
 
 sqruffInit(sqruffWasmData).then(() => {
@@ -41,6 +42,13 @@ sqruffInit(sqruffWasmData).then(() => {
     "textDocument/formatting",
     (params: DocumentFormattingParams) => {
       return lsp.format(params.textDocument.uri);
+    },
+  );
+
+  connection.onRequest(
+    "textDocument/semanticTokens/full",
+    (params: SemanticTokensParams) => {
+      return lsp.semanticTokens(params.textDocument.uri);
     },
   );
 

--- a/editors/code/tests/semantic-tokens.spec.ts
+++ b/editors/code/tests/semantic-tokens.spec.ts
@@ -1,0 +1,188 @@
+import { test as browserTest, expect, type Locator } from "@playwright/test";
+import { cpSync, readFileSync } from "fs";
+import { join } from "path";
+import { test } from "./fixtures";
+import { FIXTURES_DIR, openFile, openServerPage } from "./utils";
+
+const WORKER_ORIGIN = "http://sqruff-worker.test";
+
+browserTest("browser LSP worker returns semantic tokens", async ({ page }) => {
+  const workerScript = readFileSync(
+    join(__dirname, "..", "dist", "browserServerMain.js"),
+    "utf-8",
+  );
+
+  await page.route(`${WORKER_ORIGIN}/`, async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: "<!doctype html><title>sqruff worker test</title>",
+    });
+  });
+
+  await page.route(`${WORKER_ORIGIN}/browserServerMain.js`, async (route) => {
+    await route.fulfill({
+      contentType: "application/javascript",
+      body: workerScript,
+    });
+  });
+
+  await page.goto(WORKER_ORIGIN);
+
+  const tokenData = await page.evaluate(async () => {
+    const worker = new Worker("/browserServerMain.js");
+    const pending = new Map<
+      number,
+      { resolve: (value: unknown) => void; reject: (error: Error) => void }
+    >();
+    let nextId = 1;
+    let resolveReady!: () => void;
+    let resolveConfigLoaded!: () => void;
+
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const configLoaded = new Promise<void>((resolve) => {
+      resolveConfigLoaded = resolve;
+    });
+
+    worker.onmessage = ({ data }) => {
+      if (data === "OK") {
+        resolveReady();
+        return;
+      }
+
+      if (data.method === "loadConfig") {
+        worker.postMessage({
+          jsonrpc: "2.0",
+          id: data.id,
+          result: "[sqruff]\ndialect = ansi\n",
+        });
+        resolveConfigLoaded();
+        return;
+      }
+
+      if (typeof data.id === "number" && pending.has(data.id)) {
+        const request = pending.get(data.id)!;
+        pending.delete(data.id);
+        if (data.error) {
+          request.reject(new Error(data.error.message));
+        } else {
+          request.resolve(data.result);
+        }
+      }
+    };
+
+    function sendRequest(method: string, params: unknown): Promise<unknown> {
+      const id = nextId++;
+      worker.postMessage({ jsonrpc: "2.0", id, method, params });
+      return new Promise((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+      });
+    }
+
+    function sendNotification(method: string, params: unknown): void {
+      worker.postMessage({ jsonrpc: "2.0", method, params });
+    }
+
+    await ready;
+    await sendRequest("initialize", {
+      processId: null,
+      rootUri: "file:///workspace",
+      capabilities: {
+        textDocument: {
+          semanticTokens: {
+            requests: { full: true },
+            tokenTypes: [
+              "keyword",
+              "string",
+              "number",
+              "comment",
+              "operator",
+              "function",
+              "type",
+              "variable",
+              "parameter",
+              "property",
+              "macro",
+            ],
+            tokenModifiers: [],
+            formats: ["relative"],
+          },
+        },
+      },
+    });
+    sendNotification("initialized", {});
+    await configLoaded;
+
+    const uri = "file:///workspace/query.sql";
+    sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "sql",
+        version: 1,
+        text: "SELECT name FROM users WHERE age > 1",
+      },
+    });
+
+    const semanticTokens = (await sendRequest(
+      "textDocument/semanticTokens/full",
+      {
+        textDocument: { uri },
+      },
+    )) as { data: number[] };
+
+    worker.terminate();
+    return semanticTokens.data;
+  });
+
+  expect(tokenData.slice(0, 5)).toEqual([0, 0, 6, 0, 0]);
+  expect(chunkSemanticTokens(tokenData).some((token) => token[3] === 7)).toBe(
+    true,
+  );
+});
+
+test("VS Code renders distinct semantic token colours", async ({
+  sharedCodeServer,
+  tempDir,
+  page,
+}) => {
+  const projectDir = join(tempDir, "sample_project");
+  cpSync(FIXTURES_DIR, projectDir, { recursive: true });
+
+  await openServerPage(page, projectDir, sharedCodeServer);
+  await openFile(page, "lint_errors.sql");
+
+  const editor = page.locator(".monaco-editor").filter({ visible: true });
+  await expect(editor.locator(".view-line").first()).toContainText("SELECT");
+
+  await expect
+    .poll(() => renderedTokenColors(editor.locator(".view-lines")), {
+      timeout: 30_000,
+    })
+    .toMatchObject({
+      SELECT: "rgb(255, 0, 0)",
+      a: "rgb(0, 255, 0)",
+    });
+});
+
+async function renderedTokenColors(viewLines: Locator) {
+  return viewLines.locator("span").evaluateAll((spans) =>
+    Object.fromEntries(
+      spans
+        .filter((span) => span.children.length === 0)
+        .map((span) => [
+          span.textContent?.trim() ?? "",
+          getComputedStyle(span).color,
+        ])
+        .filter(([text]) => text.length > 0),
+    ),
+  );
+}
+
+function chunkSemanticTokens(data: number[]): number[][] {
+  const chunks: number[][] = [];
+  for (let index = 0; index < data.length; index += 5) {
+    chunks.push(data.slice(index, index + 5));
+  }
+  return chunks;
+}

--- a/editors/code/tests/utils_code_server.ts
+++ b/editors/code/tests/utils_code_server.ts
@@ -25,6 +25,14 @@ export async function startCodeServer({
   const settingsObj: Record<string, unknown> = {
     "security.workspace.trust.enabled": false,
     "workbench.startupEditor": "none",
+    "editor.semanticHighlighting.enabled": true,
+    "editor.semanticTokenColorCustomizations": {
+      enabled: true,
+      rules: {
+        keyword: "#ff0000",
+        variable: "#00ff00",
+      },
+    },
   };
   if (process.env.SQRUFF_PATH) {
     settingsObj["sqruff.executablePath"] = resolve(process.env.SQRUFF_PATH);

--- a/playground/src/Editor/Editor.tsx
+++ b/playground/src/Editor/Editor.tsx
@@ -61,16 +61,23 @@ export default function Editor({
 
   const deferredSource = useDeferredValue(source);
 
-  const checkResult: Result = useMemo(() => {
-    const { sqlSource, settingsSource } = deferredSource;
-    try {
-      const linter = new Linter(settingsSource);
-      return linter.check(sqlSource, secondaryTool ?? "Format");
-    } catch (error) {
-      console.log(error);
-      return new Result();
-    }
-  }, [deferredSource, secondaryTool]);
+  const analysis: { checkResult: Result; semanticTokens: Uint32Array } =
+    useMemo(() => {
+      const { sqlSource, settingsSource } = deferredSource;
+      try {
+        const linter = new Linter(settingsSource);
+        return {
+          checkResult: linter.check(sqlSource, secondaryTool ?? "Format"),
+          semanticTokens: linter.semanticTokens(sqlSource),
+        };
+      } catch (error) {
+        console.log(error);
+        return {
+          checkResult: new Result(),
+          semanticTokens: new Uint32Array(),
+        };
+      }
+    }, [deferredSource, secondaryTool]);
 
   return (
     <>
@@ -80,7 +87,8 @@ export default function Editor({
           <SourceEditor
             visible={tab === "Source"}
             source={source.sqlSource}
-            diagnostics={checkResult.diagnostics}
+            diagnostics={analysis.checkResult.diagnostics}
+            semanticTokens={analysis.semanticTokens}
             onChange={onSourceChanged}
           />
           <SettingsEditor
@@ -95,7 +103,7 @@ export default function Editor({
             <Panel id="secondary-panel" className={"my-2"} minSize={10}>
               <SecondaryPanel
                 tool={secondaryTool}
-                result={checkResult.secondary}
+                result={analysis.checkResult.secondary}
               />
             </Panel>
           </>

--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -3,18 +3,56 @@ import { MarkerSeverity } from "monaco-editor";
 import { useCallback, useEffect, useRef } from "react";
 import { Diagnostic } from "../pkg";
 
+declare global {
+  interface Window {
+    __sqruffLastSemanticTokens?: number[];
+  }
+}
+
+const SEMANTIC_TOKEN_TEST_THEME = "sqruff-semantic-token-test";
+
+const SEMANTIC_TOKEN_TYPES = [
+  "keyword",
+  "string",
+  "number",
+  "comment",
+  "operator",
+  "function",
+  "type",
+  "variable",
+  "parameter",
+  "property",
+  "macro",
+];
+
 export default function SourceEditor({
   visible,
   source,
   diagnostics,
+  semanticTokens,
   onChange,
 }: {
   visible: boolean;
   source: string;
   diagnostics: Diagnostic[];
+  semanticTokens: Uint32Array;
   onChange: (sqlSource: string) => void;
 }) {
   const monacoRef = useRef<Monaco | null>(null);
+  const semanticTokensRef = useRef<Uint32Array>(semanticTokens);
+  const providerRef = useRef<{ dispose: () => void } | null>(null);
+
+  useEffect(() => {
+    semanticTokensRef.current = semanticTokens;
+    publishSemanticTokensForTest(semanticTokens);
+  }, [semanticTokens]);
+
+  useEffect(() => {
+    return () => {
+      providerRef.current?.dispose();
+      providerRef.current = null;
+    };
+  }, []);
 
   useEffect(() => {
     const editor = monacoRef.current;
@@ -37,6 +75,35 @@ export default function SourceEditor({
     (_editor, instance) => {
       updateMarkers(instance, diagnostics);
       monacoRef.current = instance;
+
+      if (isSemanticTokenTest()) {
+        instance.editor.defineTheme(SEMANTIC_TOKEN_TEST_THEME, {
+          base: "vs",
+          inherit: true,
+          rules: [
+            { token: "keyword", foreground: "FF0000" },
+            { token: "variable", foreground: "00FF00" },
+          ],
+          colors: {},
+        });
+        instance.editor.setTheme(SEMANTIC_TOKEN_TEST_THEME);
+      }
+
+      if (providerRef.current == null) {
+        providerRef.current =
+          instance.languages.registerDocumentSemanticTokensProvider("sql", {
+            getLegend: () => ({
+              tokenTypes: SEMANTIC_TOKEN_TYPES,
+              tokenModifiers: [],
+            }),
+            provideDocumentSemanticTokens: () => {
+              const data = semanticTokensRef.current;
+              publishSemanticTokensForTest(data);
+              return { data };
+            },
+            releaseDocumentSemanticTokens: () => {},
+          });
+      }
     },
 
     [diagnostics],
@@ -53,6 +120,7 @@ export default function SourceEditor({
         roundedSelection: false,
         scrollBeyondLastLine: false,
         contextmenu: false,
+        "semanticHighlighting.enabled": true,
       }}
       language={"sql"}
       wrapperProps={visible ? {} : { style: { display: "none" } }}
@@ -60,6 +128,16 @@ export default function SourceEditor({
       onChange={handleChange}
     />
   );
+}
+
+function publishSemanticTokensForTest(data: Uint32Array) {
+  if (isSemanticTokenTest()) {
+    window.__sqruffLastSemanticTokens = Array.from(data);
+  }
+}
+
+function isSemanticTokenTest() {
+  return new URLSearchParams(location.search).has("__sqruffSemanticTokenTest");
 }
 
 function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {

--- a/playground/tests/main.spec.ts
+++ b/playground/tests/main.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator } from "@playwright/test";
 import { formatEditorContains, updateEditorText } from "./helpers";
 
 test("home page opens", async ({ page }) => {
@@ -37,3 +37,59 @@ test("state is loaded", async ({ page }) => {
 
   await formatEditorContains(page, "select 1 as test");
 });
+
+test("source editor provides semantic tokens", async ({ page }) => {
+  await page.goto("/?__sqruffSemanticTokenTest=1");
+
+  const tokenData = await page
+    .waitForFunction(() => {
+      const data = (
+        window as typeof window & {
+          __sqruffLastSemanticTokens?: number[];
+        }
+      ).__sqruffLastSemanticTokens;
+      return data && data.length >= 10 ? data : undefined;
+    })
+    .then((handle) => handle.jsonValue());
+
+  expect(tokenData.slice(0, 5)).toEqual([0, 0, 6, 0, 0]);
+  expect(chunkSemanticTokens(tokenData).some((token) => token[3] === 7)).toBe(
+    true,
+  );
+
+  const sourceEditor = page.locator("#main .monaco-editor").filter({
+    visible: true,
+  });
+  await expect(sourceEditor.locator(".view-line").first()).toContainText(
+    "SELECT",
+  );
+
+  await expect
+    .poll(() => renderedTokenColors(sourceEditor.locator(".view-lines")))
+    .toMatchObject({
+      SELECT: "rgb(255, 0, 0)",
+      name: "rgb(0, 255, 0)",
+    });
+});
+
+async function renderedTokenColors(viewLines: Locator) {
+  return viewLines.locator("span").evaluateAll((spans) =>
+    Object.fromEntries(
+      spans
+        .filter((span) => span.children.length === 0)
+        .map((span) => [
+          span.textContent?.trim() ?? "",
+          getComputedStyle(span).color,
+        ])
+        .filter(([text]) => text.length > 0),
+    ),
+  );
+}
+
+function chunkSemanticTokens(data: number[]): number[][] {
+  const chunks: number[][] = [];
+  for (let index = 0; index < data.length; index += 5) {
+    chunks.push(data.slice(index, index + 5));
+  }
+  return chunks;
+}


### PR DESCRIPTION
## Summary

Add LSP semantic token support and use it to provide syntax-aware SQL highlighting in both the web playground and the VS Code extension.

## What changed

- Add a semantic-token classifier that maps sqruff CST `SyntaxKind` values into LSP token categories including keywords, strings, numbers, comments, operators, functions, types, variables, parameters, properties, and macros.
- Generate delta-encoded LSP semantic tokens with UTF-16 positions and split multiline tokens into valid per-line ranges.
- Advertise and handle `textDocument/semanticTokens/full` in the native and browser LSP implementations.
- Expose semantic-token generation through the WASM bindings used by the playground.
- Register a Monaco semantic-token provider in the playground and explicitly enable semantic highlighting.
- Forward semantic-token requests through the VS Code browser worker.
- Update the Bazel Rust/WASM dependency graph and generated lock metadata for the new integration.

## Behaviour and compatibility

- Unknown syntax kinds remain unhighlighted rather than receiving an incorrect classification.
- Parse failures return an empty token list so highlighting cannot break editor operation.
- Token positions follow the LSP UTF-16 coordinate requirements, including non-ASCII input.

## Tests

- Unit coverage for classification, delta encoding, multiline tokens, and UTF-16 positions.
- Protocol-level browser-worker coverage for semantic-token responses.
- Playground Playwright coverage that verifies raw semantic-token data and distinct rendered keyword/variable colours.
- VS Code Playwright coverage that verifies distinct rendered semantic keyword/variable colours in the installed extension.
- `bazelisk test //...` — 33/33 tests pass.
