### PR TITLE
fix: preserve ANSI reference column list spacing

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -54,6 +54,7 @@ pub enum SyntaxKind {
     WithCompoundStatement,
     CommonTableExpression,
     CTEColumnList,
+    ReferencedColumnList,
     TriggerReference,
     TableConstraint,
     JoinOnCondition,

--- a/crates/lib-dialects/src/ansi.rs
+++ b/crates/lib-dialects/src/ansi.rs
@@ -1116,7 +1116,7 @@ pub fn raw_dialect() -> Dialect {
                 Ref::keyword("REFERENCES").to_matchable(),
                 Ref::new("TableReferenceSegment").to_matchable(),
                 // Foreign columns making up FOREIGN KEY constraint
-                Ref::new("BracketedColumnReferenceListGrammar")
+                Ref::new("ReferencedColumnListGrammar")
                     .optional()
                     .to_matchable(),
                 Sequence::new(vec![
@@ -1147,6 +1147,14 @@ pub fn raw_dialect() -> Dialect {
                 ])
                 .to_matchable(),
             ])
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "ReferencedColumnListGrammar".into(),
+            NodeMatcher::new(SyntaxKind::ReferencedColumnList, |_| {
+                Ref::new("BracketedColumnReferenceListGrammar").to_matchable()
+            })
             .to_matchable()
             .into(),
         ),

--- a/crates/lib-dialects/test/fixtures/dialects/ansi/sqlfluff/create_table_a_column_constraints.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/ansi/sqlfluff/create_table_a_column_constraints.yml
@@ -57,11 +57,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: c6
@@ -71,11 +72,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
           - keyword: MATCH
           - keyword: FULL
       - comma: ','
@@ -87,11 +89,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
           - keyword: MATCH
           - keyword: PARTIAL
       - comma: ','
@@ -103,11 +106,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
           - keyword: MATCH
           - keyword: SIMPLE
       - comma: ','
@@ -119,11 +123,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
           - keyword: ON
           - keyword: DELETE
           - keyword: NO
@@ -137,11 +142,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
           - keyword: ON
           - keyword: UPDATE
           - keyword: SET
@@ -155,11 +161,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c6_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c6_other
+              - end_bracket: )
           - keyword: ON
           - keyword: DELETE
           - keyword: RESTRICT
@@ -183,11 +190,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: table3
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: c7_other
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: c7_other
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: c8

--- a/crates/lib-dialects/test/fixtures/dialects/ansi/sqlfluff/create_table_a_pk_unique_fk_constraints.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/ansi/sqlfluff/create_table_a_pk_unique_fk_constraints.yml
@@ -56,12 +56,13 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table2
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: c2_
-          - comma: ','
-          - column_reference:
-            - naked_identifier: c3_
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: c2_
+            - comma: ','
+            - column_reference:
+              - naked_identifier: c3_
+            - end_bracket: )
       - end_bracket: )

--- a/crates/lib-dialects/test/fixtures/dialects/ansi/sqlfluff/create_table_constraint_reference_option.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/ansi/sqlfluff/create_table_constraint_reference_option.yml
@@ -45,11 +45,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: a
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: b
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: b
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: RESTRICT
@@ -72,11 +73,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: a
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: d
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: d
+            - end_bracket: )
         - keyword: ON
         - keyword: UPDATE
         - keyword: CASCADE
@@ -99,11 +101,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: a
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: c
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: c
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/alter_table.yml
@@ -810,11 +810,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:
@@ -838,11 +839,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: MATCH
         - keyword: FULL
 - statement_terminator: ;
@@ -868,11 +870,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: RESTRICT
@@ -902,11 +905,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: addresses
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: address
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: address
+            - end_bracket: )
         - keyword: NOT
         - keyword: VALID
 - statement_terminator: ;
@@ -1198,11 +1202,12 @@ file:
           - naked_identifier: landing
           - dot: .
           - naked_identifier: workorder
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqlfluff/create_table.yml
@@ -1339,11 +1339,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: CASCADE
@@ -1356,11 +1357,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: ON
         - keyword: UPDATE
         - keyword: RESTRICT
@@ -1373,11 +1375,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: groups
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: group_id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: group_id
+            - end_bracket: )
         - keyword: MATCH
         - keyword: SIMPLE
       - end_bracket: )
@@ -2351,14 +2354,15 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table1
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: col1
-          - comma: ','
-          - column_reference:
-            - naked_identifier: col2
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: col1
+            - comma: ','
+            - column_reference:
+              - naked_identifier: col2
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET
@@ -2413,14 +2417,15 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: table1
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: col1
-          - comma: ','
-          - column_reference:
-            - naked_identifier: col2
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: col1
+            - comma: ','
+            - column_reference:
+              - naked_identifier: col2
+            - end_bracket: )
         - keyword: ON
         - keyword: DELETE
         - keyword: SET

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_table_deferrable.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_table_deferrable.yml
@@ -28,11 +28,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: users
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
         - keyword: DEFERRABLE
       - end_bracket: )
 - statement_terminator: ;
