### PR TITLE
fix(clickhouse): tighten parametric type parsing

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -1267,99 +1267,68 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         .into(),
     )]);
 
-    clickhouse_dialect.replace_grammar(
-        "DatatypeSegment",
-        one_of(vec![
-            // Nullable(Type)
-            Sequence::new(vec![
-                StringParser::new("NULLABLE", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![Ref::new("DatatypeSegment").to_matchable()]).to_matchable(),
-            ])
-            .to_matchable(),
-            // LowCardinality(Type)
-            Sequence::new(vec![
-                StringParser::new("LOWCARDINALITY", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![Ref::new("DatatypeSegment").to_matchable()]).to_matchable(),
-            ])
-            .to_matchable(),
-            // DateTime64(precision, 'timezone')
-            Sequence::new(vec![
-                StringParser::new("DATETIME64", SyntaxKind::DataTypeIdentifier).to_matchable(),
+    clickhouse_dialect.add([
+        (
+            "DateTime64ArgumentsSegment".into(),
+            NodeMatcher::new(SyntaxKind::BracketedArguments, |_| {
                 Bracketed::new(vec![
-                    Delimited::new(vec![
-                        one_of(vec![
-                            Ref::new("NumericLiteralSegment").to_matchable(), // precision
+                    Sequence::new(vec![
+                        Ref::new("NumericLiteralSegment").to_matchable(),
+                        Sequence::new(vec![
+                            Ref::new("CommaSegment").to_matchable(),
                             Ref::new("QuotedLiteralSegment").to_matchable(),
                         ])
+                        .config(|this| this.optional())
                         .to_matchable(),
                     ])
-                    .config(|this| {
-                        this.optional();
-                    })
-                    .to_matchable(),
-                ])
-                .to_matchable(),
-            ])
-            .to_matchable(),
-            // DateTime('timezone')
-            Sequence::new(vec![
-                StringParser::new("DATETIME", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![Ref::new("QuotedLiteralSegment").to_matchable()])
                     .config(|this| this.optional())
                     .to_matchable(),
-            ])
-            .to_matchable(),
-            // FixedString(length)
-            Sequence::new(vec![
-                StringParser::new("FIXEDSTRING", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![Ref::new("NumericLiteralSegment").to_matchable()])
-                    .to_matchable(),
-            ])
-            .to_matchable(),
-            // Array(Type)
-            Sequence::new(vec![
-                StringParser::new("ARRAY", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![Ref::new("DatatypeSegment").to_matchable()]).to_matchable(),
-            ])
-            .to_matchable(),
-            // Map(KeyType, ValueType)
-            Sequence::new(vec![
-                StringParser::new("MAP", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![
-                    Delimited::new(vec![Ref::new("DatatypeSegment").to_matchable()]).to_matchable(),
                 ])
-                .to_matchable(),
-            ])
-            .to_matchable(),
-            // Tuple(Type1, Type2) or Tuple(name1 Type1, ...)
-            Sequence::new(vec![
-                StringParser::new("TUPLE", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "DateTimeArgumentsSegment".into(),
+            NodeMatcher::new(SyntaxKind::BracketedArguments, |_| {
+                Bracketed::new(vec![Ref::new("QuotedLiteralSegment").to_matchable()]).to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "NumericArgumentsSegment".into(),
+            NodeMatcher::new(SyntaxKind::BracketedArguments, |_| {
+                Bracketed::new(vec![Ref::new("NumericLiteralSegment").to_matchable()])
+                    .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "DecimalArgumentsSegment".into(),
+            NodeMatcher::new(SyntaxKind::BracketedArguments, |_| {
                 Bracketed::new(vec![
-                    Delimited::new(vec![
-                        one_of(vec![
-                            // Named tuple element: name Type
-                            Sequence::new(vec![
-                                one_of(vec![
-                                    Ref::new("SingleIdentifierGrammar").to_matchable(),
-                                    Ref::new("QuotedIdentifierSegment").to_matchable(),
-                                ])
-                                .to_matchable(),
-                                Ref::new("DatatypeSegment").to_matchable(),
-                            ])
-                            .to_matchable(),
-                            // Regular tuple element: just Type
-                            Ref::new("DatatypeSegment").to_matchable(),
+                    Sequence::new(vec![
+                        Ref::new("NumericLiteralSegment").to_matchable(),
+                        Sequence::new(vec![
+                            Ref::new("CommaSegment").to_matchable(),
+                            Ref::new("NumericLiteralSegment").to_matchable(),
                         ])
+                        .config(|this| this.optional())
                         .to_matchable(),
                     ])
                     .to_matchable(),
                 ])
-                .to_matchable(),
-            ])
-            .to_matchable(),
-            // Nested(name1 Type1, name2 Type2)
-            Sequence::new(vec![
-                StringParser::new("NESTED", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "NestedArgumentsSegment".into(),
+            NodeMatcher::new(SyntaxKind::BracketedArguments, |_| {
                 Bracketed::new(vec![
                     Delimited::new(vec![
                         Sequence::new(vec![
@@ -1370,18 +1339,14 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     ])
                     .to_matchable(),
                 ])
-                .to_matchable(),
-            ])
-            .to_matchable(),
-            // JSON data type
-            StringParser::new("JSON", SyntaxKind::DataTypeIdentifier).to_matchable(),
-            // Enum8('val1' = 1, 'val2' = 2)
-            Sequence::new(vec![
-                one_of(vec![
-                    StringParser::new("ENUM8", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                    StringParser::new("ENUM16", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                ])
-                .to_matchable(),
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "EnumArgumentsSegment".into(),
+            NodeMatcher::new(SyntaxKind::BracketedArguments, |_| {
                 Bracketed::new(vec![
                     Delimited::new(vec![
                         Sequence::new(vec![
@@ -1393,7 +1358,84 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     ])
                     .to_matchable(),
                 ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+    ]);
+
+    clickhouse_dialect.replace_grammar(
+        "DatatypeSegment",
+        one_of(vec![
+            // Nullable(Type)
+            Sequence::new(vec![
+                StringParser::new("NULLABLE", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("BracketedArguments").to_matchable(),
+            ])
+            .to_matchable(),
+            // LowCardinality(Type)
+            Sequence::new(vec![
+                StringParser::new("LOWCARDINALITY", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("BracketedArguments").to_matchable(),
+            ])
+            .to_matchable(),
+            // DateTime64(precision, 'timezone')
+            Sequence::new(vec![
+                StringParser::new("DATETIME64", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("DateTime64ArgumentsSegment")
+                    .optional()
+                    .to_matchable(),
+            ])
+            .to_matchable(),
+            // DateTime('timezone')
+            Sequence::new(vec![
+                StringParser::new("DATETIME", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("DateTimeArgumentsSegment")
+                    .optional()
+                    .to_matchable(),
+            ])
+            .to_matchable(),
+            // Time64(precision)
+            Sequence::new(vec![
+                StringParser::new("TIME64", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("NumericArgumentsSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            // FixedString(length)
+            Sequence::new(vec![
+                StringParser::new("FIXEDSTRING", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("NumericArgumentsSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            // Array(Type)
+            Sequence::new(vec![
+                StringParser::new("ARRAY", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("BracketedArguments").to_matchable(),
+            ])
+            .to_matchable(),
+            // Map(KeyType, ValueType)
+            Sequence::new(vec![
+                StringParser::new("MAP", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("BracketedArguments").to_matchable(),
+            ])
+            .to_matchable(),
+            // Nested(name1 Type1, name2 Type2)
+            Sequence::new(vec![
+                StringParser::new("NESTED", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                Ref::new("NestedArgumentsSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            // JSON data type
+            StringParser::new("JSON", SyntaxKind::DataTypeIdentifier).to_matchable(),
+            // Enum8('val1' = 1, 'val2' = 2)
+            Sequence::new(vec![
+                one_of(vec![
+                    StringParser::new("ENUM8", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                    StringParser::new("ENUM16", SyntaxKind::DataTypeIdentifier).to_matchable(),
+                ])
                 .to_matchable(),
+                Ref::new("EnumArgumentsSegment").to_matchable(),
             ])
             .to_matchable(),
             // double args
@@ -1403,7 +1445,9 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     StringParser::new("NUMERIC", SyntaxKind::DataTypeIdentifier).to_matchable(),
                 ])
                 .to_matchable(),
-                Ref::new("BracketedArguments").optional().to_matchable(),
+                Ref::new("DecimalArgumentsSegment")
+                    .optional()
+                    .to_matchable(),
             ])
             .to_matchable(),
             // single args
@@ -1415,61 +1459,52 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     StringParser::new("DECIMAL256", SyntaxKind::DataTypeIdentifier).to_matchable(),
                 ])
                 .to_matchable(),
-                Bracketed::new(vec![Ref::new("NumericLiteralSegment").to_matchable()])
-                    .to_matchable(),
+                Ref::new("NumericArgumentsSegment").to_matchable(),
             ])
             .to_matchable(),
             Ref::new("TupleTypeSegment").to_matchable(),
             Ref::new("DatatypeIdentifierSegment").to_matchable(),
             Ref::new("NumericLiteralSegment").to_matchable(),
-            Sequence::new(vec![
-                StringParser::new("DATETIME64", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![
-                    Delimited::new(vec![
-                        Ref::new("NumericLiteralSegment").to_matchable(), // precision
-                        Ref::new("QuotedLiteralSegment").optional().to_matchable(),
-                    ])
-                    // The brackets might be empty as well
-                    .config(|this| {
-                        this.optional();
-                    })
-                    .to_matchable(),
-                ])
-                .config(|this| this.optional())
-                .to_matchable(),
-            ])
-            .to_matchable(),
-            Sequence::new(vec![
-                StringParser::new("ARRAY", SyntaxKind::DataTypeIdentifier).to_matchable(),
-                Bracketed::new(vec![Ref::new("DatatypeSegment").to_matchable()]).to_matchable(),
-            ])
-            .to_matchable(),
         ])
         .to_matchable(),
     );
 
     clickhouse_dialect.add([(
         "TupleTypeSegment".into(),
-        Sequence::new(vec![
-            Ref::keyword("TUPLE").to_matchable(),
-            Ref::new("TupleTypeSchemaSegment").to_matchable(),
-        ])
+        NodeMatcher::new(SyntaxKind::StructType, |_| {
+            Sequence::new(vec![
+                Ref::keyword("TUPLE").to_matchable(),
+                Ref::new("TupleTypeSchemaSegment").to_matchable(),
+            ])
+            .to_matchable()
+        })
         .to_matchable()
         .into(),
     )]);
 
     clickhouse_dialect.add([(
         "TupleTypeSchemaSegment".into(),
-        Bracketed::new(vec![
-            Delimited::new(vec![
-                Sequence::new(vec![
-                    Ref::new("SingleIdentifierGrammar").to_matchable(),
-                    Ref::new("DatatypeSegment").to_matchable(),
+        NodeMatcher::new(SyntaxKind::TupleTypeSchema, |_| {
+            Bracketed::new(vec![
+                Delimited::new(vec![
+                    one_of(vec![
+                        Sequence::new(vec![
+                            one_of(vec![
+                                Ref::new("SingleIdentifierGrammar").to_matchable(),
+                                Ref::new("QuotedIdentifierSegment").to_matchable(),
+                            ])
+                            .to_matchable(),
+                            Ref::new("DatatypeSegment").to_matchable(),
+                        ])
+                        .to_matchable(),
+                        Ref::new("DatatypeSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
                 ])
                 .to_matchable(),
             ])
-            .to_matchable(),
-        ])
+            .to_matchable()
+        })
         .to_matchable()
         .into(),
     )]);
@@ -1477,15 +1512,9 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     clickhouse_dialect.replace_grammar(
         "BracketedArguments",
         Bracketed::new(vec![
-            Delimited::new(vec![
-                one_of(vec![
-                    Ref::new("DatatypeIdentifierSegment").to_matchable(),
-                    Ref::new("NumericLiteralSegment").to_matchable(),
-                ])
+            Delimited::new(vec![Ref::new("DatatypeSegment").to_matchable()])
+                .config(|this| this.optional())
                 .to_matchable(),
-            ])
-            .config(|this| this.optional())
-            .to_matchable(),
         ])
         .to_matchable(),
     );

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/alter_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/alter_table.yml
@@ -597,11 +597,12 @@ file:
     - naked_identifier: browser
     - data_type:
       - data_type_identifier: Array
-      - bracketed:
-        - start_bracket: (
-        - data_type:
-          - data_type_identifier: String
-        - end_bracket: )
+      - bracketed_arguments:
+        - bracketed:
+          - start_bracket: (
+          - data_type:
+            - data_type_identifier: String
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/complex_table_definition.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/complex_table_definition.yml
@@ -18,12 +18,13 @@ file:
         - quoted_identifier: '`timestamp`'
         - data_type:
           - data_type_identifier: DateTime64
-          - bracketed:
-            - start_bracket: (
-            - numeric_literal: '3'
-            - comma: ','
-            - quoted_literal: '''UTC'''
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - numeric_literal: '3'
+              - comma: ','
+              - quoted_literal: '''UTC'''
+              - end_bracket: )
         - keyword: CODEC
         - bracketed:
           - start_bracket: (
@@ -49,53 +50,57 @@ file:
         - quoted_identifier: '`category`'
         - data_type:
           - data_type_identifier: LowCardinality
-          - bracketed:
-            - start_bracket: (
-            - data_type:
-              - data_type_identifier: String
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - data_type:
+                - data_type_identifier: String
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`status`'
         - data_type:
           - data_type_identifier: Enum8
-          - bracketed:
-            - start_bracket: (
-            - quoted_literal: '''ACTIVE'''
-            - comparison_operator:
-              - raw_comparison_operator: =
-            - numeric_literal: '1'
-            - comma: ','
-            - quoted_literal: '''INACTIVE'''
-            - comparison_operator:
-              - raw_comparison_operator: =
-            - numeric_literal: '2'
-            - comma: ','
-            - quoted_literal: '''PENDING'''
-            - comparison_operator:
-              - raw_comparison_operator: =
-            - numeric_literal: '3'
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - quoted_literal: '''ACTIVE'''
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - numeric_literal: '1'
+              - comma: ','
+              - quoted_literal: '''INACTIVE'''
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - numeric_literal: '2'
+              - comma: ','
+              - quoted_literal: '''PENDING'''
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - numeric_literal: '3'
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`description`'
         - data_type:
           - data_type_identifier: Nullable
-          - bracketed:
-            - start_bracket: (
-            - data_type:
-              - data_type_identifier: String
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - data_type:
+                - data_type_identifier: String
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`tags`'
         - data_type:
           - data_type_identifier: Array
-          - bracketed:
-            - start_bracket: (
-            - data_type:
-              - data_type_identifier: String
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - data_type:
+                - data_type_identifier: String
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`value_calculated`'
@@ -201,47 +206,52 @@ file:
       - column_definition:
         - quoted_identifier: '`coordinates`'
         - data_type:
-          - data_type_identifier: Tuple
-          - bracketed:
-            - start_bracket: (
-            - data_type:
-              - data_type_identifier: Float64
-            - comma: ','
-            - data_type:
-              - data_type_identifier: Float64
-            - end_bracket: )
+          - struct_type:
+            - keyword: Tuple
+            - tuple_type_schema:
+              - bracketed:
+                - start_bracket: (
+                - data_type:
+                  - data_type_identifier: Float64
+                - comma: ','
+                - data_type:
+                  - data_type_identifier: Float64
+                - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`named_point`'
         - data_type:
-          - data_type_identifier: Tuple
-          - bracketed:
-            - start_bracket: (
-            - naked_identifier: x
-            - data_type:
-              - data_type_identifier: Float64
-            - comma: ','
-            - naked_identifier: y
-            - data_type:
-              - data_type_identifier: Float64
-            - comma: ','
-            - naked_identifier: z
-            - data_type:
-              - data_type_identifier: Float64
-            - end_bracket: )
+          - struct_type:
+            - keyword: Tuple
+            - tuple_type_schema:
+              - bracketed:
+                - start_bracket: (
+                - naked_identifier: x
+                - data_type:
+                  - data_type_identifier: Float64
+                - comma: ','
+                - naked_identifier: y
+                - data_type:
+                  - data_type_identifier: Float64
+                - comma: ','
+                - naked_identifier: z
+                - data_type:
+                  - data_type_identifier: Float64
+                - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`properties`'
         - data_type:
           - data_type_identifier: Map
-          - bracketed:
-            - start_bracket: (
-            - data_type:
-              - data_type_identifier: String
-            - comma: ','
-            - data_type:
-              - data_type_identifier: String
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - data_type:
+                - data_type_identifier: String
+              - comma: ','
+              - data_type:
+                - data_type_identifier: String
+              - end_bracket: )
       - comma: ','
       - column_definition:
         - quoted_identifier: '`json_data`'
@@ -252,20 +262,21 @@ file:
         - quoted_identifier: '`nested_data`'
         - data_type:
           - data_type_identifier: Nested
-          - bracketed:
-            - start_bracket: (
-            - naked_identifier: key
-            - data_type:
-              - data_type_identifier: String
-            - comma: ','
-            - naked_identifier: value
-            - data_type:
-              - data_type_identifier: Float64
-            - comma: ','
-            - naked_identifier: timestamp
-            - data_type:
-              - data_type_identifier: DateTime
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - naked_identifier: key
+              - data_type:
+                - data_type_identifier: String
+              - comma: ','
+              - naked_identifier: value
+              - data_type:
+                - data_type_identifier: Float64
+              - comma: ','
+              - naked_identifier: timestamp
+              - data_type:
+                - data_type_identifier: DateTime
+              - end_bracket: )
       - end_bracket: )
     - engine:
       - keyword: ENGINE
@@ -379,23 +390,24 @@ file:
     - quoted_identifier: '`new_enum_column`'
     - data_type:
       - data_type_identifier: Enum8
-      - bracketed:
-        - start_bracket: (
-        - quoted_literal: '''VALUE1'''
-        - comparison_operator:
-          - raw_comparison_operator: =
-        - numeric_literal: '1'
-        - comma: ','
-        - quoted_literal: '''VALUE2'''
-        - comparison_operator:
-          - raw_comparison_operator: =
-        - numeric_literal: '2'
-        - comma: ','
-        - quoted_literal: '''VALUE3'''
-        - comparison_operator:
-          - raw_comparison_operator: =
-        - numeric_literal: '3'
-        - end_bracket: )
+      - bracketed_arguments:
+        - bracketed:
+          - start_bracket: (
+          - quoted_literal: '''VALUE1'''
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - numeric_literal: '1'
+          - comma: ','
+          - quoted_literal: '''VALUE2'''
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - numeric_literal: '2'
+          - comma: ','
+          - quoted_literal: '''VALUE3'''
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - numeric_literal: '3'
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:
@@ -410,11 +422,12 @@ file:
     - quoted_identifier: '`new_lowcard_column`'
     - data_type:
       - data_type_identifier: LowCardinality
-      - bracketed:
-        - start_bracket: (
-        - data_type:
-          - data_type_identifier: String
-        - end_bracket: )
+      - bracketed_arguments:
+        - bracketed:
+          - start_bracket: (
+          - data_type:
+            - data_type_identifier: String
+          - end_bracket: )
     - keyword: DEFAULT
     - expression:
       - quoted_literal: '''DEFAULT_VALUE'''
@@ -432,12 +445,13 @@ file:
     - quoted_identifier: '`new_datetime_column`'
     - data_type:
       - data_type_identifier: DateTime64
-      - bracketed:
-        - start_bracket: (
-        - numeric_literal: '3'
-        - comma: ','
-        - quoted_literal: '''UTC'''
-        - end_bracket: )
+      - bracketed_arguments:
+        - bracketed:
+          - start_bracket: (
+          - numeric_literal: '3'
+          - comma: ','
+          - quoted_literal: '''UTC'''
+          - end_bracket: )
     - keyword: CODEC
     - bracketed:
       - start_bracket: (
@@ -467,11 +481,12 @@ file:
     - quoted_identifier: '`new_nullable_column`'
     - data_type:
       - data_type_identifier: Nullable
-      - bracketed:
-        - start_bracket: (
-        - data_type:
-          - data_type_identifier: Float32
-        - end_bracket: )
+      - bracketed_arguments:
+        - bracketed:
+          - start_bracket: (
+          - data_type:
+            - data_type_identifier: Float32
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
   - alter_table_statement:
@@ -582,11 +597,12 @@ file:
     - quoted_identifier: '`category`'
     - data_type:
       - data_type_identifier: LowCardinality
-      - bracketed:
-        - start_bracket: (
-        - data_type:
-          - data_type_identifier: String
-        - end_bracket: )
+      - bracketed_arguments:
+        - bracketed:
+          - start_bracket: (
+          - data_type:
+            - data_type_identifier: String
+          - end_bracket: )
     - keyword: DEFAULT
     - expression:
       - quoted_literal: '''UNKNOWN_CATEGORY'''

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/create_table.yml
@@ -494,11 +494,12 @@ file:
         - naked_identifier: s
         - data_type:
           - data_type_identifier: Nullable
-          - bracketed:
-            - start_bracket: (
-            - data_type:
-              - data_type_identifier: String
-            - end_bracket: )
+          - bracketed_arguments:
+            - bracketed:
+              - start_bracket: (
+              - data_type:
+                - data_type_identifier: String
+              - end_bracket: )
       - end_bracket: )
     - engine:
       - keyword: ENGINE

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/datetime64_precision.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/datetime64_precision.yml
@@ -25,9 +25,10 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: DateTime64
-              - bracketed:
-                - start_bracket: (
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: datetime
@@ -43,10 +44,11 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: DateTime64
-              - bracketed:
-                - start_bracket: (
-                - numeric_literal: '3'
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '3'
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: datetime
@@ -62,12 +64,13 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: DateTime64
-              - bracketed:
-                - start_bracket: (
-                - numeric_literal: '3'
-                - comma: ','
-                - quoted_literal: '''Europe/Paris'''
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '3'
+                  - comma: ','
+                  - quoted_literal: '''Europe/Paris'''
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: datetime
@@ -83,10 +86,11 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: DateTime64
-              - bracketed:
-                - start_bracket: (
-                - numeric_literal: '6'
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '6'
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: datetime

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/decimal_support.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/decimal_support.yml
@@ -10,18 +10,19 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: Nullable
-              - bracketed:
-                - start_bracket: (
-                - data_type:
-                  - data_type_identifier: Decimal
-                  - bracketed_arguments:
-                    - bracketed:
-                      - start_bracket: (
-                      - numeric_literal: '12'
-                      - comma: ','
-                      - numeric_literal: '0'
-                      - end_bracket: )
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - data_type:
+                    - data_type_identifier: Decimal
+                    - bracketed_arguments:
+                      - bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '12'
+                        - comma: ','
+                        - numeric_literal: '0'
+                        - end_bracket: )
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: num_value
@@ -37,15 +38,17 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: Nullable
-              - bracketed:
-                - start_bracket: (
-                - data_type:
-                  - data_type_identifier: Decimal32
-                  - bracketed:
-                    - start_bracket: (
-                    - numeric_literal: '1'
-                    - end_bracket: )
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - data_type:
+                    - data_type_identifier: Decimal32
+                    - bracketed_arguments:
+                      - bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '1'
+                        - end_bracket: )
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: num_value
@@ -61,15 +64,17 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: Nullable
-              - bracketed:
-                - start_bracket: (
-                - data_type:
-                  - data_type_identifier: Decimal64
-                  - bracketed:
-                    - start_bracket: (
-                    - numeric_literal: '12'
-                    - end_bracket: )
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - data_type:
+                    - data_type_identifier: Decimal64
+                    - bracketed_arguments:
+                      - bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '12'
+                        - end_bracket: )
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: num_value
@@ -85,15 +90,17 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: Nullable
-              - bracketed:
-                - start_bracket: (
-                - data_type:
-                  - data_type_identifier: Decimal128
-                  - bracketed:
-                    - start_bracket: (
-                    - numeric_literal: '12'
-                    - end_bracket: )
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - data_type:
+                    - data_type_identifier: Decimal128
+                    - bracketed_arguments:
+                      - bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '12'
+                        - end_bracket: )
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: num_value
@@ -109,15 +116,17 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: Nullable
-              - bracketed:
-                - start_bracket: (
-                - data_type:
-                  - data_type_identifier: Decimal256
-                  - bracketed:
-                    - start_bracket: (
-                    - numeric_literal: '12'
-                    - end_bracket: )
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - data_type:
+                    - data_type_identifier: Decimal256
+                    - bracketed_arguments:
+                      - bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '12'
+                        - end_bracket: )
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: num_value
@@ -155,18 +164,19 @@ file:
             - casting_operator: '::'
             - data_type:
               - data_type_identifier: Nullable
-              - bracketed:
-                - start_bracket: (
-                - data_type:
-                  - data_type_identifier: Numeric
-                  - bracketed_arguments:
-                    - bracketed:
-                      - start_bracket: (
-                      - numeric_literal: '12'
-                      - comma: ','
-                      - numeric_literal: '0'
-                      - end_bracket: )
-                - end_bracket: )
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - data_type:
+                    - data_type_identifier: Numeric
+                    - bracketed_arguments:
+                      - bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '12'
+                        - comma: ','
+                        - numeric_literal: '0'
+                        - end_bracket: )
+                  - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: num_value

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/match_support.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/match_support.yml
@@ -70,11 +70,12 @@ file:
                     - casting_operator: '::'
                     - data_type:
                       - data_type_identifier: Nullable
-                      - bracketed:
-                        - start_bracket: (
-                        - data_type:
-                          - data_type_identifier: Float64
-                        - end_bracket: )
+                      - bracketed_arguments:
+                        - bracketed:
+                          - start_bracket: (
+                          - data_type:
+                            - data_type_identifier: Float64
+                          - end_bracket: )
               - keyword: end
           - alias_expression:
             - keyword: as

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/time_types.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/time_types.sql
@@ -1,0 +1,3 @@
+SELECT '12:34:56'::Time as t1;
+
+SELECT '12:34:56.789'::Time64(3) as t2;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/time_types.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/time_types.yml
@@ -1,0 +1,36 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''12:34:56'''
+            - casting_operator: '::'
+            - data_type:
+              - data_type_identifier: Time
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: t1
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''12:34:56.789'''
+            - casting_operator: '::'
+            - data_type:
+              - data_type_identifier: Time64
+              - bracketed_arguments:
+                - bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '3'
+                  - end_bracket: )
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: t2
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_datatype.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_datatype.yml
@@ -18,21 +18,23 @@ file:
               - end_bracket: )
             - casting_operator: '::'
             - data_type:
-              - data_type_identifier: Tuple
-              - bracketed:
-                - start_bracket: (
-                - naked_identifier: id
-                - data_type:
-                  - data_type_identifier: Int64
-                - comma: ','
-                - naked_identifier: name
-                - data_type:
-                  - data_type_identifier: String
-                - comma: ','
-                - naked_identifier: created_at
-                - data_type:
-                  - data_type_identifier: Date32
-                - end_bracket: )
+              - struct_type:
+                - keyword: Tuple
+                - tuple_type_schema:
+                  - bracketed:
+                    - start_bracket: (
+                    - naked_identifier: id
+                    - data_type:
+                      - data_type_identifier: Int64
+                    - comma: ','
+                    - naked_identifier: name
+                    - data_type:
+                      - data_type_identifier: String
+                    - comma: ','
+                    - naked_identifier: created_at
+                    - data_type:
+                      - data_type_identifier: Date32
+                    - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: struct
@@ -56,21 +58,23 @@ file:
               - end_bracket: )
             - casting_operator: '::'
             - data_type:
-              - data_type_identifier: Tuple
-              - bracketed:
-                - start_bracket: (
-                - quoted_identifier: '`id`'
-                - data_type:
-                  - data_type_identifier: Int64
-                - comma: ','
-                - quoted_identifier: '`name`'
-                - data_type:
-                  - data_type_identifier: String
-                - comma: ','
-                - quoted_identifier: '`created_at`'
-                - data_type:
-                  - data_type_identifier: Date32
-                - end_bracket: )
+              - struct_type:
+                - keyword: Tuple
+                - tuple_type_schema:
+                  - bracketed:
+                    - start_bracket: (
+                    - quoted_identifier: '`id`'
+                    - data_type:
+                      - data_type_identifier: Int64
+                    - comma: ','
+                    - quoted_identifier: '`name`'
+                    - data_type:
+                      - data_type_identifier: String
+                    - comma: ','
+                    - quoted_identifier: '`created_at`'
+                    - data_type:
+                      - data_type_identifier: Date32
+                    - end_bracket: )
         - alias_expression:
           - keyword: as
           - naked_identifier: struct

--- a/crates/lib/src/tests.rs
+++ b/crates/lib/src/tests.rs
@@ -606,6 +606,94 @@ fn test_sqlite_create_temp_view_body_indent() {
     );
 }
 
+#[test]
+fn test_clickhouse_parametric_type_spacing_fix() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([
+                ("dialect".into(), Value::String("clickhouse".into())),
+                ("rules".into(), Value::String("LT01".into())),
+            ])),
+        )]),
+        None,
+        None,
+    );
+    let mut lnt = Linter::new(config, None, None, true).unwrap();
+    let sql = concat!(
+        "CREATE TABLE t (\n",
+        "    event_created_at DateTime64 (3),\n",
+        "    event_created_at_tz DateTime ('UTC'),\n",
+        "    obs_value Decimal (18, 9),\n",
+        "    fixed_str FixedString (16),\n",
+        "    nullable_col Nullable (String),\n",
+        "    lc_col LowCardinality (String),\n",
+        "    arr_col Array (UInt8),\n",
+        "    map_col Map (String, UInt8),\n",
+        "    enum_col Enum8 ('a' = 1, 'b' = 2),\n",
+        "    tuple_col Tuple (UInt8, String),\n",
+        "    nested_col Nested (a UInt8, b String),\n",
+        "    t64 Time64 (3),\n",
+        "    dec32 Decimal32 (3),\n",
+        "    dec64 Decimal64 (6)\n",
+        ") ENGINE = MergeTree ORDER BY event_created_at;",
+    );
+
+    let linted = lnt.lint_string_wrapped(sql, true).unwrap();
+
+    assert_eq!(
+        linted.fix_string(),
+        concat!(
+            "CREATE TABLE t (\n",
+            "    event_created_at DateTime64(3),\n",
+            "    event_created_at_tz DateTime('UTC'),\n",
+            "    obs_value Decimal(18, 9),\n",
+            "    fixed_str FixedString(16),\n",
+            "    nullable_col Nullable(String),\n",
+            "    lc_col LowCardinality(String),\n",
+            "    arr_col Array(UInt8),\n",
+            "    map_col Map(String, UInt8),\n",
+            "    enum_col Enum8('a' = 1, 'b' = 2),\n",
+            "    tuple_col Tuple(UInt8, String),\n",
+            "    nested_col Nested(a UInt8, b String),\n",
+            "    t64 Time64(3),\n",
+            "    dec32 Decimal32(3),\n",
+            "    dec64 Decimal64(6)\n",
+            ") ENGINE = MergeTree ORDER BY event_created_at;",
+        )
+    );
+}
+
+#[test]
+fn test_clickhouse_datetime64_rejects_timezone_without_precision() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([(
+                "dialect".into(),
+                Value::String("clickhouse".into()),
+            )])),
+        )]),
+        None,
+        None,
+    );
+    let lnt = Linter::new(config, None, None, true).unwrap();
+    let tables = Tables::default();
+
+    let parsed = lnt
+        .parse_string(
+            &tables,
+            "SELECT '2024-01-01'::DateTime64('UTC') AS dt;",
+            None,
+        )
+        .unwrap();
+
+    assert!(
+        !parsed.violations.is_empty(),
+        "expected DateTime64 timezone argument without precision to fail parsing"
+    );
+}
+
 /// Trailing source-only Jinja blocks should not hide extra rendered newlines
 /// from LT12.
 #[test]


### PR DESCRIPTION
Ports ClickHouse parametric type parsing.

Part of #2910.

## What changed

- Added typed ClickHouse argument segments for parametric data types so LT01 removes spaces before type arguments.
- Added `Time`/`Time64(precision)` fixture coverage.
- Tightened `DateTime64` arguments so timezone requires a precision.
- Preserved numeric literal argument nodes for `Decimal`/`Numeric`.
- Removed duplicate `DateTime64` and `Array` datatype alternatives.