### PR TITLE
feat(clickhouse): add ALTER TABLE mutations

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -2581,6 +2581,27 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     Ref::new("TableReferenceSegment").to_matchable(),
                 ])
                 .to_matchable(),
+                // ALTER TABLE ... UPDATE column = expr [, column = expr ...] WHERE condition
+                Sequence::new(vec![
+                    Ref::keyword("UPDATE").to_matchable(),
+                    Delimited::new(vec![
+                        Sequence::new(vec![
+                            Ref::new("SingleIdentifierGrammar").to_matchable(),
+                            Ref::new("EqualsSegment").to_matchable(),
+                            Ref::new("ExpressionSegment").to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                    Ref::new("WhereClauseSegment").to_matchable(),
+                ])
+                .to_matchable(),
+                // ALTER TABLE ... DELETE WHERE condition
+                Sequence::new(vec![
+                    Ref::keyword("DELETE").to_matchable(),
+                    Ref::new("WhereClauseSegment").to_matchable(),
+                ])
+                .to_matchable(),
             ])
             .to_matchable(),
             Ref::new("SettingsClauseSegment").optional().to_matchable(),

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/alter_table.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/alter_table.sql
@@ -128,3 +128,19 @@ ALTER TABLE x ON CLUSTER '{cluster}' REPLACE PARTITION 'y' FROM z;
 
 -- ALTER TABLE with Settings
 ALTER TABLE x ADD COLUMN y Int32 ALIAS z + 10 SETTINGS abc=1;
+
+-- UPDATE mutation examples
+ALTER TABLE my_table UPDATE column_name = 'new_value' WHERE condition = true;
+ALTER TABLE my_table UPDATE column_name = 'new_value' WHERE condition = true SETTINGS mutations_sync = 1;
+ALTER TABLE users UPDATE age = age + 1 WHERE id = 100;
+ALTER TABLE users UPDATE status = 'active', last_login = now() WHERE user_id IN (1, 2, 3);
+ALTER TABLE products ON CLUSTER '{cluster}' UPDATE price = price * 1.1 WHERE category = 'electronics';
+ALTER TABLE events UPDATE event_count = event_count + 1 WHERE event_date = today() SETTINGS mutations_sync = 2;
+
+-- DELETE mutation examples
+ALTER TABLE my_table DELETE WHERE condition = true;
+ALTER TABLE my_table DELETE WHERE condition = true SETTINGS mutations_sync = 1;
+ALTER TABLE logs DELETE WHERE log_date < today() - INTERVAL 30 DAY;
+ALTER TABLE users DELETE WHERE deleted = 1 AND last_activity < now() - INTERVAL 1 YEAR;
+ALTER TABLE sessions ON CLUSTER '{cluster}' DELETE WHERE session_id IN (SELECT id FROM expired_sessions);
+ALTER TABLE temp_data DELETE WHERE created_at < '2023-01-01' SETTINGS mutations_sync = 2;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/alter_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/alter_table.yml
@@ -1369,3 +1369,331 @@ file:
       - raw_comparison_operator: =
     - numeric_literal: '1'
 - statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: my_table
+    - keyword: UPDATE
+    - naked_identifier: column_name
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - quoted_literal: '''new_value'''
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: condition
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: my_table
+    - keyword: UPDATE
+    - naked_identifier: column_name
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - quoted_literal: '''new_value'''
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: condition
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - boolean_literal: 'true'
+    - keyword: SETTINGS
+    - naked_identifier: mutations_sync
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: users
+    - keyword: UPDATE
+    - naked_identifier: age
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - column_reference:
+        - naked_identifier: age
+      - binary_operator: +
+      - numeric_literal: '1'
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: id
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '100'
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: users
+    - keyword: UPDATE
+    - naked_identifier: status
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - quoted_literal: '''active'''
+    - comma: ','
+    - naked_identifier: last_login
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - function:
+        - function_name:
+          - function_name_identifier: now
+        - function_contents:
+          - bracketed:
+            - start_bracket: (
+            - end_bracket: )
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: user_id
+        - keyword: IN
+        - tuple:
+          - bracketed:
+            - start_bracket: (
+            - numeric_literal: '1'
+            - comma: ','
+            - numeric_literal: '2'
+            - comma: ','
+            - numeric_literal: '3'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: products
+    - on_cluster_clause:
+      - keyword: ON
+      - keyword: CLUSTER
+      - quoted_identifier: '''{cluster}'''
+    - keyword: UPDATE
+    - naked_identifier: price
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - column_reference:
+        - naked_identifier: price
+      - binary_operator: '*'
+      - numeric_literal: '1.1'
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: category
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''electronics'''
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: events
+    - keyword: UPDATE
+    - naked_identifier: event_count
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - expression:
+      - column_reference:
+        - naked_identifier: event_count
+      - binary_operator: +
+      - numeric_literal: '1'
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: event_date
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - function:
+          - function_name:
+            - function_name_identifier: today
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - keyword: SETTINGS
+    - naked_identifier: mutations_sync
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: my_table
+    - keyword: DELETE
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: condition
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: my_table
+    - keyword: DELETE
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: condition
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - boolean_literal: 'true'
+    - keyword: SETTINGS
+    - naked_identifier: mutations_sync
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: logs
+    - keyword: DELETE
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: log_date
+        - comparison_operator:
+          - raw_comparison_operator: <
+        - function:
+          - function_name:
+            - function_name_identifier: today
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+        - binary_operator: '-'
+        - interval_expression:
+          - keyword: INTERVAL
+          - numeric_literal: '30'
+          - date_part: DAY
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: users
+    - keyword: DELETE
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: deleted
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: last_activity
+        - comparison_operator:
+          - raw_comparison_operator: <
+        - function:
+          - function_name:
+            - function_name_identifier: now
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+        - binary_operator: '-'
+        - interval_expression:
+          - keyword: INTERVAL
+          - numeric_literal: '1'
+          - date_part: YEAR
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: sessions
+    - on_cluster_clause:
+      - keyword: ON
+      - keyword: CLUSTER
+      - quoted_identifier: '''{cluster}'''
+    - keyword: DELETE
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: session_id
+        - keyword: IN
+        - tuple:
+          - bracketed:
+            - start_bracket: (
+            - expression:
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - column_reference:
+                      - naked_identifier: id
+                - from_clause:
+                  - keyword: FROM
+                  - from_expression:
+                    - from_expression_element:
+                      - table_expression:
+                        - table_reference:
+                          - naked_identifier: expired_sessions
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: temp_data
+    - keyword: DELETE
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: created_at
+        - comparison_operator:
+          - raw_comparison_operator: <
+        - quoted_literal: '''2023-01-01'''
+    - keyword: SETTINGS
+    - naked_identifier: mutations_sync
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '2'
+- statement_terminator: ;


### PR DESCRIPTION
## Summary

- support ClickHouse `ALTER TABLE ... UPDATE` mutations, including multiple column assignments
- support ClickHouse `ALTER TABLE ... DELETE WHERE` mutations
- copy the upstream SQL fixture additions verbatim and generate the corresponding Sqruff parse fixture

## Why

This continues the incremental ClickHouse SQLFluff catch-up tracked in #2910. It ports [SQLFluff `e135e8300ecfbc97952ed8930cb5197aa51b7286`](https://github.com/sqlfluff/sqlfluff/commit/e135e8300ecfbc97952ed8930cb5197aa51b7286).

## Impact

ClickHouse users can now parse `ALTER TABLE` UPDATE and DELETE mutation statements, including `ON CLUSTER` and trailing `SETTINGS` clauses.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sqruff-lib-dialects --test dialects -- clickhouse`
- `git diff --check`

Refs #2910