@@ -65,11 +66,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: users
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
         - keyword: DEFERRABLE
         - keyword: INITIALLY
         - keyword: DEFERRED
@@ -104,11 +106,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: users
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
         - keyword: DEFERRABLE
         - keyword: INITIALLY
         - keyword: IMMEDIATE
@@ -143,11 +146,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: users
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
         - keyword: NOT
         - keyword: DEFERRABLE
       - end_bracket: )
@@ -181,11 +185,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: users
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
         - keyword: NOT
         - keyword: DEFERRABLE
         - keyword: INITIALLY
@@ -221,11 +226,12 @@ file:
         - keyword: REFERENCES
         - table_reference:
           - naked_identifier: users
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-            - naked_identifier: id
-          - end_bracket: )
+        - referenced_column_list:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: id
+            - end_bracket: )
         - keyword: NOT
         - keyword: DEFERRABLE
         - keyword: INITIALLY
@@ -258,11 +264,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: artist
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: artistid
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: artistid
+              - end_bracket: )
           - keyword: DEFERRABLE
       - end_bracket: )
 - statement_terminator: ;
@@ -292,11 +299,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: artist
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: artistid
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: artistid
+              - end_bracket: )
           - keyword: DEFERRABLE
           - keyword: INITIALLY
           - keyword: DEFERRED
@@ -328,11 +336,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: artist
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: artistid
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: artistid
+              - end_bracket: )
           - keyword: DEFERRABLE
           - keyword: INITIALLY
           - keyword: IMMEDIATE
@@ -364,11 +373,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: artist
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: artistid
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: artistid
+              - end_bracket: )
           - keyword: NOT
           - keyword: DEFERRABLE
       - end_bracket: )
@@ -399,11 +409,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: artist
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: artistid
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: artistid
+              - end_bracket: )
           - keyword: NOT
           - keyword: DEFERRABLE
           - keyword: INITIALLY
@@ -436,11 +447,12 @@ file:
           - keyword: REFERENCES
           - table_reference:
             - naked_identifier: artist
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-              - naked_identifier: artistid
-            - end_bracket: )
+          - referenced_column_list:
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: artistid
+              - end_bracket: )
           - keyword: NOT
           - keyword: DEFERRABLE
           - keyword: INITIALLY

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -178,6 +178,9 @@ spacing_before = touch:inline
 [sqruff:layout:type:array_accessor]
 spacing_before = touch:inline
 
+[sqruff:layout:type:referenced_column_list]
+spacing_before = touch:inline
+
 [sqruff:layout:type:colon]
 spacing_before = touch
 

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -353,8 +353,8 @@ test_align_multiple_all:
   fix_str: |
     create table tab1 (
         a varchar(25) not null,
-        b int         not null unique      references tab2 (b),
-        c varchar(5)  not null primary key references tab2 (c)
+        b int         not null unique      references tab2(b),
+        c varchar(5)  not null primary key references tab2(c)
     )
   configs:
     layout:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -267,6 +267,15 @@ test_postgres_datatype:
     core:
       dialect: postgres
 
+test_ansi_referenced_column_list_spacing:
+  pass_str: |
+    CREATE TABLE child (
+        parent_id INTEGER REFERENCES parent(id)
+    );
+  configs:
+    core:
+      dialect: ansi
+
 test_redshift_datatype:
   pass_str: |
     select


### PR DESCRIPTION
## Summary

Moves the dedicated `referenced_column_list` wrapper for `REFERENCES table(column)` from the Postgres dialect into the ANSI grammar, so dialects that inherit ANSI parse the standard foreign-key referenced column list consistently.

This preserves the existing layout behavior that prevents a space between a referenced table and its column list, while avoiding a Postgres-only override of `ReferenceDefinitionGrammar`.

## Changes

- Adds `ReferencedColumnListGrammar` to ANSI and has ANSI `ReferenceDefinitionGrammar` use it.
- Removes the duplicated Postgres `ReferenceDefinitionGrammar` override.
- Adds the referenced-column-list layout rule for touch spacing.
- Updates ANSI, Postgres, and SQLite parse fixtures affected by the new wrapper.
- Updates LT01 spacing/alignment regression coverage for `REFERENCES table(column)`.
- Squashes the branch to one conventional commit.

## Validation

- `cargo test -p sqruff-lib --test rules LT01-alignment`
- `bazelisk test //...`