### PR TITLE
ci: use lld for Bazel Rust links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
+      - name: Install LLD
+        run: sudo apt-get update --yes && sudo apt-get install --yes lld
       - name: Build website
         run: bazelisk build //:website
       - name: Setup Pages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,8 @@ jobs:
           # Only master (push to main) runs update the cache; PRs and merge
           # group jobs restore it read-only to avoid polluting/contending.
           cache-save: ${{ github.event_name == 'push' }}
+      - name: Install LLD
+        run: sudo apt-get update --yes && sudo apt-get install --yes lld
       - name: Build all targets
         run: bazelisk build --config=ci //...
       - name: Run all tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
+      - name: Install LLD
+        run: sudo apt-get update --yes && sudo apt-get install --yes lld
       - name: Build VS Code extension
         run: bazel build //editors/code:vscode_extension
       - name: Copy VSIX to expected location


### PR DESCRIPTION
## Summary
- Add a Bazel `lld` config for Rust link actions
- Install `lld` in Ubuntu GitHub Actions Bazel jobs
- Use `--config=lld` for CI, deploy, and VSIX Bazel builds

## Why
Rust was warning that the gold linker is deprecated and has known bugs. This switches Linux Bazel Rust link actions to LLD in GitHub Actions.
