### PR TITLE
feat(clickhouse): support CREATE USER

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -1788,6 +1788,31 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     );
 
     clickhouse_dialect.replace_grammar(
+        "CreateUserStatementSegment",
+        Sequence::new(vec![
+            Ref::keyword("CREATE").to_matchable(),
+            Ref::keyword("USER").to_matchable(),
+            Ref::new("IfNotExistsGrammar").optional().to_matchable(),
+            Ref::new("SingleIdentifierGrammar").to_matchable(),
+            Ref::new("OnClusterClauseSegment").optional().to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("IDENTIFIED").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("WITH").to_matchable(),
+                    Ref::new("SingleIdentifierGrammar").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Ref::keyword("BY").to_matchable(),
+                Ref::new("QuotedLiteralSegment").to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    clickhouse_dialect.replace_grammar(
         "DropRoleStatementSegment",
         Sequence::new(vec![
             Ref::keyword("DROP").to_matchable(),

--- a/crates/lib-dialects/src/clickhouse_keywords.rs
+++ b/crates/lib-dialects/src/clickhouse_keywords.rs
@@ -77,6 +77,7 @@ pub(crate) const UNRESERVED_KEYWORDS: &[&str] = &[
     "HIERARCHICAL",
     "HOUR",
     "ID",
+    "IDENTIFIED",
     "IF",
     "ILIKE",
     "IN",

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/create_user.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/create_user.sql
@@ -1,0 +1,7 @@
+-- This file tests CREATE USER with/without IDENTIFIED BY for ClickHouse dialect
+-- sqlfluff:dialect:clickhouse
+
+CREATE USER new_user IDENTIFIED BY 'secret';
+CREATE USER another_user IDENTIFIED WITH sha256_password BY 'hash';
+
+CREATE USER yet_another_user;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/create_user.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/create_user.yml
@@ -1,0 +1,27 @@
+file:
+- statement:
+  - create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - naked_identifier: new_user
+    - keyword: IDENTIFIED
+    - keyword: BY
+    - quoted_literal: '''secret'''
+- statement_terminator: ;
+- statement:
+  - create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - naked_identifier: another_user
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - naked_identifier: sha256_password
+    - keyword: BY
+    - quoted_literal: '''hash'''
+- statement_terminator: ;
+- statement:
+  - create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - naked_identifier: yet_another_user
+- statement_terminator: ;


### PR DESCRIPTION
## Summary

- add ClickHouse grammar for `CREATE USER`
- support optional `IF NOT EXISTS`, `ON CLUSTER`, and `IDENTIFIED [WITH method] BY 'password'`
- add `IDENTIFIED` to the ClickHouse unreserved keywords
- add the exact SQL fixture from SQLFluff and a Sqruff-generated parse fixture

This ports the first unchecked item from #2910, based on SQLFluff commit [d35ff2dda98d1276334466a898c058b973a49be0](https://github.com/sqlfluff/sqlfluff/commit/d35ff2dda98d1276334466a898c058b973a49be0).

## User impact

Sqruff can parse ClickHouse user creation statements with plain, password, and explicit authentication-method forms.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sqruff-lib-dialects --test dialects -- clickhouse`
- byte comparison of `create_user.sql` against the raw fixture at the upstream SQLFluff commit
