### PR TITLE
chore: update to rust to 1.96.1

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -258,7 +258,7 @@ filegroup(
 cargo_vendor(
     name = "cargo_vendor",
     manifests = [":cargo_srcs"],
-    rust_version = "1.96.0",
+    rust_version = "1.96.1",
     components = [
         "clippy",
         "rustfmt",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,7 +93,7 @@ rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
     extra_target_triples = ["wasm32-unknown-unknown"],
-    versions = ["1.96.0"],
+    versions = ["1.96.1"],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -108,7 +108,7 @@ cargo_vendor = rule(
             doc = "Cargo.toml and Cargo.lock files",
         ),
         "rust_version": attr.string(
-            default = "1.96.0",
+            default = "1.96.1",
             doc = "Rust toolchain version to install",
         ),
         "components": attr.string_list(
@@ -616,7 +616,7 @@ _cargo_attrs = {
     ),
     "script": attr.string(mandatory = True),
     "rust_version": attr.string(
-        default = "1.96.0",
+        default = "1.96.1",
         doc = "Rust toolchain version to use from the vendored toolchain",
     ),
 }


### PR DESCRIPTION
## Summary

This is stacked on top of #2840 and updates the Rust toolchain pins from `1.96.0` to `1.96.1`.

Changes:
- Update the Bzlmod rules_rust toolchain version in `MODULE.bazel`.
- Update the `cargo_vendor` Rust version in `BUILD.bazel`.
- Update the default Rust version used by the custom Cargo wrapper rules in `cargo_build.bzl`.

## Validation

- `bazelisk build //:cargo_vendor`
  - confirmed `cargo 1.96.1`
  - confirmed `rustc 1.96.1`

`MODULE.bazel.lock` did not change after the Bazelisk build.