### PR TITLE
chore: enable jinja templater for ignored rule fixtures that pass

### DIFF
--- a/crates/lib/test/fixtures/rules/std_rule_cases/CP01.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CP01.yml
@@ -122,17 +122,16 @@ test_pass_ignore_words_complex:
         ignore_words_regex: (^Se|^Fr)
 
 test_pass_ignore_templated_code_true:
-  ignored: "jinja is not set"
   pass_str: |
     {{ "select" }} a
     FROM foo
     WHERE 1
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: true
 
 test_fail_ignore_templated_code_false:
-  ignored: "jinja is not supported"
   fail_str: |
     {{ "select" }} a
     FROM foo
@@ -143,6 +142,7 @@ test_fail_ignore_templated_code_false:
     where 1
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_snowflake_group_by_cube:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CP03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CP03.yml
@@ -65,7 +65,6 @@ test_pass_ignore_templated_code_true:
       ignore_templated_areas: true
 
 test_fail_ignore_templated_code_false:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         {{ "greatest(a, b)" }},
@@ -76,6 +75,7 @@ test_fail_ignore_templated_code_false:
         greatest(i, j)
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_pass_func_name_templated_literal_mix:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CV10.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CV10.yml
@@ -361,46 +361,46 @@ test_fail_partially_templated_quoted_literals_inside_blocks:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_fully_templated_quoted_literals_are_ignored:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT {{ "'a_non_lintable_string'" }}
   configs:
     core:
+      templater: jinja
       dialect: bigquery
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_partially_templated_literals_are_ignored_when_some_quotes_are_inside_the_template_1:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT '{{ "string' FROM table1" }}
   configs:
     core:
+      templater: jinja
       dialect: bigquery
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_partially_templated_literals_are_ignored_when_some_quotes_are_inside_the_template_2:
-  ignored: "jinja is not set"
   pass_str: |
     {{ "SELECT 'stri" -}}ng' FROM table1
   configs:
     core:
+      templater: jinja
       dialect: bigquery
     rules:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
 test_pass_prefix_chars_are_correctly_detected_as_unlintable:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT
       r{{ "''" }},
       r{{ "'project' FROM table1" }}
   configs:
     core:
+      templater: jinja
       dialect: bigquery
     rules:
       convention.quoted_literals:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -5,11 +5,11 @@ test_pass_parenthesis_block_isolated:
     SELECT * FROM (SELECT 1 AS C1) AS T1;
 
 test_pass_parenthesis_block_isolated_template:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT * FROM (SELECT 1 AS C1) AS T1;' }}
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_parenthesis_block_not_isolated:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-commas.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-commas.yml
@@ -12,32 +12,32 @@ test_fail_whitespace_before_comma_template:
       ignore_templated_areas: false
 
 test_pass_errors_only_in_templated_and_ignore:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT 1 ,4' }}, 5, 6
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: true
 
 test_fail_errors_only_in_non_templated_and_ignore:
-  ignored: "jinja is not supported"
   fail_str: |
     {{ 'SELECT 1, 4' }}, 5 , 6
   fix_str: |
     {{ 'SELECT 1, 4' }}, 5, 6
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: true
 
 test_pass_single_whitespace_after_comma:
   pass_str: SELECT 1, 4
 
 test_pass_single_whitespace_after_comma_template:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT 1, 4' }}
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_multiple_whitespace_after_comma:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -4,11 +4,11 @@ test_basic:
   pass_str: SELECT 1
 
 test_basic_template:
-  ignored: "jinja is not supported"
   pass_str: |
     {{ 'SELECT 1' }}
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_basic_fix:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-trailing.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-trailing.yml
@@ -20,12 +20,13 @@ test_pass_trailing_whitespace_before_template_code:
         0
 
 test_fail_trailing_whitespace_and_whitespace_control:
-  ignored: "jinja is not supported"
   fail_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1, \n    2,\n"
   fix_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1,\n    2,\n"
+  configs:
+    core:
+      templater: jinja
 
 test_pass_macro_trailing:
-  ignored: "jinja is not supported"
   pass_str: |
     {% macro foo(bar) %}
         {{bar}}
@@ -41,3 +42,6 @@ test_pass_macro_trailing:
 
     select *
     from tbl
+  configs:
+    core:
+      templater: jinja

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -396,7 +396,6 @@ test_jinja_with_disbalanced_pairs:
   # The range(3) -%} results in swallowing the \n
   # N.B. The way LT02 handles this is questionable,
   # and this test seals in that behaviour.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT
         cohort_month
@@ -405,6 +404,9 @@ test_jinja_with_disbalanced_pairs:
         {% endfor -%}
         , TRUE AS overall
     FROM orders
