### PR TITLE
chore: bump @playwright/test from 1.60.0 to 1.61.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,7 +84,7 @@ use_repo(pnpm, "pnpm")
 playwright = use_extension("@rules_playwright//playwright:extensions.bzl", "playwright")
 playwright.repo(
     name = "playwright",
-    playwright_version = "1.60.0",
+    playwright_version = "1.61.0",
 )
 use_repo(playwright, "playwright")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -872,7 +872,7 @@
     "@@rules_playwright+//playwright:extensions.bzl%playwright": {
       "general": {
         "bzlTransitiveDigest": "+bSe22vlUVDFe7fKIMwapJXumk+p5GMt1w+KWracsos=",
-        "usagesDigest": "rZCOl7ORooClxeVBPVyeqfgxggQ2O21TgQsKy/w4EbM=",
+        "usagesDigest": "lA1OgTgLTb+9SwmkcjEv74F28oT5x/NCM8aDzRyKKzg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_playwright+,bazel_tools bazel_tools",
           "FILE:@@rules_playwright+//playwright/private/cli/src/download_paths.json 4ab1631c4ed1e744847b20a6802a0d88da0271c4547a90aa9c89f7e751882f7b"
@@ -1066,7 +1066,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip"
               ]
             }
           },
@@ -1074,7 +1074,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1082,7 +1082,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip"
               ]
             }
           },
@@ -1090,7 +1090,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1098,7 +1098,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip"
               ]
             }
           },
@@ -1106,7 +1106,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1114,7 +1114,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1122,7 +1122,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1130,7 +1130,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1138,7 +1138,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1146,7 +1146,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1154,7 +1154,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1162,7 +1162,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1170,7 +1170,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1178,7 +1178,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1186,7 +1186,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1194,7 +1194,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1202,7 +1202,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1210,7 +1210,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1218,7 +1218,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1226,7 +1226,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1234,7 +1234,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1242,7 +1242,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1250,7 +1250,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1258,7 +1258,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1266,7 +1266,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1274,7 +1274,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1282,7 +1282,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1290,7 +1290,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1298,7 +1298,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1306,7 +1306,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1314,7 +1314,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1322,7 +1322,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1330,7 +1330,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1338,7 +1338,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1346,7 +1346,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1354,7 +1354,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1362,7 +1362,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1370,7 +1370,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1378,7 +1378,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1386,7 +1386,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1394,7 +1394,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-linux-arm64.zip"
               ]
             }
           },
@@ -1402,7 +1402,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1410,7 +1410,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-linux-arm64.zip"
               ]
             }
           },
@@ -1418,7 +1418,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1426,7 +1426,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-linux-arm64.zip"
               ]
             }
           },
@@ -1434,7 +1434,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1442,7 +1442,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1450,7 +1450,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1458,7 +1458,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1466,7 +1466,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1474,7 +1474,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1482,7 +1482,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1490,7 +1490,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1498,7 +1498,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1506,7 +1506,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1514,7 +1514,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1522,7 +1522,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1530,7 +1530,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1538,7 +1538,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1546,7 +1546,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1554,7 +1554,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-headless-shell-mac-x64.zip"
               ]
             }
           },
@@ -1562,7 +1562,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
               ]
             }
           },
@@ -1570,7 +1570,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1578,7 +1578,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1586,7 +1586,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1594,7 +1594,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1602,7 +1602,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-headless-shell-linux-arm64.zip"
               ]
             }
           },
@@ -1610,7 +1610,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-headless-shell-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-headless-shell-linux64.zip"
               ]
             }
           },
@@ -1618,7 +1618,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1626,7 +1626,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1634,7 +1634,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1642,7 +1642,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1650,7 +1650,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1658,7 +1658,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1666,7 +1666,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1674,7 +1674,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1682,7 +1682,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1690,7 +1690,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1698,7 +1698,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1706,7 +1706,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-x64/chrome-mac-x64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-x64/chrome-mac-x64.zip"
               ]
             }
           },
@@ -1714,7 +1714,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/mac-arm64/chrome-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/mac-arm64/chrome-mac-arm64.zip"
               ]
             }
           },
@@ -1722,7 +1722,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-linux-arm64.zip"
               ]
             }
           },
@@ -1730,7 +1730,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1738,7 +1738,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-linux-arm64.zip"
               ]
             }
           },
