### PR TITLE
fix(clickhouse): parse lateral column aliases

### DIFF
--- a/crates/lib-dialects/src/ansi.rs
+++ b/crates/lib-dialects/src/ansi.rs
@@ -4936,6 +4936,7 @@ pub fn raw_dialect() -> Dialect {
                     Ref::new("FunctionSegment").to_matchable(),
                     Bracketed::new(vec![
                         one_of(vec![
+                            Ref::new("LateralColumnAliasExpressionGrammar").to_matchable(),
                             Ref::new("ExpressionSegment").to_matchable(),
                             Ref::new("SelectableGrammar").to_matchable(),
                             Delimited::new(vec![
@@ -4998,6 +4999,10 @@ pub fn raw_dialect() -> Dialect {
             AnyNumberOf::new(vec![Ref::new("ArrayAccessorSegment").to_matchable()])
                 .to_matchable()
                 .into(),
+        ),
+        (
+            "LateralColumnAliasExpressionGrammar".into(),
+            Nothing::new().to_matchable().into(),
         ),
     ]);
 

--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -128,6 +128,7 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     Ref::new("FunctionSegment").to_matchable(),
                     Bracketed::new(vec![
                         one_of(vec![
+                            Ref::new("LateralColumnAliasExpressionGrammar").to_matchable(),
                             Ref::new("ExpressionSegment").to_matchable(),
                             Ref::new("SelectableGrammar").to_matchable(),
                             Delimited::new(vec![
@@ -151,6 +152,15 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             .allow_gaps(false)
             .to_matchable(),
             clickhouse_dialect.grammar("Expression_D_Grammar"),
+        ])
+        .to_matchable(),
+    );
+
+    clickhouse_dialect.replace_grammar(
+        "LateralColumnAliasExpressionGrammar",
+        Sequence::new(vec![
+            Ref::new("ExpressionSegment").to_matchable(),
+            Ref::new("AliasExpressionSegment").to_matchable(),
         ])
         .to_matchable(),
     );

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_lateral_column_alias.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_lateral_column_alias.sql
@@ -1,0 +1,5 @@
+select
+    (1 as one) + 1 as col_1,
+    one + 3 as col_2,
+    one + 5 as col_3,
+    one + 7 as col_4

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_lateral_column_alias.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_lateral_column_alias.yml
@@ -1,0 +1,50 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: select
+      - select_clause_element:
+        - expression:
+          - bracketed:
+            - start_bracket: (
+            - expression:
+              - numeric_literal: '1'
+            - alias_expression:
+              - keyword: as
+              - naked_identifier: one
+            - end_bracket: )
+          - binary_operator: +
+          - numeric_literal: '1'
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col_1
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: one
+          - binary_operator: +
+          - numeric_literal: '3'
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col_2
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: one
+          - binary_operator: +
+          - numeric_literal: '5'
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col_3
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: one
+          - binary_operator: +
+          - numeric_literal: '7'
+        - alias_expression:
+          - keyword: as
+          - naked_identifier: col_4


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `f91c6533a1eb06841bedbb2d629ce0eea830256b`.
Part of #2910.

## What changed

- Added the ANSI lateral-column-alias grammar hook used inside bracketed expressions.
- Enabled ClickHouse lateral column aliases as bracketed `expression AS alias` expressions.
- Added ClickHouse fixture coverage for reusing a lateral alias across select-list expressions.