### PR TITLE
fix: scope postgres array suffix spacing

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -133,6 +133,7 @@ pub enum SyntaxKind {
     IntervalExpression,
     ArrayType,
     SizedArrayType,
+    ArrayTypeSuffix,
     SelectStatement,
     OverlapsClause,
     SelectClause,

--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -281,14 +281,7 @@ fn build_datatype_segment_grammar(pgvector: bool) -> Matchable {
         ])
         .to_matchable(),
         one_of(vec![
-            AnyNumberOf::new(vec![
-                Bracketed::new(vec![
-                    Ref::new("ExpressionSegment").optional().to_matchable(),
-                ])
-                .config(|this| this.bracket_type("square"))
-                .to_matchable(),
-            ])
-            .to_matchable(),
+            Ref::new("ArrayTypeSuffixSegment").to_matchable(),
             Ref::new("ArrayTypeSegment").to_matchable(),
             Ref::new("SizedArrayTypeSegment").to_matchable(),
         ])
@@ -1156,6 +1149,23 @@ pub fn raw_dialect() -> Dialect {
                 Ref::new("DateTimeTypeIdentifier").optional().to_matchable(),
                 Ref::new("QuotedLiteralSegment").to_matchable(),
             ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    postgres.add([(
+        "ArrayTypeSuffixSegment".into(),
+        NodeMatcher::new(SyntaxKind::ArrayTypeSuffix, |_| {
+            AnyNumberOf::new(vec![
+                Bracketed::new(vec![
+                    Ref::new("ExpressionSegment").optional().to_matchable(),
+                ])
+                .config(|this| this.bracket_type("square"))
+                .to_matchable(),
+            ])
+            .config(|this| this.min_times(1))
             .to_matchable()
         })
         .to_matchable()

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/array.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/array.yml
@@ -69,17 +69,19 @@ file:
         - naked_identifier: pay_by_quarter
       - data_type:
         - keyword: integer
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: schedule
       - data_type:
         - keyword: text
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -94,14 +96,15 @@ file:
         - naked_identifier: squares
       - data_type:
         - keyword: integer
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '3'
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '3'
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '3'
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '3'
+          - end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -587,8 +590,9 @@ file:
                         - casting_operator: '::'
                         - data_type:
                           - keyword: int
-                          - start_square_bracket: '['
-                          - end_square_bracket: ']'
+                          - array_type_suffix:
+                            - start_square_bracket: '['
+                            - end_square_bracket: ']'
                     - alias_expression:
                       - keyword: AS
                       - naked_identifier: f1

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
@@ -75,10 +75,11 @@ file:
         - naked_identifier: vector
       - data_type:
         - keyword: int
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_view.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_view.yml
@@ -505,8 +505,9 @@ file:
                 - casting_operator: '::'
                 - data_type:
                   - keyword: INTEGER
-                  - start_square_bracket: '['
-                  - end_square_bracket: ']'
+                  - array_type_suffix:
+                    - start_square_bracket: '['
+                    - end_square_bracket: ']'
             - alias_expression:
               - keyword: AS
               - quoted_identifier: '"ancestors"'
@@ -529,8 +530,9 @@ file:
                 - casting_operator: '::'
                 - data_type:
                   - keyword: text
-                  - start_square_bracket: '['
-                  - end_square_bracket: ']'
+                  - array_type_suffix:
+                    - start_square_bracket: '['
+                    - end_square_bracket: ']'
             - alias_expression:
               - keyword: AS
               - quoted_identifier: '"path"'
@@ -549,8 +551,9 @@ file:
                 - casting_operator: '::'
                 - data_type:
                   - keyword: INTEGER
-                  - start_square_bracket: '['
-                  - end_square_bracket: ']'
+                  - array_type_suffix:
+                    - start_square_bracket: '['
+                    - end_square_bracket: ']'
             - alias_expression:
               - keyword: AS
               - quoted_identifier: '"path_nodes"'

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/datatypes.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/datatypes.yml
@@ -639,39 +639,43 @@ file:
         - naked_identifier: a
       - data_type:
         - keyword: integer
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: b
       - data_type:
         - keyword: float
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: c
       - data_type:
         - keyword: char
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '1'
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '1'
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: d
       - data_type:
         - keyword: jsonb
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '3'
-        - end_square_bracket: ']'
-        - start_square_bracket: '['
-        - expression:
-          - numeric_literal: '5'
-        - end_square_bracket: ']'
+        - array_type_suffix:
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '3'
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - expression:
+            - numeric_literal: '5'
+          - end_square_bracket: ']'
       - comma: ','
       - column_reference:
         - naked_identifier: e

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -162,6 +162,10 @@ spacing_within = touch
 [sqruff:layout:type:sized_array_type]
 spacing_within = touch
 
+[sqruff:layout:type:array_type_suffix]
+spacing_before = touch:inline
+spacing_within = touch:inline
+
 [sqruff:layout:type:struct_type]
 spacing_within = touch:inline
 

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -288,6 +288,20 @@ test_bigquery_datatype:
     core:
       dialect: bigquery
 
+test_bigquery_array_literal_spacing:
+  pass_str: |
+    SELECT [1, 2, 3] AS arr
+  configs:
+    core:
+      dialect: bigquery
+
+test_duckdb_array_literal_spacing:
+  pass_str: |
+    SELECT [1, 2, 3] AS arr
+  configs:
+    core:
+      dialect: duckdb
+
 test_athena_datatype:
   pass_str: |
       select
@@ -336,6 +350,13 @@ test_sparksql_datatype:
           'bar'::CHAR(3),
           col1::STRUCT<foo: int>,
           col2::ARRAY<int>
+  configs:
+    core:
+      dialect: sparksql
+
+test_sparksql_array_literal_spacing:
+  pass_str: |
+    SELECT [1, 2, 3] AS arr
   configs:
     core:
       dialect: sparksql


### PR DESCRIPTION
PostgreSQL array datatype suffixes should keep their type-suffix shape without changing square-bracket spacing for array literals in other dialects.

Postgres supports datatype suffixes like `TEXT[]` and `integer[3][3]`, but treating the raw `[` token globally as touch-before also changes array literals such as `SELECT [1, 2, 3] AS arr` in dialects where the leading space is expected. This introduces a Postgres-specific `array_type_suffix` segment so layout can keep datatype suffixes tight while leaving general square-bracket spacing alone.

This keeps the spacing behavior focused on the Postgres datatype construct and adds regression coverage for BigQuery, SparkSQL, and DuckDB array literals.