### PR TITLE
feat(clickhouse): add tuple element access

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -169,6 +169,7 @@ pub enum SyntaxKind {
     SelectReplaceClause,
     StructTypeSchema,
     Tuple,
+    TupleElementAccess,
     NamedArgument,
     DeclareSegment,
     SetSegment,

--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -94,6 +94,67 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         "YY",
     ]);
 
+    // Tuple element access can chain numeric suffixes like `test.1.1.2`.
+    // The ANSI numeric matcher rejects `.1.1`, so make ClickHouse split each
+    // `.N` suffix before the generic dot matcher sees it. Do not split a
+    // numeric prefix off a longer word; `test.12a` should stay invalid.
+    clickhouse_dialect.insert_lexer_matchers(
+        vec![Matcher::legacy(
+            "tuple_index_numeric_literal",
+            |s| s.starts_with('.'),
+            r"\.[0-9]+(?![0-9A-Za-z_])",
+            SyntaxKind::NumericLiteral,
+        )],
+        "dot",
+    );
+
+    clickhouse_dialect.replace_grammar(
+        "AccessorGrammar",
+        AnyNumberOf::new(vec![
+            Ref::new("ArrayAccessorSegment").to_matchable(),
+            Ref::new("TupleElementAccessSegment").to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    clickhouse_dialect.replace_grammar(
+        "Expression_D_Grammar",
+        one_of(vec![
+            // Prefer postfix tuple access before ClickHouse datatype-literal
+            // parsing can consume `.N` as a standalone numeric literal.
+            Sequence::new(vec![
+                one_of(vec![
+                    Ref::new("BareFunctionSegment").to_matchable(),
+                    Ref::new("FunctionSegment").to_matchable(),
+                    Bracketed::new(vec![
+                        one_of(vec![
+                            Ref::new("ExpressionSegment").to_matchable(),
+                            Ref::new("SelectableGrammar").to_matchable(),
+                            Delimited::new(vec![
+                                Ref::new("ColumnReferenceSegment").to_matchable(),
+                                Ref::new("FunctionSegment").to_matchable(),
+                                Ref::new("LiteralGrammar").to_matchable(),
+                                Ref::new("LocalAliasSegment").to_matchable(),
+                            ])
+                            .to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .config(|this| this.parse_mode(ParseMode::Greedy))
+                    .to_matchable(),
+                    Ref::new("ColumnReferenceSegment").to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::new("TupleElementAccessSegment").to_matchable(),
+                Ref::new("AccessorGrammar").optional().to_matchable(),
+            ])
+            .allow_gaps(false)
+            .to_matchable(),
+            clickhouse_dialect.grammar("Expression_D_Grammar"),
+        ])
+        .to_matchable(),
+    );
+
     // ClickHouse supports CTEs with DML statements (INSERT, UPDATE, DELETE)
     // We add these to NonWithSelectableGrammar so WithCompoundStatementSegment can use them
     clickhouse_dialect.add([(
@@ -446,6 +507,25 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             })
             .to_matchable()
             .into(),
+        ),
+        (
+            "TupleElementAccessSegment".into(),
+            NodeMatcher::new(SyntaxKind::TupleElementAccess, |_| {
+                AnyNumberOf::new(vec![Ref::new("TupleIndexSegment").to_matchable()])
+                    .config(|this| {
+                        this.min_times(1);
+                        this.disallow_gaps();
+                    })
+                    .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "TupleIndexSegment".into(),
+            RegexParser::new(r"\.[0-9]+", SyntaxKind::NumericLiteral)
+                .to_matchable()
+                .into(),
         ),
     ]);
 

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.sql
@@ -1,0 +1,14 @@
+SELECT
+  tuple(1, 2, 3) AS arr,
+  arr.1 AS dsa,
+  arr[1].2[3] AS mixed_array_tuple_access,
+  tuple(1, 2).1 AS first_tuple_value;
+
+WITH tuple(tuple(tuple('a', 'aa'), 'b'), 'c') AS test
+SELECT
+    test.1.1.2,
+    (test.1).2,
+    ((test.1).2).3,
+    test.1[2],
+    test.1[2].3,
+    test.2;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.yml
@@ -1,0 +1,189 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: tuple
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '1'
+              - comma: ','
+              - expression:
+                - numeric_literal: '2'
+              - comma: ','
+              - expression:
+                - numeric_literal: '3'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: arr
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: arr
+          - tuple_element_access:
+            - numeric_literal: '.1'
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: dsa
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: arr
+          - array_accessor:
+            - start_square_bracket: '['
+            - numeric_literal: '1'
+            - end_square_bracket: ']'
+          - tuple_element_access:
+            - numeric_literal: '.2'
+          - array_accessor:
+            - start_square_bracket: '['
+            - numeric_literal: '3'
+            - end_square_bracket: ']'
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: mixed_array_tuple_access
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - function:
+            - function_name:
+              - function_name_identifier: tuple
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '1'
+                - comma: ','
+                - expression:
+                  - numeric_literal: '2'
+                - end_bracket: )
+          - tuple_element_access:
+            - numeric_literal: '.1'
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: first_tuple_value
+- statement_terminator: ;
+- statement:
+  - with_compound_statement:
+    - keyword: WITH
+    - common_table_expression:
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: tuple
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - function:
+                  - function_name:
+                    - function_name_identifier: tuple
+                  - function_contents:
+                    - bracketed:
+                      - start_bracket: (
+                      - expression:
+                        - function:
+                          - function_name:
+                            - function_name_identifier: tuple
+                          - function_contents:
+                            - bracketed:
+                              - start_bracket: (
+                              - expression:
+                                - quoted_literal: '''a'''
+                              - comma: ','
+                              - expression:
+                                - quoted_literal: '''aa'''
+                              - end_bracket: )
+                      - comma: ','
+                      - expression:
+                        - quoted_literal: '''b'''
+                      - end_bracket: )
+              - comma: ','
+              - expression:
+                - quoted_literal: '''c'''
+              - end_bracket: )
+      - keyword: AS
+      - naked_identifier: test
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - expression:
+            - column_reference:
+              - naked_identifier: test
+            - tuple_element_access:
+              - numeric_literal: '.1'
+              - numeric_literal: '.1'
+              - numeric_literal: '.2'
+        - comma: ','
+        - select_clause_element:
+          - expression:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: test
+                - tuple_element_access:
+                  - numeric_literal: '.1'
+              - end_bracket: )
+            - tuple_element_access:
+              - numeric_literal: '.2'
+        - comma: ','
+        - select_clause_element:
+          - expression:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: test
+                    - tuple_element_access:
+                      - numeric_literal: '.1'
+                  - end_bracket: )
+                - tuple_element_access:
+                  - numeric_literal: '.2'
+              - end_bracket: )
+            - tuple_element_access:
+              - numeric_literal: '.3'
+        - comma: ','
+        - select_clause_element:
+          - expression:
+            - column_reference:
+              - naked_identifier: test
+            - tuple_element_access:
+              - numeric_literal: '.1'
+            - array_accessor:
+              - start_square_bracket: '['
+              - numeric_literal: '2'
+              - end_square_bracket: ']'
+        - comma: ','
+        - select_clause_element:
+          - expression:
+            - column_reference:
+              - naked_identifier: test
+            - tuple_element_access:
+              - numeric_literal: '.1'
+            - array_accessor:
+              - start_square_bracket: '['
+              - numeric_literal: '2'
+              - end_square_bracket: ']'
+            - tuple_element_access:
+              - numeric_literal: '.3'
+        - comma: ','
+        - select_clause_element:
+          - expression:
+            - column_reference:
+              - naked_identifier: test
+            - tuple_element_access:
+              - numeric_literal: '.2'
+- statement_terminator: ;

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -178,6 +178,10 @@ spacing_before = touch:inline
 [sqruff:layout:type:array_accessor]
 spacing_before = touch:inline
 
+[sqruff:layout:type:tuple_element_access]
+spacing_before = touch:inline
+spacing_within = touch:inline
+
 [sqruff:layout:type:referenced_column_list]
 spacing_before = touch:inline
 

--- a/crates/lib/src/tests.rs
+++ b/crates/lib/src/tests.rs
@@ -4,7 +4,7 @@ use sqruff_lib::core::config::{FluffConfig, Value};
 use sqruff_lib::core::linter::core::Linter;
 use sqruff_lib::core::test_functions::fresh_ansi_dialect;
 use sqruff_lib_core::dialects::init::DialectKind;
-use sqruff_lib_core::dialects::syntax::SyntaxKind;
+use sqruff_lib_core::dialects::syntax::{SyntaxKind, SyntaxSet};
 use sqruff_lib_core::parser::Parser;
 use sqruff_lib_core::parser::context::ParseContext;
 use sqruff_lib_core::parser::matchable::MatchableTrait;
@@ -388,6 +388,112 @@ fn test_reindent_no_false_positive_in_jinja_for_loop() {
     assert!(
         layout.is_empty(),
         "unexpected layout violations in templated region: {layout:?}"
+    );
+}
+
+#[test]
+fn test_clickhouse_tuple_element_access_has_no_spacing_violation() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([
+                ("dialect".into(), Value::String("clickhouse".into())),
+                ("rules".into(), Value::String("LT01".into())),
+            ])),
+        )]),
+        None,
+        None,
+    );
+    let mut lnt = Linter::new(config, None, None, true).unwrap();
+    let sql = concat!(
+        "SELECT test.1.1.2;\n",
+        "SELECT (test.1).2;\n",
+        "SELECT test.2;\n",
+        "SELECT tuple(1, 2).1 FROM t;\n",
+        "SELECT ((test.1).2).3 FROM t;\n",
+    );
+
+    let linted = lnt.lint_string_wrapped(sql, true).unwrap();
+
+    let lt01: Vec<_> = linted
+        .violations()
+        .iter()
+        .filter(|v| v.rule_code() == "LT01")
+        .map(|v| (v.line_no, v.line_pos))
+        .collect();
+    assert!(
+        lt01.is_empty(),
+        "unexpected LT01 tuple access violations: {lt01:?}"
+    );
+}
+
+#[test]
+fn test_clickhouse_tuple_element_access_parse_boundaries() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([(
+                "dialect".into(),
+                Value::String("clickhouse".into()),
+            )])),
+        )]),
+        None,
+        None,
+    );
+    let lnt = Linter::new(config, None, None, true).unwrap();
+    let tables = Tables::default();
+
+    let valid_sql = [
+        "SELECT test.1.1.2;",
+        "SELECT (test.1).2;",
+        "SELECT test.2;",
+        "SELECT tuple(1, 2).1 FROM t;",
+        "SELECT ((test.1).2).3 FROM t;",
+        "SELECT test.1[2] FROM t;",
+        "SELECT test.1[2].3 FROM t;",
+        "SELECT arr[1].2[3] FROM t;",
+        "SELECT t.a.1 FROM foo AS t;",
+        "SELECT uniq(col1) FROM table1 WHERE col1 IN (SELECT col1 FROM table1 WHERE col2 = 34);",
+    ]
+    .join("\n");
+    let parsed = lnt.parse_string(&tables, &valid_sql, None).unwrap();
+    assert!(
+        parsed.violations.is_empty(),
+        "expected valid ClickHouse tuple access to parse cleanly: {:?}",
+        parsed.violations
+    );
+
+    for sql in [
+        "SELECT .1abc;",
+        "SELECT .123abc;",
+        "SELECT test.1abc;",
+        "SELECT test.12a;",
+        "SELECT test.1_2;",
+        "SELECT test.1.2e3;",
+    ] {
+        let parsed = lnt.parse_string(&tables, sql, None).unwrap();
+        assert!(
+            !parsed.violations.is_empty(),
+            "expected invalid tuple index boundary to fail parsing: {sql}"
+        );
+    }
+
+    // ClickHouse numeric literals fall back to strtod parsing and support
+    // exponential notation, so `.1e2` should stay numeric syntax rather than
+    // tuple access. See: https://clickhouse.com/docs/sql-reference/syntax#numeric
+    let parsed = lnt.parse_string(&tables, "SELECT test.1e2;", None).unwrap();
+    let tree = parsed.tree.unwrap();
+    let tuple_access = tree.recursive_crawl(
+        &SyntaxSet::new(&[SyntaxKind::ColumnReference, SyntaxKind::TupleElementAccess]),
+        true,
+        &SyntaxSet::EMPTY,
+        true,
+    );
+    assert!(
+        tuple_access
+            .iter()
+            .all(|segment| segment.raw().as_str() != "test.1e2"),
+        "expected exponent-style numeric literal not to parse as tuple access"
     );
 }
 

