### PR TITLE
ci: install Kerberos headers for Bazel build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,8 +51,8 @@ jobs:
           # Only master (push to main) runs update the cache; PRs and merge
           # group jobs restore it read-only to avoid polluting/contending.
           cache-save: ${{ github.event_name == 'push' }}
-      - name: Install LLD
-        run: sudo apt-get update --yes && sudo apt-get install --yes lld
+      - name: Install native build dependencies
+        run: sudo apt-get update --yes && sudo apt-get install --yes libkrb5-dev lld
       - name: Build all targets
         run: bazelisk build --config=ci //...
       - name: Run all tests


### PR DESCRIPTION
## Summary

- install the Kerberos development headers in the Bazel Lint job
- rename the setup step to reflect that it installs multiple native build dependencies

## Root cause

The all-target Bazel build runs the `code-server` postinstall, which compiles its transitive native `kerberos` module on Ubuntu. The GitHub Actions runner does not provide `gssapi/gssapi.h` by default, so the build fails before the test step. Ubuntu's `libkrb5-dev` package provides the missing header.

## Validation

- `node_modules/.bin/prettier --check .github/workflows/pr.yml`
- `git diff --check`
