### PR TITLE
fix(reflow): don't split operators inside unparsable sections

### DIFF
--- a/crates/lib/src/utils/reflow/elements.rs
+++ b/crates/lib/src/utils/reflow/elements.rs
@@ -427,6 +427,18 @@ impl ReflowPoint {
         anchor_on: &'static str,
     ) -> (Vec<LintResult>, ReflowPoint) {
         let mut existing_results = lint_results;
+
+        // Leave spacing untouched when it lives entirely inside an unparsable
+        // section. Since we couldn't parse that section we don't understand its
+        // tokens, so reformatting it is unsafe - e.g. splitting `>=` into `> =`
+        // when the right-hand side fails to parse (issue #2624).
+        if let (Some(prev_block), Some(next_block)) = (prev_block, next_block)
+            && prev_block.within_unparsable()
+            && next_block.within_unparsable()
+        {
+            return (existing_results, self.clone());
+        }
+
         let (pre_constraint, post_constraint, strip_newlines) =
             determine_constraints(prev_block, next_block, strip_newlines);
 
@@ -653,6 +665,14 @@ impl ReflowBlock {
 
     pub fn class_types(&self) -> &SyntaxSet {
         self.segment.class_types()
+    }
+
+    /// Whether this block sits inside an unparsable section.
+    pub fn within_unparsable(&self) -> bool {
+        self.depth_info
+            .stack_class_types
+            .iter()
+            .any(|types| types.contains(SyntaxKind::Unparsable))
     }
 
     pub fn stack_spacing_configs(&self) -> &IntMap<u64, Spacing> {

--- a/crates/lib/src/utils/reflow/respace.rs
+++ b/crates/lib/src/utils/reflow/respace.rs
@@ -656,6 +656,22 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_reflow_sequence_respace_keeps_operator_in_unparsable() {
+        // https://github.com/quarylabs/sqruff/issues/2624
+        // When the right-hand side of a comparison fails to parse, `>=` ends up
+        // inside an unparsable section. Reflow must leave that section alone
+        // rather than splitting the operator into `> =`.
+        let tables = Tables::default();
+        let root = parse_ansi_string("SELECT 1 FROM t WHERE a >= @x");
+        let config = <_>::default();
+        let seq = ReflowSequence::from_root(&root, &config);
+
+        let out = seq.respace(&tables, false, Filter::All).raw();
+        assert!(out.contains(">="), "operator should stay joined: {out:?}");
+        assert!(!out.contains("> ="), "operator must not be split: {out:?}");
+    }
+
     #[derive(Debug, Clone, Copy, PartialEq)]
     enum EditType {
         CreateBefore,


### PR DESCRIPTION
Follow-up hardening to #2624.

That issue (SQLite splitting `>=` into `> =` before `@param`) was fixed by adding bind-parameter support so `@since` parses. But the underlying fragility was more general: whenever the right-hand side of a compound comparison fails to parse, the operator ends up inside an unparsable node as two separate `raw_comparison_operator` tokens, and reflow happily spaces them apart.

It reproduces in plenty of places the bind-parameter fix doesn't touch:

```sql
-- ansi
SELECT 1 FROM t WHERE a >= @x   -- becomes `a > =`
SELECT 1 FROM t WHERE a <= @x
SELECT 1 FROM t WHERE a != @x
-- any dialect, any unparsable RHS
SELECT 1 FROM t WHERE a >= #x
```

The parse tree shows why — both halves of the operator live under `unparsable`:

```
- unparsable:
  - raw_comparison_operator: '>'
  - raw_comparison_operator: =
```

The fix: reflow leaves spacing alone when it lives entirely inside an unparsable section. If we couldn't parse it, we shouldn't reformat it. Spacing on the boundary into the section is still handled normally.

- `ReflowBlock::within_unparsable()` checks the depth-info ancestor stack.
- `respace_point` bails early (returning the point unchanged) when both neighbouring blocks are within an unparsable section.
- Regression test in `respace.rs` asserts `>=` stays joined.