+  configs:
+    core:
+      templater: jinja
 
 test_fail_attempted_hanger_fix:
   # Check messy hanger correction.
@@ -502,7 +504,6 @@ test_fail_clean_reindent_fix:
 
 # https://github.com/sqlfluff/sqlfluff/issues/643
 test_pass_indent_snowflake:
-  ignored: "jinja is not set"
   pass_str: |
     with source_data as (
         select * from {{ source('source_name', 'xxx_yyy_zzz') }}
@@ -512,11 +513,11 @@ test_pass_indent_snowflake:
     from source_data
   configs:
     core:
+      templater: jinja
       dialect: snowflake
 
 # https://github.com/sqlfluff/sqlfluff/issues/643
 test_pass_indent_indent_bigquery:
-  ignored: "jinja is not set"
   pass_str: |
     with source_data as (
         select * from {{ source('source_name', 'xxx_yyy_zzz') }}
@@ -525,6 +526,7 @@ test_pass_indent_indent_bigquery:
     from source_data
   configs:
     core:
+      templater: jinja
       dialect: bigquery
 
 test_jinja_indent_templated_table_name_a:
@@ -852,7 +854,6 @@ test_pass_ignore_templated_whitespace:
       ignore_templated_areas: false
 
 test_fail_ignore_templated_whitespace_1:
-  ignored: "jinja is not set"
   fail_str: |
     SELECT
         c1,
@@ -866,6 +867,7 @@ test_fail_ignore_templated_whitespace_1:
 
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_fail_ignore_templated_whitespace_2:
@@ -884,7 +886,6 @@ test_fail_ignore_templated_whitespace_2:
       ignore_templated_areas: false
 
 test_fail_ignore_templated_whitespace_3:
-  ignored: "jinja is not set"
   fail_str: |
     SELECT
         c1,
@@ -897,6 +898,7 @@ test_fail_ignore_templated_whitespace_3:
     FROM my_table
   configs:
     core:
+      templater: jinja
       ignore_templated_areas: false
 
 test_pass_ignore_templated_whitespace_4:
@@ -911,19 +913,23 @@ test_pass_ignore_templated_whitespace_4:
     FROM my_table
 
 test_pass_ignore_templated_newline_not_last_line:
-  ignored: "jinja is not supported"
   pass_str: |
     select *
     from {{ "\n\nmy_table" }}
     inner join
         my_table2
         using (id)
+  configs:
+    core:
+      templater: jinja
 
 test_pass_ignore_templated_newline_last_line:
-  ignored: "jinja is not set"
   pass_str: |
     select *
     from {{ "\n\nmy_table" }}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_fix_template_indentation_1:
   fail_str: |
@@ -936,7 +942,6 @@ test_fail_fix_template_indentation_1:
         {{ "c2" }}
 
 test_fail_fix_template_indentation_2:
-  ignored: "jinja is not supported"
   fail_str: |
     with
     first_join as (
@@ -959,6 +964,9 @@ test_fail_fix_template_indentation_2:
     )
 
     select * from first_join
+  configs:
+    core:
+      templater: jinja
 
 test_pass_tsql_update_indent:
   pass_str: |
@@ -1475,7 +1483,6 @@ test_fail_deny_implicit_indent:
       allow_implicit_indents: false
 
 test_pass_templated_newlines:
-  ignored: "jinja is not supported"
   # NOTE: The macro has many newlines in it,
   # and the calling of it is indented. Check that
   # this doesn't panic.
@@ -1490,6 +1497,9 @@ test_pass_templated_newlines:
     SELECT
         {{ my_macro() }} as awkward_indentation
     FROM foo
+  configs:
+    core:
+      templater: jinja
 
 test_fail_fix_beside_templated:
   ignored: "jinja is not supported"
@@ -1823,7 +1833,6 @@ test_fix_implicit_indents_4467_b:
 
 test_fix_macro_indents_4367:
   # https://github.com/sqlfluff/sqlfluff/issues/4367
-  ignored: "jinja is not supported"
   fail_str: |
     {% macro my_macro(col) %}
         {{ col }}
@@ -1842,6 +1851,9 @@ test_fix_macro_indents_4367:
         {{ my_macro("mycol") }},
         something_else
     FROM mytable
+  configs:
+    core:
+      templater: jinja
 
 test_fix_untaken_positive_4433:
   # https://github.com/sqlfluff/sqlfluff/issues/4433

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT03.yml
@@ -215,7 +215,6 @@ fails_trailing_with_comments:
   configs: *operator_before
 
 passes_templated_newline:
-  ignored: "jinja is not set"
   pass_str: |
     {% macro binary_literal(expression) %}
       X'{{ expression }}'
@@ -226,6 +225,9 @@ passes_templated_newline:
     from my_table
     where
         a = {{ binary_literal("0000") }}
+  configs:
+    core:
+      templater: jinja
 
 fails_templated_code_non_templated_newline:
   ignored: "jinja is not supported"
@@ -252,7 +254,6 @@ passes_operator_alone_on_line:
 fixes_tuple_error_issue:
   # https://github.com/sqlfluff/sqlfluff/issues/4184
   # NB: This one isn't fixable.
-  ignored: "jinja is not supported"
   fail_str: |
     select * from foo
     where c is not null and -- comment
@@ -261,5 +262,7 @@ fixes_tuple_error_issue:
         {% endif %}
         true
   configs:
+    core:
+      templater: jinja
     indentation:
       template_blocks_indent: false

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT04.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT04.yml
@@ -298,7 +298,6 @@ leading_comma_with_templated_column_1:
           line_position: leading
 
 leading_comma_with_templated_column_2:
-  ignored: "jinja is not set"
   pass_str: |
     SELECT
         c1
@@ -306,13 +305,14 @@ leading_comma_with_templated_column_2:
     c2" }} AS days_since
     FROM logs
   configs:
+    core:
+      templater: jinja
     layout:
       type:
         comma:
           line_position: leading
 
 trailing_comma_with_templated_column_1:
-  ignored: "jinja is not set"
   fail_str: |
     SELECT
         {{ "c1" }}
@@ -323,6 +323,9 @@ trailing_comma_with_templated_column_1:
         {{ "c1" }},
         c2 AS days_since
     FROM logs
+  configs:
+    core:
+      templater: jinja
 
 trailing_comma_with_templated_column_2:
   ignored: "jinja is not set"

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -121,13 +121,13 @@ test_pass_line_too_long_ignore_comments_false:
 test_compute_line_length_before_template_expansion_1:
   # Line 3 is fine before expansion. Too long after expansion is NOT considered
   # a violation.
-  ignored: "jinja is not set"
   pass_str: |
     SELECT user_id
     FROM
         `{{bi_ecommerce_orders}}` {{table_at_job_start}}
   configs:
     core:
+      templater: jinja
       dialect: bigquery
     templater:
       jinja:
@@ -178,7 +178,6 @@ test_long_jinja_comment:
 
 test_long_jinja_comment_ignore:
   # A Jinja comment is a comment.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT *
     {# comment #}
@@ -186,6 +185,7 @@ test_long_jinja_comment_ignore:
     FROM table
   configs:
     core:
+      templater: jinja
       max_line_length: 80
     rules:
       layout.long_lines:
@@ -193,17 +193,18 @@ test_long_jinja_comment_ignore:
 
 test_for_loop:
   # A Jinja for loop
-  ignored: "jinja is not set"
   pass_str: |
     {% for elem in 'foo' %}
     SELECT '{{ elem }}' FROM table1;
     SELECT '{{ elem }}' FROM table2;
     {% endfor %}
+  configs:
+    core:
+      templater: jinja
 
 test_for_loop_repeating_elements_starts_with_literal:
   # A Jinja for loop with repeating elements (that are difficult to match)
   # but starting with a literal that can be used to match
-  ignored: "jinja is not set"
   pass_str: |
     {% set elements = 'foo' %}
     SELECT
@@ -213,6 +214,9 @@ test_for_loop_repeating_elements_starts_with_literal:
             WHEN '{{ elem }}' = '' THEN 1
             {% endfor %}
         END
+  configs:
+    core:
+      templater: jinja
 
 test_for_loop_starting_with_templated_piece:
   ignored: "jinja is not set"
@@ -247,7 +251,6 @@ test_for_loop_fail_complex_match:
 
 test_for_loop_fail_simple_match:
   # If for loop only contains literals it should still pass
-  ignored: "jinja is not set"
   pass_str: |
     {% set elements = 'foo' %}
     SELECT
@@ -256,15 +259,18 @@ test_for_loop_fail_simple_match:
             WHEN 'f' THEN a
             {% endfor %}
         END
+  configs:
+    core:
+      templater: jinja
 
 test_set_statement:
   # A Jinja set statement
-  ignored: "jinja is not set"
   pass_str: |
     {% set statement = "SELECT 1 from table1;" %}
     {{ statement }}{{ statement }}
   configs:
     core:
+      templater: jinja
       max_line_length: 80
 
 test_issue_1666_line_too_long_unfixable_jinja:
@@ -370,12 +376,13 @@ test_pass_ignore_templated_comment_lines:
   # NOTE: This is potentially a behaviour change in 2.0.0.
   # This was erroneously using the `ignore_comment_clauses`
   # config when this query contains no comment clauses.
-  ignored: "jinja is not supported"
   pass_str: |
     SELECT *
         {# ........................................................................... #}
     FROM table
   configs:
+    core:
+      templater: jinja
     rules:
       layout.long_lines:
         ignore_comment_lines: true
@@ -438,7 +445,6 @@ test_pass_long_multiline_jinja:
   # None of the lines are longer than 30
   # but the whole tag is. It shouldn't
   # cause issues.
-  ignored: "jinja is not set"
   pass_str: |
     select
         {{
@@ -448,6 +454,7 @@ test_pass_long_multiline_jinja:
     from blah
   configs:
     core:
+      templater: jinja
       max_line_length: 30
 
 test_fail_long_inline_statement:
@@ -647,7 +654,6 @@ test_long_functions_and_aliases:
     FROM my_table
 
 test_order_by_rebreak_span:
-  ignored: "jinja is not supported"
   # This tests that we can correctly rebreak an "order by" expressions.
   fail_str: |
     select * from
@@ -675,6 +681,9 @@ test_order_by_rebreak_span:
             inner join tbl2
                 on tbl1.the_name = tbl2.the_name
         )
+  configs:
+    core:
+      templater: jinja
 
 test_trailing_semicolon_moves:
   # The checks that we don't move the semicolon or the comma.

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT07.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT07.yml
@@ -52,7 +52,6 @@ test_pass_cte_with_column_list:
     select * from search_path
 
 test_pass_with_clause_closing_misaligned_indentation_in_templated_block:
-  ignored: "jinja is not set"
   pass_str: |
     with
     {% if true %}
@@ -65,9 +64,11 @@ test_pass_with_clause_closing_misaligned_indentation_in_templated_block:
       )
     {% endif %}
     select * from cte
+  configs:
+    core:
+      templater: jinja
 
 test_move_parenthesis_to_next_line_in_templated_block:
-  ignored: "jinja is not supported"
   fail_str: |
     with
     {% if true %}
@@ -84,9 +85,11 @@ test_move_parenthesis_to_next_line_in_templated_block:
     )
     {% endif %}
     select * from cte
+  configs:
+    core:
+      templater: jinja
 
 test_pass_templated_clauses:
-  ignored: "jinja is not set"
   pass_str: |
     with
 
@@ -103,3 +106,6 @@ test_pass_templated_clauses:
     select * from final
     join a using (x)
     join b using (x)
+  configs:
+    core:
+      templater: jinja

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT12.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT12.yml
@@ -12,8 +12,10 @@ test_fail_multiple_final_newlines:
   fix_str: "SELECT foo FROM bar\n"
 
 test_pass_templated_plus_raw_newlines:
-  ignored: "jinja is not set"
   pass_str: "{{ '\n\n' }}\n"
+  configs:
+    core:
+      templater: jinja
 
 test_fail_templated_plus_raw_newlines:
   ignored: "jinja is not set"
@@ -26,7 +28,6 @@ test_fail_templated_plus_raw_newlines_extra_newline:
   fix_str: "{{ '\n\n' }}\n"
 
 test_pass_templated_macro_newlines:
-  ignored: "jinja is not set"
   # Tricky because the rendered code ends with two newlines:
   # - Literal newline inserted by the macro
   # - Literal newline at the end of the file
@@ -37,6 +38,9 @@ test_pass_templated_macro_newlines:
       {{ columns }}
     {% endmacro %}
     SELECT {{ get_keyed_nulls("other_id") }}
+  configs:
+    core:
+      templater: jinja
 
 test_fail_templated_no_newline:
   ignored: "jinja is not set"

--- a/crates/lib/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -318,13 +318,14 @@ fail_but_dont_fix_templated_table_name_consistent:
     FROM {{ "foo" }}
 
 fail_but_dont_fix_templated_table_name_qualified:
-  ignored: "jinja is not supported"
   fail_str: |
     SELECT
         a,
         {{ "foo" }}.b
     FROM {{ "foo" }}
   configs:
+    core:
+      templater: jinja
     rules:
       references.consistent:
         single_table_references: qualified


### PR DESCRIPTION
Many rule test cases were skipped with `ignored: "jinja is not set"` or
`"jinja is not supported"`. Where sqruff's jinja templater (python feature)
now handles them correctly, replace the ignore with `templater: jinja` under
`configs.core` so the cases actually run.

43 previously-ignored cases are enabled and pass. The remaining jinja cases
are left ignored because sqruff's handling of templated code still diverges
from the expected output (templated-block indentation, line length over
templated regions, partial-literal quoting, leading whitespace before jinja)
or panics in the parser.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UbDzWY3qd6UFST8RZeCQ6k