### PR TITLE
chore: speed up bazel cargo test

### DIFF
--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -22,7 +22,7 @@ def _cargo_vendor_impl(ctx):
     # Build component install command
     install_components = ""
     if ctx.attr.components:
-        install_components = "rustup component add " + " ".join(ctx.attr.components)
+        install_components = "rustup component add --toolchain {rust_version} ".format(rust_version = ctx.attr.rust_version) + " ".join(ctx.attr.components)
 
     script_content = """#!/bin/bash
 set -euo pipefail
@@ -34,15 +34,21 @@ EXEC_ROOT="$PWD"
 export CARGO_HOME="$EXEC_ROOT/{toolchain_out}/cargo"
 export RUSTUP_HOME="$EXEC_ROOT/{toolchain_out}/rustup"
 mkdir -p "$CARGO_HOME" "$RUSTUP_HOME"
+rm -f "$RUSTUP_HOME/settings.toml"
 
 # Download and install rustup (no-modify-path prevents writing to ~/.profile)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain {rust_version} --profile minimal
 
 # Add cargo to PATH
 export PATH="$CARGO_HOME/bin:$PATH"
+export RUSTUP_TOOLCHAIN="{rust_version}"
 
 # Install additional components if specified
 {install_components}
+
+# Force the requested toolchain to remain the default even if rustup inherited
+# stale settings from a previous sandbox path.
+rustup default {rust_version}
 
 # Verify installation
 cargo --version
@@ -535,6 +541,7 @@ TOOLCHAIN_DIR="$RUNFILES/_main/{toolchain_dir}"
 export CARGO_HOME="$TOOLCHAIN_DIR/cargo"
 export RUSTUP_HOME="$TOOLCHAIN_DIR/rustup"
 export PATH="$CARGO_HOME/bin:$PATH"
+export RUSTUP_TOOLCHAIN="{rust_version}"
 
 {tool_setup}
 
@@ -550,12 +557,16 @@ done << 'SRCS_EOF'
 {srcs}
 SRCS_EOF
 
-# Copy vendored dependencies
-cp -rL "$VENDOR_DIR" "$WORK_DIR/vendor"
-
-# Copy cargo config
+# Point cargo at the read-only vendored dependencies in runfiles. The sources are
+# immutable, so copying the full vendor tree into every test sandbox is wasted I/O.
 mkdir -p "$WORK_DIR/.cargo"
-cp "$CARGO_CONFIG" "$WORK_DIR/.cargo/config.toml"
+cat > "$WORK_DIR/.cargo/config.toml" <<EOF
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "$VENDOR_DIR"
+EOF
 
 cd "$WORK_DIR"
 
@@ -569,6 +580,7 @@ export CARGO_TARGET_DIR="$WORK_DIR/target"
         vendor_dir = vendor_info.vendor_dir.short_path,
         cargo_config = vendor_info.cargo_config.short_path,
         toolchain_dir = vendor_info.toolchain_dir.short_path,
+        rust_version = ctx.attr.rust_version,
         srcs = "\n".join([f.short_path for f in ctx.files.srcs]),
         tool_setup = tool_setup,
         python_setup = python_setup,
@@ -603,6 +615,10 @@ _cargo_attrs = {
         doc = "Additional cargo subcommand binaries (e.g. cargo-hack) to symlink into PATH",
     ),
     "script": attr.string(mandatory = True),
+    "rust_version": attr.string(
+        default = "1.96.0",
+        doc = "Rust toolchain version to use from the vendored toolchain",
+    ),
 }
 
 cargo_test = rule(

--- a/crates/lib/tests/rules.rs
+++ b/crates/lib/tests/rules.rs
@@ -1,7 +1,9 @@
+use std::path::Path;
 use std::str::FromStr;
 
 use glob::glob;
 use hashbrown::HashMap;
+use rayon::prelude::*;
 use serde::Deserialize;
 use serde_with::{KeyValueMap, serde_as};
 use sqruff_lib::core::config::{FluffConfig, Value};
@@ -54,128 +56,162 @@ fn main() {
     let mut args = Args::default();
     args.parse_args(std::env::args().skip(1));
 
-    let mut linter = Linter::new(FluffConfig::default(), None, None, true).unwrap();
-    let mut core = HashMap::new();
-    core.insert(
-        "core".to_string(),
-        linter.config_mut().raw.get("core").unwrap().clone(),
-    );
-
     let pattern = args
         .file
         .as_deref()
         .map(|f| format!("test/fixtures/rules/std_rule_cases/{f}"))
         .unwrap_or_else(|| "test/fixtures/rules/std_rule_cases/*.yml".to_string());
 
-    for path in glob(&pattern).unwrap() {
-        let path = path.unwrap();
+    let mut paths = glob(&pattern)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    paths.sort();
+
+    let verbose = std::env::var_os("SQRUFF_RULE_TEST_VERBOSE").is_some();
+    paths
+        .par_iter()
+        .for_each_init(RuleTestState::new, |state, path| {
+            process_file(state, path, verbose)
+        });
+}
+
+// FIXME: Simplify FluffConfig handling. It's quite chaotic right now.
+struct RuleTestState {
+    linter: Linter,
+    core: HashMap<String, Value>,
+}
+
+impl RuleTestState {
+    fn new() -> Self {
+        let mut linter = Linter::new(FluffConfig::default(), None, None, true).unwrap();
+        let mut core = HashMap::new();
+        core.insert(
+            "core".to_string(),
+            linter.config_mut().raw.get("core").unwrap().clone(),
+        );
+
+        Self { linter, core }
+    }
+}
+
+fn process_file(state: &mut RuleTestState, path: &Path, verbose: bool) {
+    if verbose {
         println!("Processing file: {:?}", path);
-        let input = std::fs::read_to_string(path).unwrap();
+    }
+    let input = std::fs::read_to_string(path).unwrap();
 
-        let file: TestFile = serde_yaml::from_str(&input).unwrap();
-        let file_rules = file
-            .rule
-            .split(",")
-            .map(|x| Value::String(x.into()))
-            .collect::<Vec<Value>>();
+    let file: TestFile = serde_yaml::from_str(&input).unwrap();
+    let file_rules = file
+        .rule
+        .split(",")
+        .map(|x| Value::String(x.into()))
+        .collect::<Vec<Value>>();
 
-        core.get_mut("core")
-            .unwrap()
-            .as_map_mut()
-            .unwrap()
-            .insert("rule_allowlist".into(), Value::Array(file_rules));
+    state
+        .core
+        .get_mut("core")
+        .unwrap()
+        .as_map_mut()
+        .unwrap()
+        .insert("rule_allowlist".into(), Value::Array(file_rules));
 
-        linter.config_mut().raw.extend(core.clone());
-        linter.config_mut().reload_reflow();
+    state.linter.config_mut().raw.extend(state.core.clone());
+    state.linter.config_mut().reload_reflow();
 
-        for case in file.cases {
+    for case in file.cases {
+        if verbose {
             println!("Processing case: {}", case.name);
-            let dialect_name = case
-                .configs
-                .get("core")
-                .and_then(|it| it.as_map())
-                .and_then(|it| it.get("dialect"))
-                .and_then(|it| it.as_string())
-                .unwrap_or("ansi");
+        }
+        let dialect_name = case
+            .configs
+            .get("core")
+            .and_then(|it| it.as_map())
+            .and_then(|it| it.get("dialect"))
+            .and_then(|it| it.as_string())
+            .unwrap_or("ansi");
 
-            let dialect = DialectKind::from_str(dialect_name);
+        let dialect = DialectKind::from_str(dialect_name);
 
-            if dialect.is_err() || case.ignored.is_some() {
-                let message = case
-                    .ignored
-                    .unwrap_or_else(|| format!("ignored, dialect {dialect_name} is not supported"));
-                println!("{message}");
+        if dialect.is_err() || case.ignored.is_some() {
+            let message = case
+                .ignored
+                .unwrap_or_else(|| format!("ignored, dialect {dialect_name} is not supported"));
+            println!("{message}");
 
-                continue;
+            continue;
+        }
+
+        let has_config = !case.configs.is_empty();
+        let rule = &file.rule;
+        if has_config {
+            *state.linter.config_mut() = FluffConfig::new(case.configs.clone(), None, None);
+            state.linter.config_mut().raw.extend(state.core.clone());
+
+            if let Some(core) = case.configs.get("core").and_then(|it| it.as_map()) {
+                state
+                    .linter
+                    .config_mut()
+                    .raw
+                    .get_mut("core")
+                    .unwrap()
+                    .as_map_mut()
+                    .unwrap()
+                    .extend(core.clone());
             }
 
-            let has_config = !case.configs.is_empty();
-            let rule = &file.rule;
-            if has_config {
-                *linter.config_mut() = FluffConfig::new(case.configs.clone(), None, None);
-                linter.config_mut().raw.extend(core.clone());
-
-                if let Some(core) = case.configs.get("core").and_then(|it| it.as_map()) {
-                    linter
+            for (config, value) in &case
+                .configs
+                .get("rules")
+                .cloned()
+                .unwrap_or_default()
+                .as_map()
+                .cloned()
+                .unwrap_or_default()
+            {
+                if INDENT_CONFIG.contains(&config.as_str()) {
+                    state
+                        .linter
                         .config_mut()
                         .raw
-                        .get_mut("core")
+                        .get_mut("indentation")
                         .unwrap()
                         .as_map_mut()
                         .unwrap()
-                        .extend(core.clone());
+                        .insert(config.clone(), value.clone());
                 }
-
-                for (config, value) in &case
-                    .configs
-                    .get("rules")
-                    .cloned()
-                    .unwrap_or_default()
-                    .as_map()
-                    .cloned()
-                    .unwrap_or_default()
-                {
-                    if INDENT_CONFIG.contains(&config.as_str()) {
-                        linter
-                            .config_mut()
-                            .raw
-                            .get_mut("indentation")
-                            .unwrap()
-                            .as_map_mut()
-                            .unwrap()
-                            .insert(config.clone(), value.clone());
-                    }
-                }
-
-                linter.config_mut().reload_reflow();
-
-                // Recreate linter with proper templater after all config is set up
-                let templater = match Linter::get_templater(linter.config()) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        if std::env::var("SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS").is_ok() {
-                            println!("Skipping case '{}': {}", case.name, e);
-                            *linter.config_mut() = FluffConfig::default();
-                            linter.config_mut().raw.extend(core.clone());
-                            linter.config_mut().reload_reflow();
-                            continue;
-                        } else {
-                            panic!(
-                                "Unsupported templater in case '{}': {}. \
-                                 Set SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS=1 to skip these tests.",
-                                case.name, e
-                            );
-                        }
-                    }
-                };
-                linter = Linter::new(linter.config().clone(), None, Some(templater), true).unwrap();
             }
 
-            match case.kind {
-                TestCaseKind::Pass { pass_str } => {
-                    let result = linter.lint_string_wrapped(&pass_str, false).unwrap();
-                    let error_string = format!(
-                        r#"
+            state.linter.config_mut().reload_reflow();
+
+            // Recreate linter with proper templater after all config is set up
+            let templater = match Linter::get_templater(state.linter.config()) {
+                Ok(t) => t,
+                Err(e) => {
+                    if std::env::var("SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS").is_ok() {
+                        println!("Skipping case '{}': {}", case.name, e);
+                        *state.linter.config_mut() = FluffConfig::default();
+                        state.linter.config_mut().raw.extend(state.core.clone());
+                        state.linter.config_mut().reload_reflow();
+                        continue;
+                    } else {
+                        panic!(
+                            "Unsupported templater in case '{}': {}. \
+                             Set SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS=1 to skip these tests.",
+                            case.name, e
+                        );
+                    }
+                }
+            };
+            state.linter =
+                Linter::new(state.linter.config().clone(), None, Some(templater), true).unwrap();
+        }
+
+        match case.kind {
+            TestCaseKind::Pass { pass_str } => {
+                let result = state.linter.lint_string_wrapped(&pass_str, false).unwrap();
+                let error_string = format!(
+                    r#"
 The following test test can be used to recreate the issue:
 
 #[cfg(test)]
@@ -200,41 +236,41 @@ dialect = {dialect}
     }}
 }}
 "#,
-                        rule = rule,
-                        dialect = dialect_name,
-                        pass_str = pass_str
-                    );
+                    rule = rule,
+                    dialect = dialect_name,
+                    pass_str = pass_str
+                );
 
-                    assert_eq!(&result.violations(), &[], "{}", error_string);
-                }
-                TestCaseKind::Fail { fail_str } => {
-                    let file = linter.lint_string_wrapped(&fail_str, false).unwrap();
-                    assert_ne!(&file.violations(), &[])
-                }
-                TestCaseKind::Fix { fail_str, fix_str } => {
-                    assert_ne!(
-                        &fail_str, &fix_str,
-                        "Fail and fix strings should not be equal"
-                    );
-
-                    let linted = linter.lint_string_wrapped(&fail_str, true).unwrap();
-                    let actual = linted.fix_string();
-
-                    pretty_assertions::assert_eq!(actual, fix_str);
-                }
+                assert_eq!(&result.violations(), &[], "{}", error_string);
             }
-
-            if has_config {
-                *linter.config_mut() = FluffConfig::default();
-                linter.config_mut().raw.extend(core.clone());
-                linter.config_mut().reload_reflow();
-
-                // Recreate linter with default templater to avoid leaking
-                // the custom templater (e.g. placeholder) into subsequent tests.
-                let templater = Linter::get_templater(linter.config())
-                    .expect("Default config should have a valid templater");
-                linter = Linter::new(linter.config().clone(), None, Some(templater), true).unwrap();
+            TestCaseKind::Fail { fail_str } => {
+                let file = state.linter.lint_string_wrapped(&fail_str, false).unwrap();
+                assert_ne!(&file.violations(), &[])
             }
+            TestCaseKind::Fix { fail_str, fix_str } => {
+                assert_ne!(
+                    &fail_str, &fix_str,
+                    "Fail and fix strings should not be equal"
+                );
+
+                let linted = state.linter.lint_string_wrapped(&fail_str, true).unwrap();
+                let actual = linted.fix_string();
+
+                pretty_assertions::assert_eq!(actual, fix_str);
+            }
+        }
+
+        if has_config {
+            *state.linter.config_mut() = FluffConfig::default();
+            state.linter.config_mut().raw.extend(state.core.clone());
+            state.linter.config_mut().reload_reflow();
+
+            // Recreate linter with default templater to avoid leaking
+            // the custom templater (e.g. placeholder) into subsequent tests.
+            let templater = Linter::get_templater(state.linter.config())
+                .expect("Default config should have a valid templater");
+            state.linter =
+                Linter::new(state.linter.config().clone(), None, Some(templater), true).unwrap();
         }
     }
 }


### PR DESCRIPTION
## Summary

This speeds up the Bazel-backed `cargo_test` workflow by reducing sandbox setup work and parallelizing the heaviest rule fixture test harness.

Changes:
- Point Cargo directly at the vendored dependency directory in runfiles instead of copying the full vendor tree into each test sandbox.
- Pin the generated Cargo wrapper to the requested Rust toolchain via `RUSTUP_TOOLCHAIN` and toolchain-specific component installation.
- Run `crates/lib/tests/rules.rs` rule fixture files in parallel with Rayon, reusing one `Linter` per worker and making verbose per-case logging opt-in via `SQRUFF_RULE_TEST_VERBOSE`.

## Impact

On the local Bazelisk runs, the original `//:cargo_test` baseline was about `338.4s`. The final verified state passed in `178.1s`, with the best observed improved run at `167.7s`.

## Validation

- `cargo fmt --all -- --check`
- `bazelisk test //:cargo_fmt_check --test_output=errors --test_timeout=300`
- `bazelisk test //:cargo_test --test_output=errors --test_timeout=900`