### PR TITLE
fix(clickhouse): parse SELECT APPLY wildcard modifiers

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -166,6 +166,7 @@ pub enum SyntaxKind {
     WhileStatement,
     DatePartWeek,
     SelectExceptClause,
+    SelectApplyClause,
     SelectReplaceClause,
     StructTypeSchema,
     Tuple,

--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -818,6 +818,21 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             .to_matchable()
             .into(),
         ),
+        // A Clickhouse SELECT APPLY clause.
+        // https://clickhouse.com/docs/en/sql-reference/statements/select#apply-modifier
+        (
+            "ApplyClauseSegment".into(),
+            NodeMatcher::new(SyntaxKind::SelectApplyClause, |_| {
+                Sequence::new(vec![
+                    Ref::keyword("APPLY").to_matchable(),
+                    Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()])
+                        .to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
         (
             "QuotedLiteralSegment".into(),
             one_of(vec![
@@ -864,16 +879,12 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
 
     clickhouse_dialect.replace_grammar(
         "WildcardExpressionSegment",
-        ansi::wildcard_expression_segment().copy(
-            Some(vec![
-                Ref::new("ExceptClauseSegment").optional().to_matchable(),
-            ]),
-            None,
-            None,
-            None,
-            Vec::new(),
-            false,
-        ),
+        Sequence::new(vec![
+            Ref::new("WildcardIdentifierSegment").to_matchable(),
+            Ref::new("ExceptClauseSegment").optional().to_matchable(),
+            AnyNumberOf::new(vec![Ref::new("ApplyClauseSegment").to_matchable()]).to_matchable(),
+        ])
+        .to_matchable(),
     );
 
     clickhouse_dialect.add([(

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_apply.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_apply.sql
@@ -1,0 +1,4 @@
+SELECT * APPLY(sum) FROM t1;
+SELECT * EXCEPT (c1) APPLY(sum) FROM t1;
+SELECT * APPLY(col -> sum(col)) FROM t1;
+SELECT * APPLY(sum) APPLY(length) APPLY(max) FROM t1;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_apply.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_apply.yml
@@ -1,0 +1,130 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+          - select_apply_clause:
+            - keyword: APPLY
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: sum
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t1
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+          - select_except_clause:
+            - keyword: EXCEPT
+            - bracketed:
+              - start_bracket: (
+              - naked_identifier: c1
+              - end_bracket: )
+          - select_apply_clause:
+            - keyword: APPLY
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: sum
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t1
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+          - select_apply_clause:
+            - keyword: APPLY
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: col
+                - lambda: ->
+                - function:
+                  - function_name:
+                    - function_name_identifier: sum
+                  - function_contents:
+                    - bracketed:
+                      - start_bracket: (
+                      - expression:
+                        - column_reference:
+                          - naked_identifier: col
+                      - end_bracket: )
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t1
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+          - select_apply_clause:
+            - keyword: APPLY
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: sum
+              - end_bracket: )
+          - select_apply_clause:
+            - keyword: APPLY
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: length
+              - end_bracket: )
+          - select_apply_clause:
+            - keyword: APPLY
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: max
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t1
+- statement_terminator: ;

--- a/crates/lib/src/core/default_config.cfg
+++ b/crates/lib/src/core/default_config.cfg
@@ -239,6 +239,9 @@ spacing_within = single:inline
 [sqruff:layout:type:select_clause]
 line_position = alone
 
+[sqruff:layout:type:select_apply_clause]
+spacing_within = touch:inline
+
 [sqruff:layout:type:where_clause]
 line_position = alone
 keyword_line_position = leading

--- a/crates/lib/src/tests.rs
+++ b/crates/lib/src/tests.rs
@@ -665,6 +665,53 @@ fn test_clickhouse_parametric_type_spacing_fix() {
 }
 
 #[test]
+fn test_clickhouse_select_apply_spacing_fix() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([
+                ("dialect".into(), Value::String("clickhouse".into())),
+                ("rules".into(), Value::String("LT01".into())),
+            ])),
+        )]),
+        None,
+        None,
+    );
+    let mut lnt = Linter::new(config, None, None, true).unwrap();
+    let sql = concat!(
+        "SELECT * APPLY (sum) FROM t1;\n",
+        "SELECT * EXCEPT (c1) APPLY (col -> sum(col)) FROM t1;\n",
+    );
+
+    let linted = lnt.lint_string_wrapped(sql, true).unwrap();
+
+    assert_eq!(
+        linted.fix_string(),
+        concat!(
+            "SELECT * APPLY(sum) FROM t1;\n",
+            "SELECT * EXCEPT (c1) APPLY(col -> sum(col)) FROM t1;\n",
+        )
+    );
+
+    let correct_sql = concat!(
+        "SELECT * APPLY(sum) FROM t1;\n",
+        "SELECT * EXCEPT (c1) APPLY(col -> sum(col)) FROM t1;\n",
+    );
+    let correct_linted = lnt.lint_string_wrapped(correct_sql, false).unwrap();
+    let lt01: Vec<_> = correct_linted
+        .violations()
+        .iter()
+        .filter(|v| v.rule_code() == "LT01")
+        .map(|v| (v.rule_code(), v.line_no, v.line_pos))
+        .collect();
+
+    assert!(
+        lt01.is_empty(),
+        "unexpected LT01 violations for correctly spaced APPLY clauses: {lt01:?}"
+    );
+}
+
+#[test]
 fn test_clickhouse_datetime64_rejects_timezone_without_precision() {
     let config = FluffConfig::new(
         HashMap::from([(

--- a/crates/lsp/src/semantic.rs
+++ b/crates/lsp/src/semantic.rs
@@ -312,6 +312,7 @@ pub(crate) fn classify(kind: SyntaxKind) -> Option<Highlight> {
         | WhileStatements
         | WhileStatement
         | SelectExceptClause
+        | SelectApplyClause
         | SelectReplaceClause
         | StructTypeSchema
         | Tuple


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `faa5bc6c034e8156d9939c1ae78b632c5d1992b0`.
Part of #2910.

## What changed

- Added `APPLY(...)` parsing after ClickHouse wildcard select expressions.
- Preserved `SELECT * EXCEPT (...) APPLY(...)` parsing.
- Added fixture coverage for simple, lambda, and chained `APPLY(...)` modifiers.
- Added LT01 coverage so `APPLY(...)` keeps ClickHouse's no-space modifier style.