### PR TITLE
fix(clickhouse): parse SETTINGS after UNION

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -520,6 +520,7 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 .copy(
                     Some(vec![
                         Ref::keyword("PREWHERE").to_matchable(),
+                        Ref::keyword("SETTINGS").to_matchable(),
                         Ref::keyword("INTO").to_matchable(),
                         Ref::keyword("FORMAT").to_matchable(),
                     ]),
@@ -1216,6 +1217,32 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 ]),
                 None,
                 Some(Ref::new("WhereClauseSegment").optional().to_matchable()),
+                None,
+                vec![
+                    Ref::new("FormatClauseSegment").to_matchable(),
+                    Ref::new("IntoOutfileClauseSegment").to_matchable(),
+                    Ref::new("SettingsClauseSegment").to_matchable(),
+                ],
+                false,
+            ),
+    );
+
+    clickhouse_dialect.replace_grammar(
+        "SetExpressionSegment",
+        ansi_dialect
+            .grammar("SetExpressionSegment")
+            .match_grammar(&ansi_dialect)
+            .unwrap()
+            .copy(
+                Some(vec![
+                    Ref::new("FormatClauseSegment").optional().to_matchable(),
+                    Ref::new("SettingsClauseSegment").optional().to_matchable(),
+                    Ref::new("IntoOutfileClauseSegment")
+                        .optional()
+                        .to_matchable(),
+                ]),
+                None,
+                None,
                 None,
                 Vec::new(),
                 false,

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_union_with_settings.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_union_with_settings.sql
@@ -1,0 +1,29 @@
+SELECT * FROM test1
+UNION ALL
+SELECT * FROM test2
+SETTINGS allow_experimental_window_functions = 1;
+
+SELECT * FROM test1
+UNION ALL
+SELECT * FROM test2
+UNION ALL
+SELECT * FROM test3
+SETTINGS max_threads = 4, allow_experimental_window_functions = 1;
+
+-- FORMAT after UNION ALL
+SELECT * FROM test1
+UNION ALL
+SELECT * FROM test2
+FORMAT CSV;
+
+-- INTO OUTFILE after UNION ALL
+SELECT * FROM test1
+UNION ALL
+SELECT * FROM test2
+INTO OUTFILE 'output.csv' FORMAT CSV;
+
+SELECT 1
+UNION ALL
+SELECT 2
+SETTINGS max_threads = 1
+INTO OUTFILE 'output.csv'

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_union_with_settings.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_union_with_settings.yml
@@ -1,0 +1,199 @@
+file:
+- statement:
+  - set_expression:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test1
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test2
+    - keyword: SETTINGS
+    - naked_identifier: allow_experimental_window_functions
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - set_expression:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test1
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test2
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test3
+    - keyword: SETTINGS
+    - naked_identifier: max_threads
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '4'
+    - comma: ','
+    - naked_identifier: allow_experimental_window_functions
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - set_expression:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test1
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test2
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;
+- statement:
+  - set_expression:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test1
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: test2
+    - keyword: INTO
+    - keyword: OUTFILE
+    - quoted_literal: '''output.csv'''
+    - keyword: FORMAT
+    - word: CSV
+- statement_terminator: ;
+- statement:
+  - set_expression:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '1'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - numeric_literal: '2'
+    - keyword: SETTINGS
+    - naked_identifier: max_threads
+    - comparison_operator:
+      - raw_comparison_operator: =
+    - numeric_literal: '1'
+    - keyword: INTO
+    - keyword: OUTFILE
+    - quoted_literal: '''output.csv'''


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `81c563acb91e63a7e21d438954edab4a916958dc`.
Part of #2910.

## What changed

- Added `SETTINGS` as a ClickHouse select clause terminator.
- Allowed ClickHouse set expressions to end with `FORMAT`, `SETTINGS`, and `INTO OUTFILE`.
- Added fixture coverage for `SETTINGS`, `FORMAT`, and `INTO OUTFILE` after `UNION ALL`.