### PR TITLE
feat: Trino RF01 row field access

### DIFF
--- a/crates/lib/src/rules/references/rf01.rs
+++ b/crates/lib/src/rules/references/rf01.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;
 use smol_str::SmolStr;
 use sqruff_lib_core::dialects::Dialect;
@@ -33,6 +33,19 @@ pub struct RuleRF01 {
 }
 
 impl RuleRF01 {
+    fn dialect_supports_dot_access(dialect: DialectKind) -> bool {
+        matches!(
+            dialect,
+            DialectKind::Athena
+                | DialectKind::Bigquery
+                | DialectKind::Databricks
+                | DialectKind::Duckdb
+                | DialectKind::Redshift
+                | DialectKind::Sparksql
+                | DialectKind::Trino
+        )
+    }
+
     #[allow(clippy::only_used_in_recursion)]
     fn resolve_reference<'a>(
         &self,
@@ -71,6 +84,20 @@ impl RuleRF01 {
             for standalone_alias in &payload.standalone_aliases {
                 targets.push(vec![standalone_alias.clone()]);
             }
+        }
+
+        let distinct_targets: HashSet<Vec<String>> = targets
+            .iter()
+            .map(|target| target.iter().map(|part| part.to_uppercase()).collect())
+            .collect();
+        let dialect = RefCell::borrow(&query.inner).dialect.name;
+
+        if Self::dialect_supports_dot_access(dialect)
+            && (distinct_targets.len() == 1
+                || matches!(dialect, DialectKind::Bigquery | DialectKind::Sparksql))
+            && !self.force_enable
+        {
+            return None;
         }
 
         if !object_ref_matches_table(&possible_references, &targets) {
@@ -237,18 +264,6 @@ FROM foo
 
     fn force_enable(&self) -> bool {
         self.force_enable
-    }
-
-    fn dialect_skip(&self) -> &'static [DialectKind] {
-        // Disabled by default for dialects with dot-access semantics.
-        &[
-            DialectKind::Athena,
-            DialectKind::Bigquery,
-            DialectKind::Databricks,
-            DialectKind::Duckdb,
-            DialectKind::Redshift,
-            DialectKind::Sparksql,
-        ]
     }
 
     fn eval(&self, context: &RuleContext) -> Vec<LintResult> {

--- a/crates/lib/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -323,3 +323,41 @@ test_pass_postgres_select_with_alias_quoted:
   configs:
     core:
       dialect: postgres
+
+test_pass_trino_row_field_access_single_source:
+  # Trino uses dot access for fields in ROW values. In an unaliased,
+  # single-source query, this is indistinguishable from table qualification.
+  pass_str: |
+    SELECT some_row_object.some_attribute
+    FROM some_schema.some_table
+  configs:
+    core:
+      dialect: trino
+
+test_fail_trino_row_field_access_single_source_force_enable:
+  fail_str: |
+    SELECT some_row_object.some_attribute
+    FROM some_schema.some_table
+  configs:
+    core:
+      dialect: trino
+    rules:
+      references.from:
+        force_enable: true
+
+test_fail_trino_row_field_access_multiple_sources:
+  fail_str: |
+    SELECT some_row_object.some_attribute
+    FROM some_schema.some_table
+    CROSS JOIN other_schema.other_table
+  configs:
+    core:
+      dialect: trino
+
+test_fail_trino_row_field_access_aliased_source:
+  fail_str: |
+    SELECT some_row_object.some_attribute
+    FROM some_schema.some_table AS source_table
+  configs:
+    core:
+      dialect: trino

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -2046,7 +2046,6 @@ SELECT
 FROM foo
 ```
 
-**Dialects where this rule is skipped:** `athena`, `bigquery`, `databricks`, `duckdb`, `redshift`, `sparksql`
 
 ### references.qualification
 


### PR DESCRIPTION
Fixes #2869

## Summary

- replace RF01's dialect-wide skip with SQLFluff-style query-aware handling for dot-access dialects
- classify Trino as supporting dot access, allowing ROW field access in unaliased single-source queries
- retain strict RF01 checks for `force_enable = true`, aliased sources, and multiple sources
- add regression fixtures for all four branches and regenerate rule documentation

## Root cause

Trino's `row_column.field` syntax is structurally ambiguous with a table-qualified column reference. RF01 treated the first identifier as a table name and reported it as missing from the `FROM` clause. Parenthesized expressions worked because the parser could unambiguously represent the suffix as a semi-structured accessor.

## Impact

Valid Trino ROW field access no longer produces an RF01 violation for an unaliased, single-source query. RF01 remains useful where table qualification is unambiguous.

## Validation

- `cargo test -p sqruff-lib --test rules -- RF01.yml`
- `SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS=1 cargo test -p sqruff-lib --test rules`
- `cargo test -p sqruff-lib --lib`
- `cargo fmt --all -- --check`
- `bazelisk test //:codegen_docs_check`