### PR TITLE
Update Bazel pnpm to 10.22.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -76,7 +76,7 @@ use_repo(npm, "npm")
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 pnpm.pnpm(
     name = "pnpm",
-    pnpm_version = "10.0.0",
+    pnpm_version = "10.22.0",
 )
 use_repo(pnpm, "pnpm")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -329,7 +329,7 @@
     "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
       "general": {
         "bzlTransitiveDigest": "O00I3IcLXtw3yKeykFsMFUfv921iauEwYKS9eq7mhzo=",
-        "usagesDigest": "nyElrurHbTzmoMKHyH56RcBNMobo9mZhV5BREyaI4rc=",
+        "usagesDigest": "XVGM/hKARpi5yHHFF+MhJfqgsTax/GHfDuVsMjEeBfg=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_bazel_lib+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_bazel_lib+,bazel_skylib bazel_skylib+",
@@ -355,11 +355,11 @@
             "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
             "attributes": {
               "package": "pnpm",
-              "version": "10.0.0",
+              "version": "10.22.0",
               "root_package": "",
               "link_workspace": "",
               "link_packages": {},
-              "integrity": "sha512-uP71SUvT/ky9Ttq9B0XfLuW+PksLiwj6ZDqj5MZwLMwPANaPqKjJhYpzWgAySFpEmQ7SgQUmyHXkFvABsX3xKw==",
+              "integrity": "sha512-vwSe/plbKPUn/StBrgR0zikYb37cs79UUIe9Yfu+uyv3U2LRMH/aCcLSiOHkmXh6wS1Py2F6l0cYpgUfLu50HA==",
               "url": "",
               "commit": "",
               "patch_args": [
@@ -381,7 +381,7 @@
             "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
             "attributes": {
               "package": "pnpm",
-              "version": "10.0.0",
+              "version": "10.22.0",
               "dev": false,
               "root_package": "",
               "link_packages": {},


### PR DESCRIPTION
## Summary

- update the Bazel-managed pnpm toolchain from 10.0.0 to 10.22.0
- refresh the Bazel module lock metadata and integrity

This uses the newest pnpm release supported by the repository's pinned `aspect_rules_js` version.

## Validation

- `bazelisk test //:pnpm_lock_check`
- `git diff --check`