### PR TITLE
chore: fix Python set-up commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ You'll also need to set up a python virtualenv and install dependencies as follo
 
 ```bash
 virtualenv .venv
-source ./venv/bin/activate
-make python_install
+source .venv/bin/activate
+make python_sync
 ```
 
 ### Running Tests


### PR DESCRIPTION
## Summary

Just a small issue with the python set-up commands in `CONTRIBUTING.md`

## Changes

- Fixes typo: `./venv/` to `.venv/`
- Fixes make target: `python_install` to `python_sync`