--- a/crates/lsp/src/semantic.rs
+++ b/crates/lsp/src/semantic.rs
@@ -1189,7 +1189,8 @@ pub(crate) fn classify(kind: SyntaxKind) -> Option<Highlight> {
         | StopRoutineLoadStatement
         | PauseRoutineLoadStatement
         | ResumeRoutineLoadStatement
-        | InsertOverwriteStatement => return None,
+        | InsertOverwriteStatement
+        | TupleElementAccess => return None,
     };
 
     Some(highlight)


### PR DESCRIPTION
## Summary

- port ClickHouse tuple element access from SQLFluff `e5151a7ab8506ce515da04f11ab19b798feccc74`
- parse chained tuple indexes such as `test.1.1.2`, `(test.1).2`, and `tuple(1, 2).1`
- support mixed tuple and array access such as `test.1[2]`, `test.1[2].3`, and `arr[1].2[3]`
- add tuple access layout handling so `.N` suffixes stay touch-spaced without LT01 false positives
- keep exponent-style numeric literals such as `.1e2` from being treated as tuple indexes

This continues the ClickHouse SQLFluff catch-up tracked in #2910.

Ported from SQLFluff:
https://github.com/sqlfluff/sqlfluff/commit/e5151a7ab8506ce515da04f11ab19b798feccc74

Refs #2910