### PR TITLE
fix: preserve postgres reference column list spacing

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -54,6 +54,7 @@ pub enum SyntaxKind {
     WithCompoundStatement,
     CommonTableExpression,
     CTEColumnList,
+    ReferencedColumnList,
     TriggerReference,
     TableConstraint,
     JoinOnCondition,

--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -1167,6 +1167,55 @@ pub fn raw_dialect() -> Dialect {
     postgres.replace_grammar("ArrayTypeSegment", Ref::keyword("ARRAY").to_matchable());
 
     postgres.add([(
+        "ReferencedColumnListGrammar".into(),
+        NodeMatcher::new(SyntaxKind::ReferencedColumnList, |_| {
+            Ref::new("BracketedColumnReferenceListGrammar").to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    postgres.replace_grammar(
+        "ReferenceDefinitionGrammar",
+        Sequence::new(vec![
+            Ref::keyword("REFERENCES").to_matchable(),
+            Ref::new("TableReferenceSegment").to_matchable(),
+            // Foreign columns making up FOREIGN KEY constraint
+            Ref::new("ReferencedColumnListGrammar")
+                .optional()
+                .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("MATCH").to_matchable(),
+                one_of(vec![
+                    Ref::keyword("FULL").to_matchable(),
+                    Ref::keyword("PARTIAL").to_matchable(),
+                    Ref::keyword("SIMPLE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+            AnyNumberOf::new(vec![
+                // ON DELETE clause, e.g. ON DELETE NO ACTION
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("DELETE").to_matchable(),
+                    Ref::new("ReferentialActionGrammar").to_matchable(),
+                ])
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("UPDATE").to_matchable(),
+                    Ref::new("ReferentialActionGrammar").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    postgres.add([(
         "IndexAccessMethodSegment".into(),
         NodeMatcher::new(SyntaxKind::IndexAccessMethod, |_| {
             Ref::new("SingleIdentifierGrammar").to_matchable()

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_table.yml
@@ -810,11 +810,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:
@@ -838,11 +839,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: MATCH
         - keyword: FULL
 - statement_terminator: ;
@@ -868,11 +870,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: RESTRICT
@@ -902,11 +905,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: NOT
         - keyword: VALID
 - statement_terminator: ;
@@ -1198,11 +1202,12 @@ file:
           - naked_identifier: landing
           - dot: .
           - naked_identifier: workorder
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
@@ -1339,11 +1339,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: CASCADE
@@ -1356,11 +1357,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: ON
         - keyword: UPDATE
         - keyword: RESTRICT
@@ -1373,11 +1375,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: MATCH
         - keyword: SIMPLE
       - end_bracket: )
@@ -2351,14 +2354,15 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table1
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: col1
-          - comma: ','
-          - column_reference:
-            - naked_identifier: col2
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: col1
+            - comma: ','
+            - column_reference:
+              - naked_identifier: col2
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET
@@ -2413,14 +2417,15 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table1
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: col1
-          - comma: ','
-          - column_reference:
-            - naked_identifier: col2
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: col1
+            - comma: ','
+            - column_reference:
+              - naked_identifier: col2
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -178,6 +178,9 @@ spacing_before = touch:inline
 [sqruff:layout:type:array_accessor]
 spacing_before = touch:inline
 
+[sqruff:layout:type:referenced_column_list]
+spacing_before = touch:inline
+
 [sqruff:layout:type:colon]
 spacing_before = touch
 

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -267,6 +267,15 @@ test_postgres_datatype:
     core:
       dialect: postgres
 
+test_postgres_referenced_column_list_spacing:
+  pass_str: |
+    CREATE TABLE child (
+        parent_id INTEGER REFERENCES parent(id)
+    );
+  configs:
+    core:
+      dialect: postgres
+
 test_redshift_datatype:
   pass_str: |
     select


### PR DESCRIPTION
PostgreSQL foreign-key references should preserve the table-to-column-list form used by `REFERENCES parent(id)`.

The referenced column list currently parses as a generic bracketed list, so layout treats it like ordinary bracketed syntax and can insert a space between the referenced table and its column list. This adds a dedicated `referenced_column_list` segment for Postgres reference definitions so layout can keep that relationship tight without changing generic bracket handling.

The change applies to column and table foreign-key references through the shared `ReferenceDefinitionGrammar`.