### PR TITLE
fix(sqlite): support bind parameters so >= isn't split before @param

### DIFF
--- a/crates/lib-dialects/src/sqlite.rs
+++ b/crates/lib-dialects/src/sqlite.rs
@@ -9,7 +9,7 @@ use sqruff_lib_core::parser::grammar::{Anything, Nothing, Ref};
 use sqruff_lib_core::parser::lexer::Matcher;
 use sqruff_lib_core::parser::matchable::MatchableTrait;
 use sqruff_lib_core::parser::node_matcher::NodeMatcher;
-use sqruff_lib_core::parser::parsers::TypedParser;
+use sqruff_lib_core::parser::parsers::{StringParser, TypedParser};
 use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::parser::types::ParseMode;
 
@@ -42,6 +42,27 @@ pub fn raw_dialect() -> Dialect {
             SyntaxKind::BytesSingleQuote,
         )],
         "single_quote",
+    );
+
+    // SQLite bind parameters: @name, :name, ?NNN and $name. These must be
+    // lexed before the bare `question`/`colon` matchers so the full parameter
+    // token is captured (e.g. `>= @since` instead of splitting `>=`).
+    sqlite_dialect.insert_lexer_matchers(
+        vec![
+            Matcher::regex(
+                "at_sign_literal",
+                r"@[a-zA-Z0-9_]+",
+                SyntaxKind::AtSignLiteral,
+            ),
+            Matcher::regex("colon_literal", r":[a-zA-Z0-9_]+", SyntaxKind::ColonLiteral),
+            Matcher::regex("question_literal", r"\?[0-9]+", SyntaxKind::QuestionLiteral),
+            Matcher::regex(
+                "dollar_literal",
+                r"\$[a-zA-Z0-9_]+",
+                SyntaxKind::DollarLiteral,
+            ),
+        ],
+        "question",
     );
 
     sqlite_dialect.sets_mut("reserved_keywords").clear();
@@ -79,13 +100,64 @@ pub fn raw_dialect() -> Dialect {
                 .to_matchable()
                 .into(),
         ),
+        // SQLite bind parameter segments.
+        (
+            "AtSignLiteralSegment".into(),
+            TypedParser::new(SyntaxKind::AtSignLiteral, SyntaxKind::AtSignLiteral)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "ColonLiteralSegment".into(),
+            TypedParser::new(SyntaxKind::ColonLiteral, SyntaxKind::ColonLiteral)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "QuestionLiteralSegment".into(),
+            TypedParser::new(SyntaxKind::QuestionLiteral, SyntaxKind::QuestionLiteral)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "DollarLiteralSegment".into(),
+            TypedParser::new(SyntaxKind::DollarLiteral, SyntaxKind::DollarLiteral)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "QuestionMarkSegment".into(),
+            StringParser::new("?", SyntaxKind::QuestionMark)
+                .to_matchable()
+                .into(),
+        ),
+        // SQLite allows named and argument based parameters to prevent SQL
+        // injection: @name, ?, :name, ?NNN and $name.
+        (
+            "ParameterizedSegment".into(),
+            NodeMatcher::new(SyntaxKind::ParameterizedExpression, |_| {
+                one_of(vec![
+                    Ref::new("AtSignLiteralSegment").to_matchable(),
+                    Ref::new("QuestionMarkSegment").to_matchable(),
+                    Ref::new("ColonLiteralSegment").to_matchable(),
+                    Ref::new("QuestionLiteralSegment").to_matchable(),
+                    Ref::new("DollarLiteralSegment").to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
         // Extend LiteralGrammar to include blob literals
         (
             "LiteralGrammar".into(),
             sqlite_dialect
                 .grammar("LiteralGrammar")
                 .copy(
-                    Some(vec![Ref::new("BytesQuotedLiteralSegment").to_matchable()]),
+                    Some(vec![
+                        Ref::new("ParameterizedSegment").to_matchable(),
+                        Ref::new("BytesQuotedLiteralSegment").to_matchable(),
+                    ]),
                     None,
                     None,
                     None,

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/named_parameters.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/named_parameters.sql
@@ -1,0 +1,33 @@
+SELECT @variable
+FROM table1
+WHERE @variable = 1;
+
+SELECT ?2
+FROM table1
+WHERE ?2 = 1;
+
+SELECT :variable
+FROM table1
+WHERE :variable = 1;
+
+SELECT $variable
+FROM table1
+WHERE $variable = 1;
+
+SELECT @variable
+FROM table1
+GROUP BY @variable
+HAVING $variable = 1;
+
+SELECT ? from table1 where ? = 1;
+
+-- Bind parameters directly after a compound comparison operator must not
+-- split the operator (e.g. `>=` into `> =`). See issue #2624.
+SELECT id, title, published_at
+FROM posts
+WHERE published_at >= @since;
+
+SELECT id
+FROM posts
+GROUP BY id
+HAVING count(id) >= @threshold;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/named_parameters.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/named_parameters.yml
@@ -1,0 +1,216 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - at_sign_literal: '@variable'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - parameterized_expression:
+          - at_sign_literal: '@variable'
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - question_literal: ?2
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - parameterized_expression:
+          - question_literal: ?2
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - colon_literal: :variable
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - parameterized_expression:
+          - colon_literal: :variable
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - dollar_literal: $variable
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - parameterized_expression:
+          - dollar_literal: $variable
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - at_sign_literal: '@variable'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - expression:
+        - parameterized_expression:
+          - at_sign_literal: '@variable'
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - parameterized_expression:
+          - dollar_literal: $variable
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - parameterized_expression:
+          - question_mark: '?'
+    - from_clause:
+      - keyword: from
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+    - where_clause:
+      - keyword: where
+      - expression:
+        - parameterized_expression:
+          - question_mark: '?'
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: title
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: published_at
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: posts
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: published_at
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+          - raw_comparison_operator: =
+        - parameterized_expression:
+          - at_sign_literal: '@since'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: id
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: posts
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: id
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: id
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+          - raw_comparison_operator: =
+        - parameterized_expression:
+          - at_sign_literal: '@threshold'
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #2624

In the SQLite dialect, `sqruff fix` was mangling `WHERE published_at >= @since` into `published_at > =` on its own line. Turns out the operator wasn't really the problem — SQLite bind parameters weren't supported at all, so `@since` parsed as an unparsable section. That made the `>=` comparison fail to match, the parser backtracked, and `>=` fell apart into two loose symbols that the layout rules then happily spaced and wrapped.

The actual fix is to teach the SQLite dialect about bind parameters, matching SQLFluff: `@name`, `:name`, `?NNN`, `$name`, and bare `?`. Once `@since` parses as a proper expression, the comparison matches and `>=` stays intact.

Changes:
- Lexer matchers for the four parameter forms, inserted ahead of the bare `?`/`:` matchers so the whole token gets captured.
- A `ParameterizedSegment` wiring those forms (plus `?`) into `LiteralGrammar`.
- A `named_parameters.sql` fixture covering every form in SELECT/WHERE/HAVING, including the exact `>= @since` case from the issue.

All `SyntaxKind` variants already existed, so this stays contained to the SQLite dialect.
