### PR TITLE
feat: fix Trino multi-parameter lambdas

### DIFF
--- a/crates/lib-dialects/src/trino.rs
+++ b/crates/lib-dialects/src/trino.rs
@@ -78,7 +78,7 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         ),
         (
             "LambdaArrowSegment".into(),
-            StringParser::new("->", SyntaxKind::Symbol)
+            StringParser::new("->", SyntaxKind::LambdaArrow)
                 .to_matchable()
                 .into(),
         ),
@@ -931,8 +931,11 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             Sequence::new(vec![
                 one_of(vec![
                     Ref::new("ParameterNameSegment").to_matchable(),
-                    Bracketed::new(vec![Ref::new("ParameterNameSegment").to_matchable()])
-                        .to_matchable(),
+                    Bracketed::new(vec![
+                        Delimited::new(vec![Ref::new("ParameterNameSegment").to_matchable()])
+                            .to_matchable(),
+                    ])
+                    .to_matchable(),
                 ])
                 .to_matchable(),
                 Ref::new("LambdaArrowSegment").to_matchable(),

--- a/crates/lib-dialects/test/fixtures/dialects/trino/sqlfluff/array.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/trino/sqlfluff/array.yml
@@ -117,7 +117,7 @@ file:
                     - end_square_bracket: ']'
               - comma: ','
               - parameter: x
-              - symbol: ->
+              - lambda_arrow: ->
               - expression:
                 - column_reference:
                   - naked_identifier: x
@@ -155,7 +155,7 @@ file:
                     - end_square_bracket: ']'
               - comma: ','
               - parameter: x
-              - symbol: ->
+              - lambda_arrow: ->
               - expression:
                 - column_reference:
                   - naked_identifier: x

--- a/crates/lib-dialects/test/fixtures/dialects/trino/sqlfluff/regexp_replace_with_lambda.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/trino/sqlfluff/regexp_replace_with_lambda.yml
@@ -17,7 +17,7 @@ file:
                 - quoted_literal: '''(\w)(\w*)'''
               - comma: ','
               - parameter: x
-              - symbol: ->
+              - lambda_arrow: ->
               - expression:
                 - function:
                   - function_name:

--- a/crates/lib-dialects/test/fixtures/dialects/trino/sqruff/array_sort_with_lambda.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/trino/sqruff/array_sort_with_lambda.sql
@@ -1,0 +1,1 @@
+SELECT array_sort(ARRAY[3, 2, 5, 1, 2], (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)));

--- a/crates/lib-dialects/test/fixtures/dialects/trino/sqruff/array_sort_with_lambda.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/trino/sqruff/array_sort_with_lambda.yml
@@ -1,0 +1,80 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: array_sort
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - typed_array_literal:
+                  - array_type:
+                    - keyword: ARRAY
+                  - array_literal:
+                    - start_square_bracket: '['
+                    - numeric_literal: '3'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - comma: ','
+                    - numeric_literal: '5'
+                    - comma: ','
+                    - numeric_literal: '1'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - end_square_bracket: ']'
+              - comma: ','
+              - bracketed:
+                - start_bracket: (
+                - parameter: x
+                - comma: ','
+                - parameter: y
+                - end_bracket: )
+              - lambda_arrow: ->
+              - expression:
+                - function:
+                  - function_name:
+                    - function_name_identifier: IF
+                  - function_contents:
+                    - bracketed:
+                      - start_bracket: (
+                      - expression:
+                        - column_reference:
+                          - naked_identifier: x
+                        - comparison_operator:
+                          - raw_comparison_operator: <
+                        - column_reference:
+                          - naked_identifier: y
+                      - comma: ','
+                      - expression:
+                        - numeric_literal: '1'
+                      - comma: ','
+                      - expression:
+                        - function:
+                          - function_name:
+                            - function_name_identifier: IF
+                          - function_contents:
+                            - bracketed:
+                              - start_bracket: (
+                              - expression:
+                                - column_reference:
+                                  - naked_identifier: x
+                                - comparison_operator:
+                                  - raw_comparison_operator: =
+                                - column_reference:
+                                  - naked_identifier: y
+                              - comma: ','
+                              - expression:
+                                - numeric_literal: '0'
+                              - comma: ','
+                              - expression:
+                                - numeric_literal:
+                                  - sign_indicator: '-'
+                                  - numeric_literal: '1'
+                              - end_bracket: )
+                      - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
## Summary

- parse parenthesized, comma-delimited Trino lambda parameters
- classify Trino lambda arrows as `lambda_arrow`
- add a sqruff-owned regression fixture for multi-parameter `array_sort` lambdas

## Root cause

The Trino lambda grammar only accepted a single parameter inside parentheses, so expressions such as `(x, y) -> ...` could be tokenized but not fully parsed.

Fixes #1302.

## Validation

- `bazelisk test //...` (33/33 tests passed)
