### PR TITLE
fix: preserve postgres named constraint indentation

### DIFF
--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -298,6 +298,112 @@ fn build_datatype_segment_grammar(pgvector: bool) -> Matchable {
     .to_matchable()
 }
 
+fn table_constraint_body_grammar() -> Matchable {
+    Sequence::new(vec![
+        one_of(vec![
+            Sequence::new(vec![
+                Ref::keyword("CHECK").to_matchable(),
+                Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()]).to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("NO").to_matchable(),
+                    Ref::keyword("INHERIT").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("UNIQUE").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("NULLS").to_matchable(),
+                    Ref::keyword("NOT").optional().to_matchable(),
+                    Ref::keyword("DISTINCT").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
+                Ref::new("IndexParametersSegment").optional().to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::new("PrimaryKeyGrammar").to_matchable(),
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
+                Ref::new("IndexParametersSegment").optional().to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("EXCLUDE").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("USING").to_matchable(),
+                    Ref::new("IndexAccessMethodSegment").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Bracketed::new(vec![
+                    Delimited::new(vec![
+                        Ref::new("ExclusionConstraintElementSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::new("IndexParametersSegment").optional().to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("WHERE").to_matchable(),
+                    Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
+                        .to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("FOREIGN").to_matchable(),
+                Ref::keyword("KEY").to_matchable(),
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
+                Ref::new("ReferenceDefinitionGrammar").to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+        AnyNumberOf::new(vec![
+            one_of(vec![
+                Ref::keyword("DEFERRABLE").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("NOT").to_matchable(),
+                    Ref::keyword("DEFERRABLE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            one_of(vec![
+                Sequence::new(vec![
+                    Ref::keyword("INITIALLY").to_matchable(),
+                    Ref::keyword("DEFERRED").to_matchable(),
+                ])
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("INITIALLY").to_matchable(),
+                    Ref::keyword("IMMEDIATE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("NOT").to_matchable(),
+                Ref::keyword("VALID").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("NO").to_matchable(),
+                Ref::keyword("INHERIT").to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    ])
+    .to_matchable()
+}
+
 pub fn raw_dialect() -> Dialect {
     let mut postgres = ansi::raw_dialect();
     postgres.name = DialectKind::Postgres;
@@ -4881,114 +4987,16 @@ pub fn raw_dialect() -> Dialect {
     postgres.add([(
         "TableConstraintSegment".into(),
         NodeMatcher::new(SyntaxKind::TableConstraint, |_| {
-            Sequence::new(vec![
+            one_of(vec![
                 Sequence::new(vec![
                     Ref::keyword("CONSTRAINT").to_matchable(),
                     Ref::new("ObjectReferenceSegment").to_matchable(),
-                ])
-                .config(|this| this.optional())
-                .to_matchable(),
-                one_of(vec![
-                    Sequence::new(vec![
-                        Ref::keyword("CHECK").to_matchable(),
-                        Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
-                            .to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("NO").to_matchable(),
-                            Ref::keyword("INHERIT").to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("UNIQUE").to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("NULLS").to_matchable(),
-                            Ref::keyword("NOT").optional().to_matchable(),
-                            Ref::keyword("DISTINCT").to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                        Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("IndexParametersSegment").optional().to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::new("PrimaryKeyGrammar").to_matchable(),
-                        Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("IndexParametersSegment").optional().to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("EXCLUDE").to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("USING").to_matchable(),
-                            Ref::new("IndexAccessMethodSegment").to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                        Bracketed::new(vec![
-                            Delimited::new(vec![
-                                Ref::new("ExclusionConstraintElementSegment").to_matchable(),
-                            ])
-                            .to_matchable(),
-                        ])
-                        .to_matchable(),
-                        Ref::new("IndexParametersSegment").optional().to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("WHERE").to_matchable(),
-                            Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
-                                .to_matchable(),
-                        ])
-                        .config(|this| this.optional())
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("FOREIGN").to_matchable(),
-                        Ref::keyword("KEY").to_matchable(),
-                        Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("ReferenceDefinitionGrammar").to_matchable(),
-                    ])
-                    .to_matchable(),
+                    MetaSegment::indent().to_matchable(),
+                    table_constraint_body_grammar(),
+                    MetaSegment::dedent().to_matchable(),
                 ])
                 .to_matchable(),
-                AnyNumberOf::new(vec![
-                    one_of(vec![
-                        Ref::keyword("DEFERRABLE").to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("NOT").to_matchable(),
-                            Ref::keyword("DEFERRABLE").to_matchable(),
-                        ])
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    one_of(vec![
-                        Sequence::new(vec![
-                            Ref::keyword("INITIALLY").to_matchable(),
-                            Ref::keyword("DEFERRED").to_matchable(),
-                        ])
-                        .to_matchable(),
-                        Sequence::new(vec![
-                            Ref::keyword("INITIALLY").to_matchable(),
-                            Ref::keyword("IMMEDIATE").to_matchable(),
-                        ])
-                        .to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("NOT").to_matchable(),
-                        Ref::keyword("VALID").to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("NO").to_matchable(),
-                        Ref::keyword("INHERIT").to_matchable(),
-                    ])
-                    .to_matchable(),
-                ])
-                .to_matchable(),
+                table_constraint_body_grammar(),
             ])
             .to_matchable()
         })

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT02-postgres.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT02-postgres.yml
@@ -1,0 +1,14 @@
+rule: LT02
+
+test_pass_postgres_named_table_constraint_indent:
+  pass_str: |
+    CREATE TABLE child (
+        parent_id INTEGER,
+        CONSTRAINT child_parent_fk
+            FOREIGN KEY (parent_id)
+            REFERENCES parent(id)
+            ON DELETE CASCADE
+    );
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
Named PostgreSQL table constraints should retain continuation indentation for the constraint body.

When a table constraint starts with `CONSTRAINT name`, the following constraint body is a logical child of that named constraint. Without an indent marker there, layout can flatten `FOREIGN KEY`, `REFERENCES`, and referential-action lines back to the same indentation level as the constraint name. This refactors the Postgres table constraint grammar to share the constraint body parser while adding indent/dedent metadata only around named constraint bodies.

The unnamed table constraint forms continue to use the same body grammar.