### PR TITLE
chore: bump secretlint deps to 13.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     ]
   },
   "devDependencies": {
-    "@secretlint/secretlint-formatter-sarif": "^11.4.0",
-    "@secretlint/secretlint-rule-no-dotenv": "^11.7.1",
+    "@secretlint/secretlint-formatter-sarif": "^13.0.2",
+    "@secretlint/secretlint-rule-no-dotenv": "^13.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
     "prettier": "^3.8.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
   .:
     devDependencies:
       '@secretlint/secretlint-formatter-sarif':
-        specifier: ^11.4.0
-        version: 11.4.0
+        specifier: ^13.0.2
+        version: 13.0.2
       '@secretlint/secretlint-rule-no-dotenv':
-        specifier: ^11.7.1
-        version: 11.7.1
+        specifier: ^13.0.2
+        version: 13.0.2
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: ^13.0.2
         version: 13.0.2
@@ -113,7 +113,7 @@ importers:
         version: 10.5.0(jiti@2.7.0)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
+        version: 2.32.0(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@10.5.0(jiti@2.7.0))
@@ -749,16 +749,16 @@ packages:
   '@secretlint/secretlint-formatter-sarif@10.2.2':
     resolution: {integrity: sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==}
 
-  '@secretlint/secretlint-formatter-sarif@11.4.0':
-    resolution: {integrity: sha512-787kS48WBSSaMxDnY5bI3rjs5Uc0WCLeh/qBz9Iu+aj6HJzN2cMO/BE7CkzCqvkgls43BuBwR2kBS4+fHOJ2Dg==}
+  '@secretlint/secretlint-formatter-sarif@13.0.2':
+    resolution: {integrity: sha512-FmLM5RRWaBvQR/LlYLusIJHGjS+HzQFLW8llqauw7a3Vzo9w3/qxsWeRF9VGDoaQl4/fUmtDDn/U6XrWqqoVRg==}
 
   '@secretlint/secretlint-rule-no-dotenv@10.2.2':
     resolution: {integrity: sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==}
     engines: {node: '>=20.0.0'}
 
-  '@secretlint/secretlint-rule-no-dotenv@11.7.1':
-    resolution: {integrity: sha512-U2dIwVklhTInTSw44DVX8l2Cd/txzx080HNFLbxQQmCxicgXUh+SZGrZr+JfAmQuL6BoZM9bfZV/LtPDREDFAA==}
-    engines: {node: '>=20.0.0'}
+  '@secretlint/secretlint-rule-no-dotenv@13.0.2':
+    resolution: {integrity: sha512-D93y+7yNe1VxmSVGU2IKmr15Ti0ZtfLyCee6ro8Hhwtb73F9JtIochFSGrBaCnFlmxv7otcgKesRbPhwUJUKLw==}
+    engines: {node: '>=22.0.0'}
 
   '@secretlint/secretlint-rule-preset-recommend@10.2.2':
     resolution: {integrity: sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==}
@@ -776,9 +776,9 @@ packages:
     resolution: {integrity: sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==}
     engines: {node: '>=20.0.0'}
 
-  '@secretlint/types@11.7.1':
-    resolution: {integrity: sha512-bIkBwIdQScZX5xm3DsLp3oL5U/KKUYWgmst39dZsDi55X9tKuPd7/uVpO1PqNrDW1I0QD5t6es/2LonG5RjxXg==}
-    engines: {node: '>=20.0.0'}
+  '@secretlint/types@13.0.2':
+    resolution: {integrity: sha512-cAZjr6ZTKgSuJMLyTGDrUEtK3XEZa+JStIkD+DmdkT32VGAN+dQJiYr1So3XJopsKSrqhP5kjZKT8WWtftZIpQ==}
+    engines: {node: '>=22.0.0'}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -2967,6 +2967,10 @@ packages:
     resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
     engines: {node: '>=20'}
 
+  node-sarif-builder@4.1.0:
+    resolution: {integrity: sha512-IWqZF6u0EI/07HTBm+zZ+MgXgWl09dnSJRGaDCPBSlOqilDcx6pj3Mpb3HvPN8V2Gr+ISw7ZrMsL7STWs1F++w==}
+    engines: {node: '>=20'}
+
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
@@ -4621,17 +4625,17 @@ snapshots:
     dependencies:
       node-sarif-builder: 3.4.0
 
-  '@secretlint/secretlint-formatter-sarif@11.4.0':
+  '@secretlint/secretlint-formatter-sarif@13.0.2':
     dependencies:
-      node-sarif-builder: 3.4.0
+      node-sarif-builder: 4.1.0
 
   '@secretlint/secretlint-rule-no-dotenv@10.2.2':
     dependencies:
       '@secretlint/types': 10.2.2
 
-  '@secretlint/secretlint-rule-no-dotenv@11.7.1':
+  '@secretlint/secretlint-rule-no-dotenv@13.0.2':
     dependencies:
-      '@secretlint/types': 11.7.1
+      '@secretlint/types': 13.0.2
 
   '@secretlint/secretlint-rule-preset-recommend@10.2.2': {}
 
@@ -4644,7 +4648,7 @@ snapshots:
 
   '@secretlint/types@10.2.2': {}
 
-  '@secretlint/types@11.7.1': {}
+  '@secretlint/types@13.0.2': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -5953,17 +5957,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.5.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.5.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5974,7 +5977,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.5.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.5.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@10.5.0(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5985,8 +5988,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7115,6 +7116,11 @@ snapshots:
   node-releases@2.0.36: {}
 
   node-sarif-builder@3.4.0:
+    dependencies:
+      '@types/sarif': 2.1.7
+      fs-extra: 11.3.4
+
+  node-sarif-builder@4.1.0:
     dependencies:
       '@types/sarif': 2.1.7
       fs-extra: 11.3.4


### PR DESCRIPTION
Consolidates the two open dependabot bumps into a single change so they don't conflict on `pnpm-lock.yaml`:

- `@secretlint/secretlint-formatter-sarif`: `^11.4.0` → `^13.0.2` (supersedes #2754)
- `@secretlint/secretlint-rule-no-dotenv`: `^11.7.1` → `^13.0.2` (supersedes #2755)

`@secretlint/secretlint-rule-preset-recommend` is already at `^13.0.2`, so all three direct secretlint devDependencies are now aligned at `13.0.2` (the latest published version).

The `@secretlint/*@10.2.2` family in the lockfile is a transitive dependency of `@vscode/vsce` and is intentionally left untouched.

Closes #2754
Closes #2755

🤖 Generated with [Claude Code](https://claude.com/claude-code)