### PR TITLE
fix(clickhouse): parse QUALIFY clauses

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -1164,6 +1164,22 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     ]);
 
     clickhouse_dialect.add([(
+        "QualifyClauseSegment".into(),
+        NodeMatcher::new(SyntaxKind::QualifyClause, |_| {
+            Sequence::new(vec![
+                Ref::keyword("QUALIFY").to_matchable(),
+                MetaSegment::indent().to_matchable(),
+                optionally_bracketed(vec![Ref::new("ExpressionSegment").to_matchable()])
+                    .to_matchable(),
+                MetaSegment::dedent().to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    clickhouse_dialect.add([(
         "PreWhereClauseSegment".into(),
         NodeMatcher::new(SyntaxKind::PreWhereClause, |_| {
             Sequence::new(vec![
@@ -1229,6 +1245,16 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 ]),
                 None,
                 None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .copy(
+                Some(vec![
+                    Ref::new("QualifyClauseSegment").optional().to_matchable(),
+                ]),
+                None,
+                Some(Ref::new("OrderByClauseSegment").optional().to_matchable()),
                 None,
                 Vec::new(),
                 false,

--- a/crates/lib-dialects/src/clickhouse_keywords.rs
+++ b/crates/lib-dialects/src/clickhouse_keywords.rs
@@ -140,6 +140,7 @@ pub(crate) const UNRESERVED_KEYWORDS: &[&str] = &[
     "PRIMARY",
     "PROFILE",
     "PROJECTION",
+    "QUALIFY",
     "QUARTER",
     "QUERY",
     "QUOTA",

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/qualify.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/qualify.sql
@@ -1,0 +1,144 @@
+SELECT
+	ROW_NUMBER() OVER (PARTITION BY col_1) AS row
+FROM table
+QUALIFY row = 1;
+
+SELECT
+    *
+FROM table
+QUALIFY ROW_NUMBER() OVER (PARTITION BY col_1) = 1;
+
+SELECT
+    ROW_NUMBER() OVER (PARTITION BY col_1) AS row
+FROM table
+WHERE col_1 = 'active'
+QUALIFY row = 1;
+
+SELECT
+     *
+FROM table
+WHERE col_1 = 'active'
+QUALIFY ROW_NUMBER() OVER (PARTITION BY col_1) = 1;
+
+SELECT
+     *
+FROM table
+WHERE col_1 = 'active'
+WINDOW test_window AS (PARTITION BY col_1)
+QUALIFY ROW_NUMBER() OVER test_window = 1;
+
+SELECT
+    ROW_NUMBER() OVER (PARTITION BY col_1) AS row
+FROM table1
+JOIN table2
+ON table1.col_1 = table2.col_1
+QUALIFY row = 1;
+
+SELECT
+     *
+FROM table1
+JOIN table2
+ON table1.col_1 = table2.col_1
+QUALIFY ROW_NUMBER() OVER (PARTITION BY col_1) = 1;
+
+SELECT
+    ROW_NUMBER() OVER (PARTITION BY col_1) AS row
+FROM table1
+JOIN table2
+ON table1.col_1 = table2.col_1
+WHERE table1.col_1 = 'active'
+QUALIFY row = 1;
+
+SELECT
+     *
+FROM table1
+JOIN table2
+ON table1.col_1 = table2.col_1
+WHERE table1.col_1 = 'active'
+QUALIFY ROW_NUMBER() OVER (PARTITION BY col_1) = 1;
+
+SELECT
+     *
+FROM table1
+JOIN table2
+ON table1.col_1 = table2.col_1
+WHERE table1.col_1 = 'active'
+WINDOW test_window AS (PARTITION BY table1.col_1)
+QUALIFY ROW_NUMBER() OVER test_window = 1;
+
+SELECT
+    table2.col_a,
+    table1.col_b,
+    count(*) AS total,
+    row_number() OVER (PARTITION BY table1.col_b ORDER BY count(*) DESC) AS rank
+FROM table1
+LEFT JOIN table2 ON table1.col_1 = table2.col_1
+WHERE table1.col_1 LIKE '%test%'
+GROUP BY table2.col_a,table1.col_b
+QUALIFY rank = 1;
+
+SELECT
+    table2.col_a,
+    table1.col_b,
+    count(*) AS total,
+    row_number() OVER (PARTITION BY table1.col_b ORDER BY count(*) DESC) AS rank
+FROM table1
+LEFT JOIN table2 ON table1.col_1 = table2.col_1
+WHERE table1.col_1 LIKE '%test%'
+GROUP BY table2.col_a,table1.col_b
+HAVING count(*) > 1
+QUALIFY rank = 1;
+
+SELECT
+    table2.col_a,
+    table1.col_b,
+    count(*) AS total,
+    row_number() OVER (PARTITION BY table1.col_b ORDER BY count(*) DESC) AS rank
+FROM table1
+LEFT JOIN table2 ON table1.col_1 = table2.col_1
+WHERE table1.col_1 LIKE '%test%'
+GROUP BY table2.col_a,table1.col_b
+HAVING count(*) > 1
+QUALIFY rank = 1
+ORDER BY total;
+
+SELECT
+    table2.col_a,
+    table1.col_b,
+    count(*) AS total,
+    row_number() OVER (PARTITION BY table1.col_b ORDER BY count(*) DESC) AS rank
+FROM table1
+LEFT JOIN table2 ON table1.col_1 = table2.col_1
+WHERE table1.col_1 LIKE '%test%'
+GROUP BY table2.col_a,table1.col_b
+HAVING count(*) > 1
+QUALIFY rank = 1
+LIMIT 1;
+
+SELECT
+    table2.col_a,
+    table1.col_b,
+    count(*) AS total,
+    row_number() OVER (PARTITION BY table1.col_b ORDER BY count(*) DESC) AS rank
+FROM table1
+LEFT JOIN table2 ON table1.col_1 = table2.col_1
+WHERE table1.col_1 LIKE '%test%'
+GROUP BY table2.col_a,table1.col_b
+HAVING count(*) > 1
+QUALIFY rank = 1
+ORDER BY total
+LIMIT 1;
+
+SELECT
+    table2.col_a,
+    table1.col_b,
+    count(*) AS total,
+    row_number() OVER (PARTITION BY table1.col_b ORDER BY count(*) DESC) AS rank
+FROM table1
+LEFT JOIN table2 ON table1.col_1 = table2.col_1
+WHERE table1.col_1 LIKE '%test%'
+GROUP BY table2.col_a,table1.col_b
+HAVING count(*) > 1
+QUALIFY rank = 1
+ORDER BY total
+LIMIT 1 BY table2.col_a;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/qualify.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/qualify.yml
@@ -1,0 +1,1425 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: row
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: row
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: row
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: col_1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''active'''
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: row
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: col_1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''active'''
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: col_1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''active'''
+    - named_window:
+      - keyword: WINDOW
+      - named_window_expression:
+        - naked_identifier: test_window
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - window_specification:
+            - partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                - column_reference:
+                  - naked_identifier: col_1
+          - end_bracket: )
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - naked_identifier: test_window
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: row
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: row
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: row
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''active'''
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: row
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''active'''
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: col_1
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - quoted_literal: '''active'''
+    - named_window:
+      - keyword: WINDOW
+      - named_window_expression:
+        - naked_identifier: test_window
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - window_specification:
+            - partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                - column_reference:
+                  - naked_identifier: table1
+                  - dot: .
+                  - naked_identifier: col_1
+          - end_bracket: )
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: ROW_NUMBER
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - naked_identifier: test_window
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table2
+          - dot: .
+          - naked_identifier: col_a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: total
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: row_number
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: col_b
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                    - function:
+                      - function_name:
+                        - function_name_identifier: count
+                      - function_contents:
+                        - bracketed:
+                          - start_bracket: (
+                          - star: '*'
+                          - end_bracket: )
+                  - keyword: DESC
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: rank
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - keyword: LIKE
+        - quoted_literal: '''%test%'''
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: table1
+        - dot: .
+        - naked_identifier: col_b
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: rank
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table2
+          - dot: .
+          - naked_identifier: col_a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: total
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: row_number
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: col_b
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                    - function:
+                      - function_name:
+                        - function_name_identifier: count
+                      - function_contents:
+                        - bracketed:
+                          - start_bracket: (
+                          - star: '*'
+                          - end_bracket: )
+                  - keyword: DESC
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: rank
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - keyword: LIKE
+        - quoted_literal: '''%test%'''
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: table1
+        - dot: .
+        - naked_identifier: col_b
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '1'
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: rank
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table2
+          - dot: .
+          - naked_identifier: col_a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: total
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: row_number
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: col_b
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                    - function:
+                      - function_name:
+                        - function_name_identifier: count
+                      - function_contents:
+                        - bracketed:
+                          - start_bracket: (
+                          - star: '*'
+                          - end_bracket: )
+                  - keyword: DESC
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: rank
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - keyword: LIKE
+        - quoted_literal: '''%test%'''
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: table1
+        - dot: .
+        - naked_identifier: col_b
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '1'
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: rank
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: total
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table2
+          - dot: .
+          - naked_identifier: col_a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: total
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: row_number
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: col_b
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                    - function:
+                      - function_name:
+                        - function_name_identifier: count
+                      - function_contents:
+                        - bracketed:
+                          - start_bracket: (
+                          - star: '*'
+                          - end_bracket: )
+                  - keyword: DESC
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: rank
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - keyword: LIKE
+        - quoted_literal: '''%test%'''
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: table1
+        - dot: .
+        - naked_identifier: col_b
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '1'
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: rank
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - limit_clause:
+      - keyword: LIMIT
+      - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table2
+          - dot: .
+          - naked_identifier: col_a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: total
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: row_number
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: col_b
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                    - function:
+                      - function_name:
+                        - function_name_identifier: count
+                      - function_contents:
+                        - bracketed:
+                          - start_bracket: (
+                          - star: '*'
+                          - end_bracket: )
+                  - keyword: DESC
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: rank
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - keyword: LIKE
+        - quoted_literal: '''%test%'''
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: table1
+        - dot: .
+        - naked_identifier: col_b
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '1'
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: rank
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: total
+    - limit_clause:
+      - keyword: LIMIT
+      - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table2
+          - dot: .
+          - naked_identifier: col_a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: total
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: row_number
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+          - over_clause:
+            - keyword: OVER
+            - bracketed:
+              - start_bracket: (
+              - window_specification:
+                - partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: col_b
+                - orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                    - function:
+                      - function_name:
+                        - function_name_identifier: count
+                      - function_contents:
+                        - bracketed:
+                          - start_bracket: (
+                          - star: '*'
+                          - end_bracket: )
+                  - keyword: DESC
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: rank
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: table1
+        - join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table2
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: table1
+                - dot: .
+                - naked_identifier: col_1
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: table2
+                - dot: .
+                - naked_identifier: col_1
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: table1
+          - dot: .
+          - naked_identifier: col_1
+        - keyword: LIKE
+        - quoted_literal: '''%test%'''
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: table1
+        - dot: .
+        - naked_identifier: col_b
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '1'
+    - qualify_clause:
+      - keyword: QUALIFY
+      - expression:
+        - column_reference:
+          - naked_identifier: rank
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - numeric_literal: '1'
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: total
+    - limit_clause:
+      - keyword: LIMIT
+      - numeric_literal: '1'
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: table2
+        - dot: .
+        - naked_identifier: col_a
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `dc0d656b3f117c161d70f8a63d1f9ffa46cfe244`.
Part of #2910.

## What changed

- Added ClickHouse `QUALIFY` clause parsing.
- Registered `QUALIFY` as an unreserved ClickHouse keyword.
- Added ClickHouse fixture coverage for `QUALIFY` with `WHERE`, `WINDOW`, joins, `GROUP BY`, `HAVING`, `ORDER BY`, and `LIMIT`.