### PR TITLE
feat(clickhouse): add parametric aggregate functions

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -1759,6 +1759,31 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         .to_matchable(),
     );
 
+    // Support ClickHouse parametric aggregate functions, which use a
+    // double-parentheses syntax: `func(params)(args)`.
+    // https://clickhouse.com/docs/sql-reference/aggregate-functions/parametric-functions
+    clickhouse_dialect.replace_grammar(
+        "FunctionContentsSegment",
+        one_of(vec![
+            // Double parentheses pattern: func(params)(args)
+            Sequence::new(vec![
+                Bracketed::new(vec![Ref::new("FunctionContentsGrammar").to_matchable()])
+                    .to_matchable(),
+                Bracketed::new(vec![Ref::new("FunctionContentsGrammar").to_matchable()])
+                    .to_matchable(),
+            ])
+            .to_matchable(),
+            // Standard ANSI single parentheses
+            Sequence::new(vec![
+                Bracketed::new(vec![Ref::new("FunctionContentsGrammar").to_matchable()])
+                    .config(|this| this.optional())
+                    .to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
     clickhouse_dialect.add([(
         "DropDictionaryStatementSegment".into(),
         NodeMatcher::new(SyntaxKind::DropDictionaryStatement, |_| {

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/parametric_aggregate_functions.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/parametric_aggregate_functions.sql
@@ -1,0 +1,55 @@
+SELECT histogram(5)(number + 1) FROM system.numbers LIMIT 20;
+
+SELECT histogram(10)(value) FROM data;
+
+SELECT median(value) FROM data;
+
+SELECT medianBFloat16(value) FROM data;
+
+SELECT quantile(0.95)(response_time) FROM metrics;
+
+SELECT quantile(0.5)(price) FROM sales;
+
+SELECT quantile(price) FROM sales;
+
+SELECT quantiles(0.25, 0.5, 0.75)(value) FROM data;
+
+SELECT quantiles(0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.999)(click) AS quantiles_click_size
+FROM clickhouse_table;
+
+SELECT
+    quantiles(0.25, 0.5, 0.75)(col1) AS q1,
+    quantiles(0.1, 0.9)(col2) AS q2
+FROM table1;
+
+SELECT quantileBFloat16(0.75)(a), quantileBFloat16(0.75)(b) FROM example_table;
+
+SELECT quantileDD(0.5)(value) FROM data;
+
+SELECT quantileDeterministic(0.5)(value, id) FROM test_table;
+
+SELECT quantileDeterministic(value, 1) FROM test_table;
+
+SELECT quantilesDeterministic(0.25, 0.5, 0.75)(x, id) FROM test_table;
+
+SELECT quantileExact(0.95)(value) FROM data;
+
+SELECT quantilesExact(0.25, 0.5, 0.75, 0.9)(value) FROM data;
+
+SELECT retention(date = '2020-01-01', date = '2020-01-02', date = '2020-01-03') AS r FROM events;
+
+SELECT sequenceCount('(?1)(?2)')(timestamp, event_type = 1, event_type = 2) FROM user_events;
+
+SELECT sequenceMatch('(?1)(?2)')(timestamp, event_type = 1, event_type = 2) FROM user_events;
+
+SELECT studentTTest(sample_data, sample_index) FROM student_ttest;
+
+SELECT studentTTest(0.95)(sample_data, sample_index) FROM student_ttest;
+
+SELECT studentTTestOneSample()(value, 20.0) FROM student_ttest;
+
+SELECT studentTTestOneSample(value, 20.0) FROM student_ttest;
+
+SELECT studentTTestOneSample(0.95)(value, 20.0) FROM student_ttest;
+
+SELECT sumMapFilteredWithOverflow([1, 4, 8])(statusMap.status, statusMap.requests) as summap_overflow, toTypeName(summap_overflow) FROM sum_map;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/parametric_aggregate_functions.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/parametric_aggregate_functions.yml
@@ -1,0 +1,905 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: histogram
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '5'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: number
+                - binary_operator: +
+                - numeric_literal: '1'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: numbers
+    - limit_clause:
+      - keyword: LIMIT
+      - numeric_literal: '20'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: histogram
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '10'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: median
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: medianBFloat16
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantile
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.95'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: response_time
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: metrics
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantile
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.5'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: price
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: sales
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantile
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: price
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: sales
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantiles
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.25'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.5'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.75'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantiles
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.01'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.05'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.1'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.25'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.5'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.75'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.9'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.95'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.99'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.999'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: click
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: quantiles_click_size
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: clickhouse_table
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantiles
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.25'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.5'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.75'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: col1
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: q1
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantiles
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.1'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.9'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: col2
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: q2
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantileBFloat16
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.75'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: a
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantileBFloat16
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.75'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: b
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: example_table
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantileDD
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.5'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantileDeterministic
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.5'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: id
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantileDeterministic
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - comma: ','
+              - expression:
+                - numeric_literal: '1'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantilesDeterministic
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.25'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.5'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.75'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: x
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: id
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantileExact
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.95'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: quantilesExact
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.25'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.5'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.75'
+              - comma: ','
+              - expression:
+                - numeric_literal: '0.9'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: data
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: retention
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: date
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - quoted_literal: '''2020-01-01'''
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: date
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - quoted_literal: '''2020-01-02'''
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: date
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - quoted_literal: '''2020-01-03'''
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: r
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: events
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: sequenceCount
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - quoted_literal: '''(?1)(?2)'''
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: timestamp
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: event_type
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - numeric_literal: '1'
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: event_type
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - numeric_literal: '2'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: user_events
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: sequenceMatch
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - quoted_literal: '''(?1)(?2)'''
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: timestamp
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: event_type
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - numeric_literal: '1'
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: event_type
+                - comparison_operator:
+                  - raw_comparison_operator: =
+                - numeric_literal: '2'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: user_events
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: studentTTest
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: sample_data
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: sample_index
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: student_ttest
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: studentTTest
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.95'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: sample_data
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: sample_index
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: student_ttest
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: studentTTestOneSample
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - comma: ','
+              - expression:
+                - numeric_literal: '20.0'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: student_ttest
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: studentTTestOneSample
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - comma: ','
+              - expression:
+                - numeric_literal: '20.0'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: student_ttest
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: studentTTestOneSample
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '0.95'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: value
+              - comma: ','
+              - expression:
+                - numeric_literal: '20.0'
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: student_ttest
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: sumMapFilteredWithOverflow
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '4'
+                  - comma: ','
+                  - numeric_literal: '8'
+                  - end_square_bracket: ']'
+              - end_bracket: )
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: statusMap
+                  - dot: .
+                  - naked_identifier: status
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: statusMap
+                  - dot: .
+                  - naked_identifier: requests
+              - end_bracket: )
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: summap_overflow
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: toTypeName
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: summap_overflow
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: sum_map
+- statement_terminator: ;


### PR DESCRIPTION
Port ClickHouse parametric aggregate function support from SQLFluff. These
functions use a double-parentheses syntax `func(params)(args)`, e.g.
`quantile(0.95)(response_time)` or `histogram(5)(number + 1)`.

Override the ANSI `FunctionContentsSegment` in the ClickHouse dialect so it
accepts either the parametric two-bracket pattern or the standard ANSI
single-bracket form, and copy/adapt the upstream `.sql` fixture with a
generated Sqruff `.yml`.

Refs quarylabs/sqruff#2910
Ported from sqlfluff/sqlfluff@2b7bf83c9808cb5f74bd580e8767602dfad7e59e

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TUqk8S6k25vsbivPA5LKn7