### PR TITLE
perf(parser): avoid hashing the whole templated file per parent marker

### DIFF
--- a/crates/lib-core/src/parser/markers.rs
+++ b/crates/lib-core/src/parser/markers.rs
@@ -1,7 +1,6 @@
 use std::ops::Range;
 use std::rc::Rc;
 
-use hashbrown::HashSet;
 
 use crate::slice_helpers::zero_slice;
 use crate::templaters::TemplatedFile;
@@ -125,21 +124,37 @@ impl PositionMarker {
         let mut source_end = usize::MIN;
         let mut template_start = usize::MAX;
         let mut template_end = usize::MIN;
-        let mut templated_files = HashSet::new();
+        // The children of a node all carry clones of one `TemplatedFile` (an
+        // `Arc`), so confirm they are the same file by pointer identity rather
+        // than inserting each into a `HashSet`. The derived `Hash`/`Eq` hash and
+        // compare the entire templated source, so the old set made building each
+        // parent marker O(source_len) per child — quadratic in file size over a
+        // whole parse. A content comparison is kept only as a fallback for the
+        // (unexpected) case of two distinct allocations, preserving the original
+        // "all from one file" check exactly.
+        let mut templated_file: Option<&TemplatedFile> = None;
 
         for marker in markers {
             source_start = source_start.min(marker.source_slice.start);
             source_end = source_end.max(marker.source_slice.end);
             template_start = template_start.min(marker.templated_slice.start);
             template_end = template_end.max(marker.templated_slice.end);
-            templated_files.insert(marker.templated_file.clone());
+            match templated_file {
+                None => templated_file = Some(&marker.templated_file),
+                Some(existing) => {
+                    if !existing.ptr_eq(&marker.templated_file)
+                        && *existing != marker.templated_file
+                    {
+                        panic!("Attempted to make a parent marker from multiple files.");
+                    }
+                }
+            }
         }
 
-        if templated_files.len() != 1 {
-            panic!("Attempted to make a parent marker from multiple files.");
-        }
-
-        let templated_file = templated_files.into_iter().next().unwrap();
+        let templated_file = match templated_file {
+            Some(templated_file) => templated_file.clone(),
+            None => panic!("Attempted to make a parent marker from multiple files."),
+        };
         PositionMarker::new(
             source_start..source_end,
             template_start..template_end,

--- a/crates/lib-core/src/parser/markers.rs
+++ b/crates/lib-core/src/parser/markers.rs
@@ -1,7 +1,6 @@
 use std::ops::Range;
 use std::rc::Rc;
 
-
 use crate::slice_helpers::zero_slice;
 use crate::templaters::TemplatedFile;
 
@@ -124,14 +123,6 @@ impl PositionMarker {
         let mut source_end = usize::MIN;
         let mut template_start = usize::MAX;
         let mut template_end = usize::MIN;
-        // The children of a node all carry clones of one `TemplatedFile` (an
-        // `Arc`), so confirm they are the same file by pointer identity rather
-        // than inserting each into a `HashSet`. The derived `Hash`/`Eq` hash and
-        // compare the entire templated source, so the old set made building each
-        // parent marker O(source_len) per child — quadratic in file size over a
-        // whole parse. A content comparison is kept only as a fallback for the
-        // (unexpected) case of two distinct allocations, preserving the original
-        // "all from one file" check exactly.
         let mut templated_file: Option<&TemplatedFile> = None;
 
         for marker in markers {

--- a/crates/lib-core/src/templaters.rs
+++ b/crates/lib-core/src/templaters.rs
@@ -126,11 +126,6 @@ impl TemplatedFile {
     }
 
     /// Whether `self` and `other` share the same underlying allocation.
-    ///
-    /// This is an O(1) identity check on the inner [`Arc`], unlike the derived
-    /// `PartialEq`/`Hash`, which compare/hash the entire templated source. Use it
-    /// when many clones of one [`TemplatedFile`] need to be confirmed identical
-    /// without paying a content comparison per clone.
     pub fn ptr_eq(&self, other: &TemplatedFile) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
     }

--- a/crates/lib-core/src/templaters.rs
+++ b/crates/lib-core/src/templaters.rs
@@ -125,6 +125,16 @@ impl TemplatedFile {
         &self.inner.name
     }
 
+    /// Whether `self` and `other` share the same underlying allocation.
+    ///
+    /// This is an O(1) identity check on the inner [`Arc`], unlike the derived
+    /// `PartialEq`/`Hash`, which compare/hash the entire templated source. Use it
+    /// when many clones of one [`TemplatedFile`] need to be confirmed identical
+    /// without paying a content comparison per clone.
+    pub fn ptr_eq(&self, other: &TemplatedFile) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     #[cfg(feature = "stringify")]
     pub fn to_yaml(&self) -> String {
         let inner = &*self.inner;


### PR DESCRIPTION
Fixes #2837.

### Problem
`PositionMarker::from_child_markers` collected every child marker's `TemplatedFile` into a `HashSet` purely to assert they all came from one file (`set.len() == 1`). `TemplatedFile` is an `Arc<TemplatedFileInner>` whose derived `Hash`/`Eq` hash and compare the **entire templated source**. A parent marker is built for every node, and each one re-hashed the whole source once per child — so a parse is O(source_len) per node, i.e. **quadratic in file size**.

Profiling a large generated SQL file showed ~all CPU time under `MatchResult::apply → pos_marker → from_child_markers → BuildHasher::hash_one → foldhash::hash_bytes_long`.

### Fix
Confirm "same file" by `Arc` pointer identity instead. The children of a node all carry clones of one `Arc`, so the check is O(1) via `Arc::ptr_eq` (new `TemplatedFile::ptr_eq` helper). A content comparison is kept only as a fallback when the pointers differ, preserving the original semantics exactly.

### Result
Generated bulk-`INSERT` SQL, `sqruff lint --dialect ansi`, release build (Apple M4):

| input  | before  | after  |
|-------:|--------:|-------:|
| 0.8 MB | 13.7 s  | 1.6 s  |
| 1.7 MB | 59.7 s  | 4.0 s  |
| 3.4 MB | 227.6 s | 12.4 s |

Quadratic → roughly linear; ~18× on the 3.4 MB file.

### Tests
`cargo test -p sqruff-lib-core -p sqruff-lib` passes; output is unchanged. (Jinja-templated rule fixtures require a Python env and were skipped locally via `SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS=1`; the change does not touch templating.)