### PR TITLE
fix: handle postgres pgvector table layout

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -54,6 +54,7 @@ pub enum SyntaxKind {
     WithCompoundStatement,
     CommonTableExpression,
     CTEColumnList,
+    ReferencedColumnList,
     TriggerReference,
     TableConstraint,
     JoinOnCondition,

--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -134,6 +134,7 @@ pub enum SyntaxKind {
     IntervalExpression,
     ArrayType,
     SizedArrayType,
+    ArrayTypeSuffix,
     SelectStatement,
     OverlapsClause,
     SelectClause,

--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -285,14 +285,7 @@ fn build_datatype_segment_grammar(pgvector: bool) -> Matchable {
         ])
         .to_matchable(),
         one_of(vec![
-            AnyNumberOf::new(vec![
-                Bracketed::new(vec![
-                    Ref::new("ExpressionSegment").optional().to_matchable(),
-                ])
-                .config(|this| this.bracket_type("square"))
-                .to_matchable(),
-            ])
-            .to_matchable(),
+            Ref::new("ArrayTypeSuffixSegment").to_matchable(),
             Ref::new("ArrayTypeSegment").to_matchable(),
             Ref::new("SizedArrayTypeSegment").to_matchable(),
         ])
@@ -1266,6 +1259,23 @@ pub fn raw_dialect() -> Dialect {
                 Ref::new("DateTimeTypeIdentifier").optional().to_matchable(),
                 Ref::new("QuotedLiteralSegment").to_matchable(),
             ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    postgres.add([(
+        "ArrayTypeSuffixSegment".into(),
+        NodeMatcher::new(SyntaxKind::ArrayTypeSuffix, |_| {
+            AnyNumberOf::new(vec![
+                Bracketed::new(vec![
+                    Ref::new("ExpressionSegment").optional().to_matchable(),
+                ])
+                .config(|this| this.bracket_type("square"))
+                .to_matchable(),
+            ])
+            .config(|this| this.min_times(1))
             .to_matchable()
         })
         .to_matchable()

--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -277,7 +277,11 @@ fn build_datatype_segment_grammar(pgvector: bool) -> Matchable {
             Ref::new("WellKnownTextGeometrySegment").to_matchable(),
             Ref::new("DateTimeTypeIdentifier").to_matchable(),
             Sequence::new(vec![one_of(known_types).to_matchable()]).to_matchable(),
-            Ref::new("DatatypeIdentifierSegment").to_matchable(),
+            Sequence::new(vec![
+                Ref::new("DatatypeIdentifierSegment").to_matchable(),
+                Ref::new("BracketedArguments").optional().to_matchable(),
+            ])
+            .to_matchable(),
         ])
         .to_matchable(),
         one_of(vec![
@@ -293,6 +297,112 @@ fn build_datatype_segment_grammar(pgvector: bool) -> Matchable {
             Ref::new("SizedArrayTypeSegment").to_matchable(),
         ])
         .config(|this| this.optional())
+        .to_matchable(),
+    ])
+    .to_matchable()
+}
+
+fn table_constraint_body_grammar() -> Matchable {
+    Sequence::new(vec![
+        one_of(vec![
+            Sequence::new(vec![
+                Ref::keyword("CHECK").to_matchable(),
+                Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()]).to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("NO").to_matchable(),
+                    Ref::keyword("INHERIT").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("UNIQUE").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("NULLS").to_matchable(),
+                    Ref::keyword("NOT").optional().to_matchable(),
+                    Ref::keyword("DISTINCT").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
+                Ref::new("IndexParametersSegment").optional().to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::new("PrimaryKeyGrammar").to_matchable(),
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
+                Ref::new("IndexParametersSegment").optional().to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("EXCLUDE").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("USING").to_matchable(),
+                    Ref::new("IndexAccessMethodSegment").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Bracketed::new(vec![
+                    Delimited::new(vec![
+                        Ref::new("ExclusionConstraintElementSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::new("IndexParametersSegment").optional().to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("WHERE").to_matchable(),
+                    Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
+                        .to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("FOREIGN").to_matchable(),
+                Ref::keyword("KEY").to_matchable(),
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
+                Ref::new("ReferenceDefinitionGrammar").to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+        AnyNumberOf::new(vec![
+            one_of(vec![
+                Ref::keyword("DEFERRABLE").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("NOT").to_matchable(),
+                    Ref::keyword("DEFERRABLE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            one_of(vec![
+                Sequence::new(vec![
+                    Ref::keyword("INITIALLY").to_matchable(),
+                    Ref::keyword("DEFERRED").to_matchable(),
+                ])
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("INITIALLY").to_matchable(),
+                    Ref::keyword("IMMEDIATE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("NOT").to_matchable(),
+                Ref::keyword("VALID").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("NO").to_matchable(),
+                Ref::keyword("INHERIT").to_matchable(),
+            ])
+            .to_matchable(),
+        ])
         .to_matchable(),
     ])
     .to_matchable()
@@ -1165,6 +1275,53 @@ pub fn raw_dialect() -> Dialect {
     postgres.replace_grammar("DatatypeSegment", build_datatype_segment_grammar(false));
 
     postgres.replace_grammar("ArrayTypeSegment", Ref::keyword("ARRAY").to_matchable());
+
+    postgres.add([(
+        "ReferencedColumnListGrammar".into(),
+        NodeMatcher::new(SyntaxKind::ReferencedColumnList, |_| {
+            Ref::new("BracketedColumnReferenceListGrammar").to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    postgres.replace_grammar(
+        "ReferenceDefinitionGrammar",
+        Sequence::new(vec![
+            Ref::keyword("REFERENCES").to_matchable(),
+            Ref::new("TableReferenceSegment").to_matchable(),
+            Ref::new("ReferencedColumnListGrammar")
+                .optional()
+                .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("MATCH").to_matchable(),
+                one_of(vec![
+                    Ref::keyword("FULL").to_matchable(),
+                    Ref::keyword("PARTIAL").to_matchable(),
+                    Ref::keyword("SIMPLE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+            AnyNumberOf::new(vec![
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("DELETE").to_matchable(),
+                    Ref::new("ReferentialActionGrammar").to_matchable(),
+                ])
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("UPDATE").to_matchable(),
+                    Ref::new("ReferentialActionGrammar").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
 
     postgres.add([(
         "IndexAccessMethodSegment".into(),
@@ -4881,114 +5038,16 @@ pub fn raw_dialect() -> Dialect {
     postgres.add([(
         "TableConstraintSegment".into(),
         NodeMatcher::new(SyntaxKind::TableConstraint, |_| {
-            Sequence::new(vec![
+            one_of(vec![
                 Sequence::new(vec![
                     Ref::keyword("CONSTRAINT").to_matchable(),
                     Ref::new("ObjectReferenceSegment").to_matchable(),
-                ])
-                .config(|this| this.optional())
-                .to_matchable(),
-                one_of(vec![
-                    Sequence::new(vec![
-                        Ref::keyword("CHECK").to_matchable(),
-                        Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
-                            .to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("NO").to_matchable(),
-                            Ref::keyword("INHERIT").to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("UNIQUE").to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("NULLS").to_matchable(),
-                            Ref::keyword("NOT").optional().to_matchable(),
-                            Ref::keyword("DISTINCT").to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                        Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("IndexParametersSegment").optional().to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::new("PrimaryKeyGrammar").to_matchable(),
-                        Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("IndexParametersSegment").optional().to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("EXCLUDE").to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("USING").to_matchable(),
-                            Ref::new("IndexAccessMethodSegment").to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                        Bracketed::new(vec![
-                            Delimited::new(vec![
-                                Ref::new("ExclusionConstraintElementSegment").to_matchable(),
-                            ])
-                            .to_matchable(),
-                        ])
-                        .to_matchable(),
-                        Ref::new("IndexParametersSegment").optional().to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("WHERE").to_matchable(),
-                            Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
-                                .to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("FOREIGN").to_matchable(),
-                        Ref::keyword("KEY").to_matchable(),
-                        Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("ReferenceDefinitionGrammar").to_matchable(),
-                    ])
-                    .to_matchable(),
+                    MetaSegment::indent().to_matchable(),
+                    table_constraint_body_grammar(),
+                    MetaSegment::dedent().to_matchable(),
                 ])
                 .to_matchable(),
-                AnyNumberOf::new(vec![
-                    one_of(vec![
-                        Ref::keyword("DEFERRABLE").to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("NOT").to_matchable(),
-                            Ref::keyword("DEFERRABLE").to_matchable(),
-                        ])
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    one_of(vec![
-                        Sequence::new(vec![
-                            Ref::keyword("INITIALLY").to_matchable(),
-                            Ref::keyword("DEFERRED").to_matchable(),
-                        ])
-                        .to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("INITIALLY").to_matchable(),
-                            Ref::keyword("IMMEDIATE").to_matchable(),
-                        ])
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("NOT").to_matchable(),
-                        Ref::keyword("VALID").to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("NO").to_matchable(),
-                        Ref::keyword("INHERIT").to_matchable(),
-                    ])
-                    .to_matchable(),
-                ])
-                .to_matchable(),
+                table_constraint_body_grammar(),
             ])
             .to_matchable()
         })

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_table.yml
@@ -810,11 +810,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:
@@ -838,11 +839,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: MATCH
         - keyword: FULL
 - statement_terminator: ;
@@ -868,11 +870,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: RESTRICT
@@ -902,11 +905,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: NOT
         - keyword: VALID
 - statement_terminator: ;
@@ -1198,11 +1202,12 @@ file:
           - naked_identifier: landing
           - dot: .
           - naked_identifier: workorder
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/array.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/array.yml
@@ -69,17 +69,19 @@ file:
         - naked_identifier: pay_by_quarter
       - data_type:
         - keyword: integer
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: schedule
       - data_type:
         - keyword: text
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -94,14 +96,15 @@ file:
         - naked_identifier: squares
       - data_type:
         - keyword: integer
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '3'
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '3'
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '3'
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '3'
+          - end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -587,8 +590,9 @@ file:
                         - casting_operator: '::'
                         - data_type:
                           - keyword: int
-                          - start_square_bracket: '['
-                          - end_square_bracket: ']'
+                          - array_type_suffix:
+                            - start_square_bracket: '['
+                            - end_square_bracket: ']'
                     - alias_expression:
                       - keyword: AS
                       - naked_identifier: f1

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
@@ -1339,11 +1339,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: CASCADE
@@ -1356,11 +1357,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: ON
         - keyword: UPDATE
         - keyword: RESTRICT
@@ -1373,11 +1375,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: MATCH
         - keyword: SIMPLE
       - end_bracket: )
@@ -2351,14 +2354,15 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table1
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: col1
-          - comma: ','
-          - column_reference:
-            - naked_identifier: col2
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: col1
+            - comma: ','
+            - column_reference:
+              - naked_identifier: col2
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET
@@ -2413,14 +2417,15 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table1
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: col1
-          - comma: ','
-          - column_reference:
-            - naked_identifier: col2
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: col1
+            - comma: ','
+            - column_reference:
+              - naked_identifier: col2
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
@@ -75,10 +75,11 @@ file:
         - naked_identifier: vector
       - data_type:
         - keyword: int
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_view.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_view.yml
@@ -505,8 +505,9 @@ file:
                 - casting_operator: '::'
                 - data_type:
                   - keyword: INTEGER
-                  - start_square_bracket: '['
-                  - end_square_bracket: ']'
+                  - array_type_suffix:
+                    - start_square_bracket: '['
+                    - end_square_bracket: ']'
             - alias_expression:
               - keyword: AS
               - quoted_identifier: '"ancestors"'
@@ -529,8 +530,9 @@ file:
                 - casting_operator: '::'
                 - data_type:
                   - keyword: text
-                  - start_square_bracket: '['
-                  - end_square_bracket: ']'
+                  - array_type_suffix:
+                    - start_square_bracket: '['
+                    - end_square_bracket: ']'
             - alias_expression:
               - keyword: AS
               - quoted_identifier: '"path"'
@@ -549,8 +551,9 @@ file:
                 - casting_operator: '::'
                 - data_type:
                   - keyword: INTEGER
-                  - start_square_bracket: '['
-                  - end_square_bracket: ']'
+                  - array_type_suffix:
+                    - start_square_bracket: '['
+                    - end_square_bracket: ']'
             - alias_expression:
               - keyword: AS
               - quoted_identifier: '"path_nodes"'

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/datatypes.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/datatypes.yml
@@ -639,39 +639,43 @@ file:
         - naked_identifier: a
       - data_type:
         - keyword: integer
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: b
       - data_type:
         - keyword: float
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: c
       - data_type:
         - keyword: char
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '1'
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '1'
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: d
       - data_type:
         - keyword: jsonb
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '3'
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '5'
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '3'
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '5'
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: e

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/issue_2747_pgvector_formatting.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/issue_2747_pgvector_formatting.sql
@@ -1,0 +1,14 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS example_embeddings (
+    id BIGSERIAL NOT NULL,
+    source_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    embedding vector(1536),
+    labels TEXT[],
+    PRIMARY KEY (source_id, id),
+    CONSTRAINT fk_example_source
+        FOREIGN KEY (source_id)
+        REFERENCES example_sources(source_id)
+        ON DELETE CASCADE
+) PARTITION BY LIST (source_id);

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/issue_2747_pgvector_formatting.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/issue_2747_pgvector_formatting.yml
@@ -1,0 +1,108 @@
+file:
+- statement:
+  - create_extension_statement:
+    - keyword: CREATE
+    - keyword: EXTENSION
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - extension_reference:
+      - naked_identifier: vector
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: example_embeddings
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: id
+      - data_type:
+        - keyword: BIGSERIAL
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+        - naked_identifier: source_id
+      - data_type:
+        - keyword: BIGINT
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+        - naked_identifier: content
+      - data_type:
+        - keyword: TEXT
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+        - naked_identifier: embedding
+      - data_type:
+        - data_type_identifier: vector
+        - bracketed_arguments:
+          - bracketed:
+            - start_bracket: (
+            - numeric_literal: '1536'
+            - end_bracket: )
+      - comma: ','
+      - column_reference:
+        - naked_identifier: labels
+      - data_type:
+        - keyword: TEXT
+        - start_square_bracket: '['
+        - end_square_bracket: ']'
+      - comma: ','
+      - table_constraint:
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+            - naked_identifier: source_id
+          - comma: ','
+          - column_reference:
+            - naked_identifier: id
+          - end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+          - naked_identifier: fk_example_source
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+            - naked_identifier: source_id
+          - end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+          - naked_identifier: example_sources
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: source_id
+            - end_bracket: )
+        - keyword: ON
+        - keyword: DELETE
+        - keyword: CASCADE
+      - end_bracket: )
+    - keyword: PARTITION
+    - keyword: BY
+    - keyword: LIST
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: source_id
+      - end_bracket: )
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/issue_2747_pgvector_formatting.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/issue_2747_pgvector_formatting.yml
@@ -58,8 +58,9 @@ file:
         - naked_identifier: labels
       - data_type:
         - keyword: TEXT
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - table_constraint:
         - keyword: PRIMARY

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -98,7 +98,6 @@ spacing_after = touch
 spacing_before = touch
 
 [sqruff:layout:type:start_square_bracket]
-spacing_before = touch:inline
 spacing_after = touch
 
 [sqruff:layout:type:end_square_bracket]
@@ -162,6 +161,10 @@ spacing_within = touch
 
 [sqruff:layout:type:sized_array_type]
 spacing_within = touch
+
+[sqruff:layout:type:array_type_suffix]
+spacing_before = touch:inline
+spacing_within = touch:inline
 
 [sqruff:layout:type:struct_type]
 spacing_within = touch:inline

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -98,6 +98,7 @@ spacing_after = touch
 spacing_before = touch
 
 [sqruff:layout:type:start_square_bracket]
+spacing_before = touch:inline
 spacing_after = touch
 
 [sqruff:layout:type:end_square_bracket]
@@ -176,6 +177,9 @@ spacing_within = touch:inline
 spacing_before = touch:inline
 
 [sqruff:layout:type:array_accessor]
+spacing_before = touch:inline
+
+[sqruff:layout:type:referenced_column_list]
 spacing_before = touch:inline
 
 [sqruff:layout:type:colon]

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -288,6 +288,20 @@ test_bigquery_datatype:
     core:
       dialect: bigquery
 
+test_bigquery_array_literal_spacing:
+  pass_str: |
+    SELECT [1, 2, 3] AS arr
+  configs:
+    core:
+      dialect: bigquery
+
+test_duckdb_array_literal_spacing:
+  pass_str: |
+    SELECT [1, 2, 3] AS arr
+  configs:
+    core:
+      dialect: duckdb
+
 test_athena_datatype:
   pass_str: |
       select
@@ -336,6 +350,13 @@ test_sparksql_datatype:
           'bar'::CHAR(3),
           col1::STRUCT<foo: int>,
           col2::ARRAY<int>
+  configs:
+    core:
+      dialect: sparksql
+
+test_sparksql_array_literal_spacing:
+  pass_str: |
+    SELECT [1, 2, 3] AS arr
   configs:
     core:
       dialect: sparksql

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01_LT02-postgres.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01_LT02-postgres.yml
@@ -1,0 +1,21 @@
+rule: LT01,LT02
+
+test_pass_postgres_pgvector_create_table_layout:
+  pass_str: |
+    CREATE EXTENSION IF NOT EXISTS vector;
+
+    CREATE TABLE IF NOT EXISTS example_embeddings (
+        id BIGSERIAL NOT NULL,
+        source_id BIGINT NOT NULL,
+        content TEXT NOT NULL,
+        embedding vector(1536),
+        labels TEXT[],
+        PRIMARY KEY (source_id, id),
+        CONSTRAINT fk_example_source
+            FOREIGN KEY (source_id)
+            REFERENCES example_sources(source_id)
+            ON DELETE CASCADE
+    ) PARTITION BY LIST (source_id);
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
PostgreSQL pgvector table formatting should preserve the expected layout for CREATE TABLE statements that combine extension-style vector columns, array types, table constraints, and partition clauses.

The current Postgres formatting path treats pgvector-style `vector(...)` and adjacent bracketed syntax too broadly, so reflow inserts spaces into PostgreSQL type/reference syntax and removes expected continuation indentation from table constraints. This change gives the parser and reflow config more precise segment types for these constructs so `vector(1536)`, `TEXT[]`, and `REFERENCES table(column)` keep their PostgreSQL shape while table bodies retain their indentation.

Closes #2747