@@ -1746,7 +1746,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1754,7 +1754,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1427/chromium-tip-of-tree-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium-tip-of-tree/1432/chromium-tip-of-tree-linux-arm64.zip"
               ]
             }
           },
@@ -1762,7 +1762,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/149.0.7827.0/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/151.0.7886.0/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1770,7 +1770,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip"
               ]
             }
           },
@@ -1778,7 +1778,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1786,7 +1786,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip"
               ]
             }
           },
@@ -1794,7 +1794,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -1802,7 +1802,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/chromium/1223/chromium-linux-arm64.zip"
+                "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip"
               ]
             }
           },
@@ -1810,7 +1810,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip"
+                "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip"
               ]
             }
           },
@@ -2002,7 +2002,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-debian-11-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-debian-11-arm64.zip"
               ]
             }
           },
@@ -2010,7 +2010,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-debian-11.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-debian-11.zip"
               ]
             }
           },
@@ -2018,7 +2018,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-debian-12-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-debian-12-arm64.zip"
               ]
             }
           },
@@ -2026,7 +2026,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-debian-12.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-debian-12.zip"
               ]
             }
           },
@@ -2034,7 +2034,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2042,7 +2042,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2050,7 +2050,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2058,7 +2058,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2066,7 +2066,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac-arm64.zip"
               ]
             }
           },
@@ -2074,7 +2074,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2082,7 +2082,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac-arm64.zip"
               ]
             }
           },
@@ -2090,7 +2090,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2098,7 +2098,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac-arm64.zip"
               ]
             }
           },
@@ -2106,7 +2106,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2114,7 +2114,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac-arm64.zip"
               ]
             }
           },
@@ -2122,7 +2122,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac.zip"
               ]
             }
           },
@@ -2130,7 +2130,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-mac-arm64.zip"
               ]
             }
           },
@@ -2138,7 +2138,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-ubuntu-20.04.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-ubuntu-20.04.zip"
               ]
             }
           },
@@ -2146,7 +2146,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-ubuntu-22.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-ubuntu-22.04-arm64.zip"
               ]
             }
           },
@@ -2154,7 +2154,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-ubuntu-22.04.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-ubuntu-22.04.zip"
               ]
             }
           },
@@ -2162,7 +2162,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-ubuntu-24.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-ubuntu-24.04-arm64.zip"
               ]
             }
           },
@@ -2170,7 +2170,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox-beta/1512/firefox-beta-ubuntu-24.04.zip"
+                "https://cdn.playwright.dev/builds/firefox-beta/1526/firefox-beta-ubuntu-24.04.zip"
               ]
             }
           },
@@ -2178,7 +2178,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-debian-11-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-debian-11-arm64.zip"
               ]
             }
           },
@@ -2186,7 +2186,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-debian-11.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-debian-11.zip"
               ]
             }
           },
@@ -2194,7 +2194,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-debian-12-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-debian-12-arm64.zip"
               ]
             }
           },
@@ -2202,7 +2202,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-debian-12.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-debian-12.zip"
               ]
             }
           },
@@ -2210,7 +2210,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2218,7 +2218,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2226,7 +2226,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2234,7 +2234,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2242,7 +2242,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac-arm64.zip"
               ]
             }
           },
@@ -2250,7 +2250,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2258,7 +2258,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac-arm64.zip"
               ]
             }
           },
@@ -2266,7 +2266,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2274,7 +2274,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac-arm64.zip"
               ]
             }
           },
@@ -2282,7 +2282,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2290,7 +2290,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac-arm64.zip"
               ]
             }
           },
@@ -2298,7 +2298,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac.zip"
               ]
             }
           },
@@ -2306,7 +2306,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-mac-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-mac-arm64.zip"
               ]
             }
           },
@@ -2314,7 +2314,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-ubuntu-20.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-ubuntu-20.04-arm64.zip"
               ]
             }
           },
@@ -2322,7 +2322,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-ubuntu-20.04.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-ubuntu-20.04.zip"
               ]
             }
           },
@@ -2330,7 +2330,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-ubuntu-22.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-ubuntu-22.04-arm64.zip"
               ]
             }
           },
@@ -2338,7 +2338,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-ubuntu-22.04.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-ubuntu-22.04.zip"
               ]
             }
           },
