### PR TITLE
feat: enable Hive dialect

### DIFF
--- a/crates/lib-core/src/dialects/init.rs
+++ b/crates/lib-core/src/dialects/init.rs
@@ -102,6 +102,7 @@ pub enum DialectKind {
     Db2,
     Duckdb,
     Greenplum,
+    Hive,
     Mysql,
     Oracle,
     Postgres,
@@ -126,6 +127,7 @@ impl DialectKind {
             DialectKind::Db2 => "db2",
             DialectKind::Duckdb => "duckdb",
             DialectKind::Greenplum => "greenplum",
+            DialectKind::Hive => "hive",
             DialectKind::Mysql => "mysql",
             DialectKind::Oracle => "oracle",
             DialectKind::Postgres => "postgres",
@@ -154,6 +156,7 @@ impl DialectKind {
             DialectKind::Db2 => "IBM Db2 SQL dialect.",
             DialectKind::Duckdb => "DuckDB SQL dialect for in-process analytical database.",
             DialectKind::Greenplum => "Greenplum SQL dialect, a massively parallel Postgres.",
+            DialectKind::Hive => "Apache Hive SQL dialect for data warehousing.",
             DialectKind::Mysql => "MySQL SQL dialect for the popular open-source database.",
             DialectKind::Oracle => "Oracle SQL dialect for Oracle Database.",
             DialectKind::Postgres => {
@@ -194,6 +197,7 @@ impl DialectKind {
             DialectKind::Greenplum => {
                 Some("https://docs.vmware.com/en/VMware-Greenplum/index.html")
             }
+            DialectKind::Hive => Some("https://hive.apache.org/docs/latest/language/"),
             DialectKind::Mysql => Some("https://dev.mysql.com/doc/"),
             DialectKind::Oracle => {
                 Some("https://www.oracle.com/database/technologies/appdev/sql.html")

--- a/crates/lib-dialects/src/hive.rs
+++ b/crates/lib-dialects/src/hive.rs
@@ -1,16 +1,96 @@
 use sqruff_lib_core::dialects::Dialect;
+use sqruff_lib_core::dialects::init::{DialectConfig, DialectKind};
 use sqruff_lib_core::dialects::syntax::SyntaxKind;
 use sqruff_lib_core::helpers::{Config, ToMatchable};
 use sqruff_lib_core::parser::grammar::Ref;
 use sqruff_lib_core::parser::grammar::anyof::one_of;
 use sqruff_lib_core::parser::grammar::delimited::Delimited;
 use sqruff_lib_core::parser::grammar::sequence::{Bracketed, Sequence};
+use sqruff_lib_core::parser::matchable::MatchableTrait;
 use sqruff_lib_core::parser::node_matcher::NodeMatcher;
+use sqruff_lib_core::parser::parsers::{StringParser, TypedParser};
+use sqruff_lib_core::value::Value;
+
+sqruff_lib_core::dialect_config!(HiveDialectConfig {});
+
+pub fn dialect(config: Option<&Value>) -> Dialect {
+    let _dialect_config: HiveDialectConfig = config
+        .map(HiveDialectConfig::from_value)
+        .unwrap_or_default();
+
+    raw_dialect().config(|dialect| dialect.expand())
+}
 
 pub fn raw_dialect() -> Dialect {
     let mut hive_dialect = super::ansi::dialect(None);
+    hive_dialect.name = DialectKind::Hive;
+
+    // These keywords are referenced by Hive-specific grammars below but are not
+    // part of ANSI. Registering them is required when Hive is expanded directly
+    // rather than used only as a grammar source by SparkSQL.
+    hive_dialect.sets_mut("unreserved_keywords").extend([
+        "COLLECTION",
+        "DELIMITED",
+        "DIRECTORIES",
+        "ITEMS",
+        "MSCK",
+        "PARTITIONS",
+        "REPAIR",
+        "SERDE",
+        "SERDEPROPERTIES",
+        "SKEWED",
+        "STORED",
+        "STRUCT",
+        "SYNC",
+    ]);
+
+    hive_dialect.update_bracket_sets(
+        "angle_bracket_pairs",
+        vec![(
+            "angle",
+            "StartAngleBracketSegment",
+            "EndAngleBracketSegment",
+            false,
+        )],
+    );
 
     hive_dialect.add([
+        (
+            "QuotedLiteralSegment".into(),
+            one_of(vec![
+                TypedParser::new(SyntaxKind::SingleQuote, SyntaxKind::QuotedLiteral).to_matchable(),
+                TypedParser::new(SyntaxKind::DoubleQuote, SyntaxKind::QuotedLiteral).to_matchable(),
+            ])
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "BackQuotedIdentifierSegment".into(),
+            TypedParser::new(SyntaxKind::BackQuote, SyntaxKind::QuotedIdentifier)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "SingleIdentifierGrammar".into(),
+            one_of(vec![
+                Ref::new("NakedIdentifierSegment").to_matchable(),
+                Ref::new("BackQuotedIdentifierSegment").to_matchable(),
+            ])
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "StartAngleBracketSegment".into(),
+            StringParser::new("<", SyntaxKind::StartAngleBracket)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "EndAngleBracketSegment".into(),
+            StringParser::new(">", SyntaxKind::EndAngleBracket)
+                .to_matchable()
+                .into(),
+        ),
         (
             "CommentGrammar".into(),
             Sequence::new(vec![
@@ -279,6 +359,135 @@ pub fn raw_dialect() -> Dialect {
                 .to_matchable(),
         ])
         .to_matchable(),
+    );
+
+    hive_dialect.add([
+        (
+            "PrimitiveTypeSegment".into(),
+            NodeMatcher::new(SyntaxKind::PrimitiveType, |_| {
+                one_of(vec![
+                    Ref::keyword("BOOLEAN").to_matchable(),
+                    Ref::keyword("TINYINT").to_matchable(),
+                    Ref::keyword("SMALLINT").to_matchable(),
+                    Ref::keyword("INT").to_matchable(),
+                    Ref::keyword("INTEGER").to_matchable(),
+                    Ref::keyword("BIGINT").to_matchable(),
+                    Ref::keyword("FLOAT").to_matchable(),
+                    Ref::keyword("REAL").to_matchable(),
+                    Ref::keyword("DOUBLE").to_matchable(),
+                    Ref::keyword("DATE").to_matchable(),
+                    Ref::keyword("TIMESTAMP").to_matchable(),
+                    Ref::keyword("STRING").to_matchable(),
+                    Sequence::new(vec![
+                        one_of(vec![
+                            Ref::keyword("CHAR").to_matchable(),
+                            Ref::keyword("VARCHAR").to_matchable(),
+                            Ref::keyword("DECIMAL").to_matchable(),
+                            Ref::keyword("DEC").to_matchable(),
+                            Ref::keyword("NUMERIC").to_matchable(),
+                        ])
+                        .to_matchable(),
+                        Ref::new("BracketedArguments").optional().to_matchable(),
+                    ])
+                    .to_matchable(),
+                    Ref::keyword("BINARY").to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "RowTypeSchemaSegment".into(),
+            Bracketed::new(vec![
+                Delimited::new(vec![
+                    Sequence::new(vec![
+                        Ref::new("ParameterNameSegment").to_matchable(),
+                        Ref::new("DatatypeSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "RowTypeSegment".into(),
+            Sequence::new(vec![
+                Ref::keyword("ROW").to_matchable(),
+                Ref::new("RowTypeSchemaSegment").to_matchable(),
+            ])
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "SetStatementSegment".into(),
+            NodeMatcher::new(SyntaxKind::SetStatement, |_| {
+                Sequence::new(vec![
+                    Ref::keyword("SET").to_matchable(),
+                    Ref::new("SingleIdentifierGrammar").to_matchable(),
+                    Sequence::new(vec![
+                        Ref::new("ColonDelimiterSegment").to_matchable(),
+                        Ref::new("SingleIdentifierGrammar").to_matchable(),
+                    ])
+                    .config(|config| config.optional())
+                    .to_matchable(),
+                    Sequence::new(vec![
+                        Ref::new("EqualsSegment").to_matchable(),
+                        Ref::new("LiteralGrammar").to_matchable(),
+                    ])
+                    .config(|config| config.optional())
+                    .to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+    ]);
+
+    hive_dialect.replace_grammar(
+        "DatatypeSegment",
+        NodeMatcher::new(SyntaxKind::DataType, |_| {
+            one_of(vec![
+                Ref::new("PrimitiveTypeSegment").to_matchable(),
+                Ref::new("SizedArrayTypeSegment").to_matchable(),
+                Ref::new("ArrayTypeSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("MAP").to_matchable(),
+                    Bracketed::new(vec![
+                        Delimited::new(vec![Ref::new("DatatypeSegment").to_matchable()])
+                            .to_matchable(),
+                    ])
+                    .config(|config| {
+                        config.bracket_pairs_set = "angle_bracket_pairs";
+                        config.bracket_type = "angle";
+                    })
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::new("StructTypeSegment").to_matchable(),
+                Ref::new("RowTypeSegment").to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable(),
+    );
+
+    hive_dialect.replace_grammar(
+        "StatementSegment",
+        super::ansi::statement_segment().copy(
+            Some(vec![
+                Ref::new("MsckRepairTableStatementSegment").to_matchable(),
+                Ref::new("SetStatementSegment").to_matchable(),
+            ]),
+            None,
+            None,
+            None,
+            Vec::new(),
+            false,
+        ),
     );
 
     hive_dialect

--- a/crates/lib-dialects/src/lib.rs
+++ b/crates/lib-dialects/src/lib.rs
@@ -91,6 +91,8 @@ pub fn dialect_config_options(
         DialectKind::Duckdb => duckdb::DuckDBDialectConfig::config_options(),
         #[cfg(feature = "greenplum")]
         DialectKind::Greenplum => greenplum::GreenplumDialectConfig::config_options(),
+        #[cfg(feature = "hive")]
+        DialectKind::Hive => hive::HiveDialectConfig::config_options(),
         #[cfg(feature = "mysql")]
         DialectKind::Mysql => mysql::MySQLDialectConfig::config_options(),
         #[cfg(feature = "oracle")]
@@ -133,6 +135,8 @@ pub fn kind_to_dialect(kind: &DialectKind, config: Option<&Value>) -> Option<Dia
         DialectKind::Duckdb => duckdb::dialect(config),
         #[cfg(feature = "greenplum")]
         DialectKind::Greenplum => greenplum::dialect(config),
+        #[cfg(feature = "hive")]
+        DialectKind::Hive => hive::dialect(config),
         #[cfg(feature = "mysql")]
         DialectKind::Mysql => mysql::dialect(config),
         #[cfg(feature = "oracle")]

--- a/crates/lib-dialects/test/fixtures/dialects/hive/sqlfluff/select.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/hive/sqlfluff/select.sql
@@ -1,0 +1,3 @@
+SELECT id, name
+FROM users
+WHERE active = TRUE;

--- a/crates/lib-dialects/test/fixtures/dialects/hive/sqlfluff/select.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/hive/sqlfluff/select.yml
@@ -1,0 +1,28 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: name
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: users
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: active
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - boolean_literal: 'TRUE'
+- statement_terminator: ;

--- a/crates/lib/src/rules/convention/cv10.rs
+++ b/crates/lib/src/rules/convention/cv10.rs
@@ -110,11 +110,11 @@ from foo
     }
 
     fn eval(&self, context: &RuleContext) -> Vec<LintResult> {
-        // TODO: "databricks", "hive", "mysql"
+        // TODO: "databricks", "mysql"
         if !(self.force_enable
             || matches!(
                 context.dialect.name,
-                DialectKind::Bigquery | DialectKind::Sparksql
+                DialectKind::Bigquery | DialectKind::Hive | DialectKind::Sparksql
             ))
         {
             return Vec::new();

--- a/crates/lib/src/rules/references/rf01.rs
+++ b/crates/lib/src/rules/references/rf01.rs
@@ -40,6 +40,7 @@ impl RuleRF01 {
                 | DialectKind::Bigquery
                 | DialectKind::Databricks
                 | DialectKind::Duckdb
+                | DialectKind::Hive
                 | DialectKind::Redshift
                 | DialectKind::Sparksql
                 | DialectKind::Trino

--- a/crates/lib/src/rules/references/rf03.rs
+++ b/crates/lib/src/rules/references/rf03.rs
@@ -359,7 +359,11 @@ FROM foo
     }
 
     fn dialect_skip(&self) -> &'static [DialectKind] {
-        &[DialectKind::Bigquery, DialectKind::Redshift]
+        &[
+            DialectKind::Bigquery,
+            DialectKind::Hive,
+            DialectKind::Redshift,
+        ]
     }
 
     fn eval(&self, context: &RuleContext) -> Vec<LintResult> {

--- a/crates/lib/src/rules/references/rf06.rs
+++ b/crates/lib/src/rules/references/rf06.rs
@@ -296,6 +296,7 @@ fn identifier_quote_chars(dialect: DialectKind) -> Option<(&'static str, &'stati
         | DialectKind::Trino => Some(("\"", "\"")),
         DialectKind::Bigquery
         | DialectKind::Databricks
+        | DialectKind::Hive
         | DialectKind::Mysql
         | DialectKind::Sparksql
         | DialectKind::Starrocks => Some(("`", "`")),
@@ -319,6 +320,7 @@ mod tests {
             (DialectKind::Db2, Some(("\"", "\""))),
             (DialectKind::Duckdb, Some(("\"", "\""))),
             (DialectKind::Greenplum, Some(("\"", "\""))),
+            (DialectKind::Hive, Some(("`", "`"))),
             (DialectKind::Mysql, Some(("`", "`"))),
             (DialectKind::Oracle, Some(("\"", "\""))),
             (DialectKind::Postgres, Some(("\"", "\""))),

--- a/docs/reference/dialects.md
+++ b/docs/reference/dialects.md
@@ -12,6 +12,7 @@ Sqruff currently supports the following SQL dialects:
 - [db2](#db2)
 - [duckdb](#duckdb)
 - [greenplum](#greenplum)
+- [hive](#hive)
 - [mysql](#mysql)
 - [oracle](#oracle)
 - [postgres](#postgres)
@@ -116,6 +117,18 @@ Greenplum SQL dialect, a massively parallel Postgres.
 **Configuration:**
 ```ini
 [sqruff:dialect:greenplum]
+```
+
+
+### hive
+
+Apache Hive SQL dialect for data warehousing.
+
+**Documentation:** [https://hive.apache.org/docs/latest/language/](https://hive.apache.org/docs/latest/language/)
+
+**Configuration:**
+```ini
+[sqruff:dialect:hive]
 ```
 
 

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -2117,7 +2117,7 @@ SELECT
 FROM foo
 ```
 
-**Dialects where this rule is skipped:** `bigquery`, `redshift`
+**Dialects where this rule is skipped:** `bigquery`, `hive`, `redshift`
 
 ### references.keywords
 


### PR DESCRIPTION
## Summary

- expose Hive through `DialectKind`, configuration dispatch, fixtures, and generated dialect documentation
- make the existing Hive grammar usable standalone with Hive keywords, quoted literals and identifiers, complex and row datatypes, `SET hivevar:`, and `MSCK REPAIR`
- enable Hive-aware behavior in the relevant convention and reference rules

## Why

The Hive module was compiled as a feature and used as a grammar source by SparkSQL, but it was unreachable through configuration because it had no `DialectKind` or dispatcher entry. Expanding it directly also exposed missing Hive keyword, datatype, quoting, and statement registrations. This change wires the dialect end to end and supplies the minimum standalone grammar needed by the existing Hive rule fixtures.

## Validation

- `bazelisk test //...` — 33/33 test targets passed
- generated docs refreshed with `bazelisk run //:codegen_docs_fix`
- `bazelisk test //:codegen_docs_check`