### PR TITLE
fix: RF02 flags unqualified references in correlated subqueries (#2598)

### DIFF
--- a/crates/lib-core/src/parser/segments/select.rs
+++ b/crates/lib-core/src/parser/segments/select.rs
@@ -7,12 +7,16 @@ pub struct SelectClauseElementSegment(pub ErasedSegment);
 
 impl SelectClauseElementSegment {
     pub fn alias(&self) -> Option<ColumnAliasInfo> {
+        // Stop recursing into nested SELECT statements so that an alias defined
+        // deeper inside a scalar subquery (e.g. `MAX(x.col) AS m`) is not
+        // mistaken for the alias of the outer select clause element
+        // (`(...) AS _stats`). See sqlfluff issue #6389.
         let alias_expression_segment = self
             .0
             .recursive_crawl(
                 const { &SyntaxSet::new(&[SyntaxKind::AliasExpression]) },
                 true,
-                &SyntaxSet::EMPTY,
+                const { &SyntaxSet::new(&[SyntaxKind::SelectStatement]) },
                 true,
             )
             .first()?

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -390,6 +390,10 @@ force_enable = False
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
+# Whether to ignore references to tables from a parent (outer) query when
+# linting a subquery. When False (the default), a correlated subquery that
+# references an outer table is treated as referencing more than one table.
+subqueries_ignore_external_references = False
 
 [sqruff:rules:references.consistent]
 # References must be consistently used

--- a/crates/lib/src/rules/aliasing/al04.rs
+++ b/crates/lib/src/rules/aliasing/al04.rs
@@ -5,6 +5,7 @@ use smol_str::SmolStr;
 use sqruff_lib_core::dialects::common::{AliasInfo, ColumnAliasInfo};
 use sqruff_lib_core::dialects::syntax::{SyntaxKind, SyntaxSet};
 use sqruff_lib_core::helpers::IndexSet;
+use sqruff_lib_core::parser::segments::ErasedSegment;
 use sqruff_lib_core::parser::segments::object_reference::ObjectReferenceSegment;
 use sqruff_lib_core::utils::analysis::select::get_select_statement_info;
 
@@ -19,6 +20,8 @@ type Handle<T> = fn(
     Vec<ObjectReferenceSegment>,
     Vec<ColumnAliasInfo>,
     Vec<SmolStr>,
+    Option<ErasedSegment>,
+    &RuleContext,
     &T,
 ) -> Vec<LintResult>;
 
@@ -107,11 +110,12 @@ FROM
             return Vec::new();
         };
 
-        let _parent_select = context
+        let parent_select = context
             .parent_stack
             .iter()
             .rev()
-            .find(|seg| seg.is_type(SyntaxKind::SelectStatement));
+            .find(|seg| seg.is_type(SyntaxKind::SelectStatement))
+            .cloned();
 
         (self.lint_references_and_aliases)(
             select_info.table_aliases,
@@ -119,6 +123,8 @@ FROM
             select_info.reference_buffer,
             select_info.col_aliases,
             select_info.using_cols,
+            parent_select,
+            context,
             &self.context,
         )
     }
@@ -129,12 +135,15 @@ FROM
 }
 
 impl RuleAL04 {
+    #[allow(clippy::too_many_arguments)]
     pub fn lint_references_and_aliases(
         table_aliases: Vec<AliasInfo>,
         _: Vec<SmolStr>,
         _: Vec<ObjectReferenceSegment>,
         _: Vec<ColumnAliasInfo>,
         _: Vec<SmolStr>,
+        _: Option<ErasedSegment>,
+        _: &RuleContext,
         _: &(),
     ) -> Vec<LintResult> {
         let mut duplicates = IndexSet::default();

--- a/crates/lib/src/rules/references/rf02.rs
+++ b/crates/lib/src/rules/references/rf02.rs
@@ -4,7 +4,9 @@ use regex::Regex;
 use smol_str::SmolStr;
 use sqruff_lib_core::dialects::common::{AliasInfo, ColumnAliasInfo};
 use sqruff_lib_core::dialects::syntax::{SyntaxKind, SyntaxSet};
+use sqruff_lib_core::parser::segments::ErasedSegment;
 use sqruff_lib_core::parser::segments::object_reference::ObjectReferenceSegment;
+use sqruff_lib_core::utils::analysis::select::get_select_statement_info;
 
 use crate::core::config::Value;
 use crate::core::rules::context::RuleContext;
@@ -12,9 +14,16 @@ use crate::core::rules::crawlers::{Crawler, SegmentSeekerCrawler};
 use crate::core::rules::{Erased as _, ErasedRule, LintResult, Rule, RuleGroups};
 use crate::rules::aliasing::al04::RuleAL04;
 
+#[derive(Clone, Debug, Default)]
+pub struct RuleRF02Config {
+    ignore_words: Vec<String>,
+    ignore_words_regex: Vec<Regex>,
+    subqueries_ignore_external_references: bool,
+}
+
 #[derive(Clone, Debug)]
 pub struct RuleRF02 {
-    base: RuleAL04<(Vec<String>, Vec<Regex>)>,
+    base: RuleAL04<RuleRF02Config>,
 }
 
 impl Default for RuleRF02 {
@@ -22,7 +31,7 @@ impl Default for RuleRF02 {
         Self {
             base: RuleAL04 {
                 lint_references_and_aliases: Self::lint_references_and_aliases,
-                context: (Vec::new(), Vec::new()),
+                context: RuleRF02Config::default(),
             },
         }
     }
@@ -50,10 +59,18 @@ impl Rule for RuleRF02 {
             })
             .unwrap_or_default();
 
+        let subqueries_ignore_external_references = config["subqueries_ignore_external_references"]
+            .as_bool()
+            .unwrap_or(false);
+
         Ok(Self {
             base: RuleAL04 {
                 lint_references_and_aliases: Self::lint_references_and_aliases,
-                context: (ignore_words, ignore_words_regex),
+                context: RuleRF02Config {
+                    ignore_words,
+                    ignore_words_regex,
+                    subqueries_ignore_external_references,
+                },
             },
         }
         .erased())
@@ -105,26 +122,68 @@ LEFT JOIN vee ON vee.a = foo.a
 }
 
 impl RuleRF02 {
+    /// Determine if a subquery is part of the `from` clause.
+    ///
+    /// Any subqueries in the `from_clause` should be ignored, unless they are a
+    /// nested correlated query (i.e. inside a `where_clause`).
+    fn is_root_from_clause(rule_context: &RuleContext) -> bool {
+        for x in rule_context.parent_stack.iter().rev() {
+            if x.is_type(SyntaxKind::FromClause) {
+                return true;
+            } else if x.is_type(SyntaxKind::WhereClause) {
+                return false;
+            }
+        }
+        false
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn lint_references_and_aliases(
-        table_aliases: Vec<AliasInfo>,
+        mut table_aliases: Vec<AliasInfo>,
         standalone_aliases: Vec<SmolStr>,
         references: Vec<ObjectReferenceSegment>,
         col_aliases: Vec<ColumnAliasInfo>,
         using_cols: Vec<SmolStr>,
-        context: &(Vec<String>, Vec<Regex>),
+        parent_select: Option<ErasedSegment>,
+        rule_context: &RuleContext,
+        context: &RuleRF02Config,
     ) -> Vec<LintResult> {
+        let parent_select_info = parent_select.and_then(|parent| {
+            get_select_statement_info(&parent, rule_context.dialect.into(), true)
+        });
+        if let Some(parent_select_info) = parent_select_info {
+            // If we are looking at a subquery, include any table references
+            // from the parent (outer) select.
+            for table_alias in parent_select_info.table_aliases {
+                let is_from = Self::is_root_from_clause(rule_context);
+                if !table_alias
+                    .from_expression_element
+                    .path_to(&rule_context.segment)
+                    .is_empty()
+                    || is_from
+                    || context.subqueries_ignore_external_references
+                {
+                    // Skip the subquery alias itself, or if the subquery is
+                    // inside a `from`/`join` clause that isn't a nested
+                    // `where` clause.
+                    continue;
+                }
+                table_aliases.push(table_alias);
+            }
+        }
+
         if table_aliases.len() <= 1 {
             return Vec::new();
         }
 
         let mut violation_buff = Vec::new();
         for r in references {
-            if context.0.contains(&r.0.raw().to_lowercase()) {
+            if context.ignore_words.contains(&r.0.raw().to_lowercase()) {
                 continue;
             }
 
             if context
-                .1
+                .ignore_words_regex
                 .iter()
                 .any(|regex| regex.is_match(r.0.raw().as_ref()))
             {

--- a/crates/lib/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -39,6 +39,116 @@ test_pass_qualified_references_multi_table_statements_subquery_mix:
     ) AS foo
     LEFT JOIN vee ON vee.a = foo.a
 
+test_fail_unreferenced_subquery_column:
+  fail_str: |
+    SELECT a
+    FROM foo
+    WHERE a IN (SELECT a FROM bar)
+
+test_pass_referenced_subquery_column:
+  pass_str: |
+    SELECT a
+    FROM foo
+    WHERE a IN (SELECT bar.a FROM bar)
+
+test_pass_referenced_subquery_is_self:
+  pass_str: |
+    SELECT *
+    FROM (SELECT a FROM mytable)
+
+test_fail_nested_correlated_subquery_inside_from_clause:
+  fail_str: |
+    SELECT
+        a.id AS a_id,
+        b.id AS b_id
+    FROM
+        (
+            SELECT id
+            FROM foo
+            WHERE id IN (SELECT id FROM baz)
+        ) AS a
+    INNER JOIN bar AS b ON a.id = b.id;
+
+test_fail_select_scalar_subquery:
+  # See issue #2598
+  fail_str: |
+    SELECT
+        (SELECT max(id) FROM foo2) AS f1
+    FROM bar;
+
+test_fail_exists_subquery:
+  fail_str: |
+    SELECT id
+    FROM bar
+    WHERE EXISTS (
+        SELECT 1 FROM foo2
+        WHERE bar.id = id
+    );
+
+test_pass_ignore_deeper_alias_6389:
+  pass_str: |
+    SELECT (SELECT MAX(x.col) AS m FROM x) AS _stats
+    FROM stats_today AS t
+    LEFT JOIN stats_this_month AS tm
+      ON tm.x = t.x
+    WHERE _stats IS NOT NULL;
+
+test_fail_unqual_refs_multi_table_statements_ignore_external_references:
+  fail_str: |
+    SELECT a, b
+    FROM foo
+    LEFT JOIN vee ON vee.a = foo.a
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: true
+
+test_fail_unqual_refs_multi_table_statements_subq_ignore_external_references:
+  fail_str: |
+    SELECT a
+    FROM (
+        SELECT a, b
+        FROM foo
+        LEFT JOIN vee ON vee.a = foo.a
+    )
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: true
+
+test_pass_unreferenced_subquery_column_subqueries_ignore_external_references:
+  pass_str: |
+    SELECT a
+    FROM foo
+    WHERE a IN (SELECT a FROM bar)
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: true
+
+test_pass_select_scalar_subquery_subqueries_ignore_external_references:
+  pass_str: |
+    SELECT
+        (SELECT max(id) FROM foo2) AS f1
+    FROM bar;
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: true
+
+test_pass_exists_subquery_subqueries_ignore_external_references:
+  pass_str: |
+    SELECT id
+    FROM bar
+    WHERE EXISTS (
+        SELECT 1 FROM foo2
+        WHERE bar.id = id
+    );
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: true
+
 test_allow_date_parts_as_function_parameter_bigquery:
   # Allow use of BigQuery date parts (which are not quoted and were previously
   # mistaken for column references and flagged by this rule).


### PR DESCRIPTION
## What

Fixes #2598. RF02 (`references.qualification`) did not flag unqualified column references inside subqueries that also have access to an outer query's tables.

```sql
-- before: no diagnostic; after: RF02 on `x`
SELECT (SELECT 1 FROM t2 WHERE x = 1) AS sub1 FROM t1;

-- before: RF03 only; after: RF02 + RF03
SELECT (SELECT 1 FROM t2 WHERE x = t2.y) AS sub1 FROM t1;
```

## Why

This matches SQLFluff. When linting a subquery, SQLFluff merges the parent select's table references into the subquery's table list (unless the subquery is in a `FROM`/`JOIN` clause, is the from-element itself, or `subqueries_ignore_external_references` is set). A correlated/scalar subquery with access to an outer table therefore references more than one table, so its columns must be qualified.

sqruff already computed the parent select in `al04.rs` but named it `_parent_select` and discarded it, so RF02's `table_aliases.len() <= 1` check always short-circuited. (RF03 was unaffected because it uses a separate `Query`-based crawler.)

## Changes

- **`aliasing/al04.rs`**: thread `parent_select: Option<ErasedSegment>` and `&RuleContext` through the shared handler type and `eval`.
- **`references/rf02.rs`**: port SQLFluff's parent-table merge and `is_root_from_clause` logic, and add the `subqueries_ignore_external_references` config keyword (default `false`).
- **`lib-core/.../segments/select.rs`**: fix a related latent bug (SQLFluff #6389) where `SelectClauseElementSegment::alias` recursed into nested subqueries and picked up the inner alias (`... AS m`) instead of the element's own alias (`(...) AS _stats`); recursion now stops at `select_statement`.
- **`default_config.cfg`**: document the new config key.
- **`RF02.yml`**: port SQLFluff's subquery / external-reference test fixtures, including the issue #2598 case.

## Testing

`bazelisk test //...` — all 33 targets pass (incl. `cargo_test`, `cargo_clippy`, `cargo_fmt_check`, `codegen_docs_check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)