### PR TITLE
[codex] Fix SQLite temporary view formatting

### DIFF
--- a/crates/lib-dialects/src/sqlite.rs
+++ b/crates/lib-dialects/src/sqlite.rs
@@ -1043,6 +1043,23 @@ pub fn raw_dialect() -> Dialect {
     );
 
     sqlite_dialect.replace_grammar(
+        "CreateViewStatementSegment",
+        Sequence::new(vec![
+            Ref::keyword("CREATE").to_matchable(),
+            Ref::new("TemporaryGrammar").optional().to_matchable(),
+            Ref::keyword("VIEW").to_matchable(),
+            Ref::new("IfNotExistsGrammar").optional().to_matchable(),
+            Ref::new("TableReferenceSegment").to_matchable(),
+            Ref::new("BracketedColumnReferenceListGrammar")
+                .optional()
+                .to_matchable(),
+            Ref::keyword("AS").to_matchable(),
+            optionally_bracketed(vec![Ref::new("SelectableGrammar").to_matchable()]).to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    sqlite_dialect.replace_grammar(
         "StatementSegment",
         one_of(vec![
             Ref::new("AlterTableStatementSegment").to_matchable(),

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_view.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_view.sql
@@ -1,0 +1,17 @@
+CREATE TEMP VIEW IF NOT EXISTS view_name AS
+SELECT
+    col1,
+    col2
+FROM
+    table_name;
+
+CREATE TEMPORARY VIEW IF NOT EXISTS temp_table AS
+SELECT * FROM tab
+WHERE col = 'value';
+
+CREATE VIEW Test.Data (id, name, age)
+AS
+SELECT id, name, age
+FROM temp_table
+WHERE age > 18
+AND name = 'John';

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_view.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_view.yml
@@ -1,0 +1,120 @@
+file:
+- statement:
+  - create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: view_name
+    - keyword: AS
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: col1
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: col2
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+  - create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: temp_table
+    - keyword: AS
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: tab
+      - where_clause:
+        - keyword: WHERE
+        - expression:
+          - column_reference:
+            - naked_identifier: col
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - quoted_literal: '''value'''
+- statement_terminator: ;
+- statement:
+  - create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - table_reference:
+      - naked_identifier: Test
+      - dot: .
+      - naked_identifier: Data
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: id
+      - comma: ','
+      - column_reference:
+        - naked_identifier: name
+      - comma: ','
+      - column_reference:
+        - naked_identifier: age
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: age
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: temp_table
+      - where_clause:
+        - keyword: WHERE
+        - expression:
+          - column_reference:
+            - naked_identifier: age
+          - comparison_operator:
+            - raw_comparison_operator: '>'
+          - numeric_literal: '18'
+          - binary_operator: AND
+          - column_reference:
+            - naked_identifier: name
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - quoted_literal: '''John'''
+- statement_terminator: ;

--- a/crates/lib/src/tests.rs
+++ b/crates/lib/src/tests.rs
@@ -1,5 +1,6 @@
+use hashbrown::HashMap;
 use itertools::Itertools;
-use sqruff_lib::core::config::FluffConfig;
+use sqruff_lib::core::config::{FluffConfig, Value};
 use sqruff_lib::core::linter::core::Linter;
 use sqruff_lib::core::test_functions::fresh_ansi_dialect;
 use sqruff_lib_core::dialects::init::DialectKind;
@@ -472,6 +473,31 @@ fn test_lt12_reports_missing_source_newline_after_jinja_block() {
         .map(|v| (v.line_no, v.line_pos))
         .collect();
     assert!(!lt12.is_empty(), "expected LT12 violation");
+}
+
+#[test]
+fn test_sqlite_create_temp_view_body_indent() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([
+                ("dialect".into(), Value::String("sqlite".into())),
+                ("rules".into(), Value::String("LT02".into())),
+            ])),
+        )]),
+        None,
+        None,
+    );
+    let mut lnt = Linter::new(config, None, None, true).unwrap();
+    let sql =
+        "CREATE TEMP VIEW IF NOT EXISTS view_name AS\nSELECT\ncol1,\ncol2\nFROM\ntable_name;\n";
+
+    let linted = lnt.lint_string_wrapped(sql, true).unwrap();
+
+    assert_eq!(
+        linted.fix_string(),
+        "CREATE TEMP VIEW IF NOT EXISTS view_name AS\nSELECT\n    col1,\n    col2\nFROM\n    table_name;\n"
+    );
 }
 
 /// Trailing source-only Jinja blocks should not hide extra rendered newlines


### PR DESCRIPTION
## Summary

- Port the SQLite `CREATE VIEW` grammar portion of upstream SQLFluff PR https://github.com/sqlfluff/sqlfluff/pull/5919.
- Add SQLite parser fixtures for `CREATE TEMP VIEW`, `CREATE TEMPORARY VIEW`, and `CREATE VIEW ... (columns) AS ...`.
- Add a formatter regression test covering the reported `CREATE TEMP VIEW ... AS SELECT ...` indentation issue.

## Root Cause

The SQLite dialect inherited the ANSI `CreateViewStatementSegment`, which does not accept SQLite's optional `TEMP`/`TEMPORARY` keyword before `VIEW`. As a result, `CREATE TEMP VIEW ... AS SELECT ...` was not parsed as a create-view statement, and the formatter lost the nested `SELECT` indentation context.

## Validation

- `cargo test -p sqruff-lib-dialects --test dialects -- sqlite`
- `cargo test -p sqruff-lib test_sqlite_create_temp_view_body_indent`
- `bazelisk test //...`