### PR TITLE
fix(clickhouse): parse EXCEPT ALL bracketed set expressions

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -576,8 +576,8 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     ]);
 
     // Disambiguate wildcard EXCEPT from set operator EXCEPT.
-    // Exclude patterns like `EXCEPT ( ... )` and `EXCEPT identifier` from
-    // being parsed as a set operator to allow wildcard `* EXCEPT ...` to bind.
+    // Exclude `EXCEPT ( ... )` from being parsed as a set operator to allow
+    // wildcard `* EXCEPT (...)` to bind.
     clickhouse_dialect.replace_grammar(
         "SetOperatorSegment",
         one_of(vec![
@@ -595,17 +595,9 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         ])
         .config(|config| {
             config.exclude = Some(
-                one_of(vec![
-                    Sequence::new(vec![
-                        Ref::keyword("EXCEPT").to_matchable(),
-                        Bracketed::new(vec![Anything::new().to_matchable()]).to_matchable(),
-                    ])
-                    .to_matchable(),
-                    Sequence::new(vec![
-                        Ref::keyword("EXCEPT").to_matchable(),
-                        Ref::new("SingleIdentifierGrammar").to_matchable(),
-                    ])
-                    .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("EXCEPT").to_matchable(),
+                    Bracketed::new(vec![Anything::new().to_matchable()]).to_matchable(),
                 ])
                 .to_matchable(),
             );

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_except.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_except.sql
@@ -1,2 +1,9 @@
 SELECT * EXCEPT (c1) from t1;
 SELECT * EXCEPT (c1, c2) from t1;
+
+SELECT field_1
+FROM table_1
+EXCEPT ALL (
+    SELECT field_1
+    FROM table_2
+);

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_except.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_except.yml
@@ -45,3 +45,38 @@ file:
             - table_reference:
               - naked_identifier: t1
 - statement_terminator: ;
+- statement:
+  - set_expression:
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - column_reference:
+            - naked_identifier: field_1
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: table_1
+    - set_operator:
+      - keyword: EXCEPT
+      - keyword: ALL
+    - bracketed:
+      - start_bracket: (
+      - select_statement:
+        - select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: field_1
+        - from_clause:
+          - keyword: FROM
+          - from_expression:
+            - from_expression_element:
+              - table_expression:
+                - table_reference:
+                  - naked_identifier: table_2
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `2cb339cc016c7c177b5f5f2864eed0de247f4a5e`.
Part of #2910.

## What changed

- Narrowed ClickHouse `EXCEPT` set-operator exclusion to match upstream behavior.
- Allowed `EXCEPT ALL (...)` to parse as a ClickHouse set expression.
- Preserved wildcard `SELECT * EXCEPT (...)` parsing.
- Added ClickHouse fixture coverage for the bracketed `EXCEPT ALL` set expression case.