@@ -2346,7 +2346,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-ubuntu-24.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-ubuntu-24.04-arm64.zip"
               ]
             }
           },
@@ -2354,7 +2354,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/firefox/1522/firefox-ubuntu-24.04.zip"
+                "https://cdn.playwright.dev/builds/firefox/1532/firefox-ubuntu-24.04.zip"
               ]
             }
           },
@@ -2378,7 +2378,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-debian-12-arm64.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-debian-12-arm64.zip"
               ]
             }
           },
@@ -2386,7 +2386,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-debian-12.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-debian-12.zip"
               ]
             }
           },
@@ -2410,7 +2410,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-mac-15.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-mac-15.zip"
               ]
             }
           },
@@ -2418,7 +2418,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-mac-15-arm64.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-mac-15-arm64.zip"
               ]
             }
           },
@@ -2442,7 +2442,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-ubuntu-22.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-ubuntu-22.04-arm64.zip"
               ]
             }
           },
@@ -2450,7 +2450,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-ubuntu-22.04.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-ubuntu-22.04.zip"
               ]
             }
           },
@@ -2458,7 +2458,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-ubuntu-24.04-arm64.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-ubuntu-24.04-arm64.zip"
               ]
             }
           },
@@ -2466,14 +2466,14 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://cdn.playwright.dev/builds/webkit/2287/webkit-ubuntu-24.04.zip"
+                "https://cdn.playwright.dev/builds/webkit/2311/webkit-ubuntu-24.04.zip"
               ]
             }
           },
           "playwright": {
             "repoRuleId": "@@rules_playwright+//playwright:repositories.bzl%playwright_repository",
             "attributes": {
-              "playwright_version": "1.60.0",
+              "playwright_version": "1.61.0",
               "browsers_workspace_name_prefix": "playwright",
               "rules_playwright_cannonical_name": "@rules_playwright+"
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^10.0.1
       version: 10.0.1
     '@playwright/test':
-      specifier: 1.60.0
-      version: 1.60.0
+      specifier: 1.61.0
+      version: 1.61.0
     eslint:
       specifier: ^10.5.0
       version: 10.5.0
@@ -53,7 +53,7 @@ importers:
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.60.0
+        version: 1.61.0
       '@rauschma/env-var':
         specifier: ^1.0.1
         version: 1.0.1
@@ -101,7 +101,7 @@ importers:
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.60.0
+        version: 1.61.0
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -610,8 +610,8 @@ packages:
     resolution: {integrity: sha512-/HHFVVP2pzEtqBVOFRoWlDtBoO8bzIWOqS62APdm3OhYbE2+kVUs/ALpkevvAKKfY0DMDVezYN22bDBh77UQ9Q==}
     engines: {node: '>=18'}
 
-  '@playwright/test@1.60.0':
-    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3169,8 +3169,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3179,8 +3179,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4496,9 +4496,9 @@ snapshots:
     dependencies:
       playwright-core: 1.58.2
 
-  '@playwright/test@1.60.0':
+  '@playwright/test@1.61.0':
     dependencies:
-      playwright: 1.60.0
+      playwright: 1.61.0
 
   '@rauschma/env-var@1.0.1': {}
 
@@ -7362,7 +7362,7 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.0: {}
 
   playwright@1.58.2:
     dependencies:
@@ -7370,9 +7370,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  playwright@1.60.0:
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 
 catalog:
   '@eslint/js': ^10.0.1
-  '@playwright/test': 1.60.0
+  '@playwright/test': 1.61.0
   eslint: ^10.5.0
   typescript: ^6.0.3
   typescript-eslint: ^8.61.1


### PR DESCRIPTION
Rebase of dependabot #2786 onto current `main`, made to work with Bazel.

- `@playwright/test` 1.60.0 → 1.61.0 (`pnpm-workspace.yaml` catalog + `pnpm-lock.yaml`)
- Bump the `rules_playwright` browser pin in `MODULE.bazel` 1.60.0 → 1.61.0 so the Bazel-managed browser binaries match the npm version (otherwise `playwright_test` fails on a version mismatch)
- `MODULE.bazel.lock` repinned accordingly

`bazelisk test //editors/code:playwright_test //playground:playwright_test //:pnpm_lock_check` passes.

Supersedes #2786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)