### PR TITLE
chore: update documentation links in default config

### DIFF
--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -51,7 +51,7 @@ large_file_skip_byte_limit = 20000
 max_line_length = 80
 
 [sqruff:indentation]
-# See https://docs.sqruff.com/layout#configuring-indent-locations
+# See https://playground.quary.dev/docs/usage/configuration/
 indent_unit = space
 tab_space_size = 4
 indented_joins = False
@@ -72,7 +72,7 @@ skip_indentation_in = script_content
 trailing_comments = before
 
 # Layout configuration
-# See https://docs.sqruff.com/layout#configuring-layout-and-spacing
+# See https://playground.quary.dev/docs/usage/configuration/
 [sqruff:layout:type:comma]
 spacing_before = touch
 line_position = trailing


### PR DESCRIPTION
## Summary
Updated outdated SQLFluff documentation links in the default configuration file to point to the Quary playground documentation instead.

## Changes
- Updated indentation configuration documentation link from `https://docs.sqruff.com/layout#configuring-indent-locations` to `https://playground.quary.dev/docs/usage/configuration/`
- Updated layout configuration documentation link from `https://docs.sqruff.com/layout#configuring-layout-and-spacing` to `https://playground.quary.dev/docs/usage/configuration/`

These changes ensure users are directed to the correct, current documentation when reviewing the default configuration file.

https://claude.ai/code/session_015tj5nbsU5iQTLAboXwtRHn