### PR TITLE
fix(clickhouse): parse ARRAY JOIN clause boundaries

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -1142,11 +1142,22 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     clickhouse_dialect.add([
         (
             "JoinLikeClauseGrammar".into(),
-            Sequence::new(vec![
-                AnyNumberOf::new(vec![Ref::new("ArrayJoinClauseSegment").to_matchable()])
-                    .config(|this| this.min_times(1))
-                    .to_matchable(),
-                Ref::new("AliasExpressionSegment").optional().to_matchable(),
+            AnyNumberOf::new(vec![Ref::new("ArrayJoinClauseSegment").to_matchable()])
+                .config(|this| this.min_times(1))
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "ArrayJoinClauseTerminatorGrammar".into(),
+            one_of(vec![
+                Ref::keyword("WHERE").to_matchable(),
+                Ref::new("FromClauseTerminatorGrammar").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("LEFT").optional().to_matchable(),
+                    Ref::keyword("ARRAY").to_matchable(),
+                    Ref::new("JoinKeywordsGrammar").to_matchable(),
+                ])
+                .to_matchable(),
             ])
             .to_matchable()
             .into(),
@@ -1586,6 +1597,26 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     );
 
     clickhouse_dialect.add([(
+        "ArrayJoinClauseElementSegment".into(),
+        NodeMatcher::new(SyntaxKind::SelectClauseElement, |_| {
+            one_of(vec![
+                Ref::new("WildcardExpressionSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::new("BaseExpressionElementGrammar").to_matchable(),
+                    Ref::new("AliasExpressionSegment")
+                        .exclude(Ref::new("ArrayJoinClauseTerminatorGrammar"))
+                        .optional()
+                        .to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    clickhouse_dialect.add([(
         "ArrayJoinClauseSegment".into(),
         NodeMatcher::new(SyntaxKind::ArrayJoinClause, |_| {
             Sequence::new(vec![
@@ -1593,8 +1624,10 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 Ref::keyword("ARRAY").to_matchable(),
                 Ref::new("JoinKeywordsGrammar").to_matchable(),
                 MetaSegment::indent().to_matchable(),
-                Delimited::new(vec![Ref::new("SelectClauseElementSegment").to_matchable()])
-                    .to_matchable(),
+                Delimited::new(vec![
+                    Ref::new("ArrayJoinClauseElementSegment").to_matchable(),
+                ])
+                .to_matchable(),
                 MetaSegment::dedent().to_matchable(),
             ])
             .to_matchable()

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/join.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/join.sql
@@ -115,3 +115,11 @@ SELECT * FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr, arr2;
 SELECT x, y FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr AS x, arr2 AS y;
 SELECT *,ch,cg FROM (SELECT 1) ARRAY JOIN ['1','2'] as cg, splitByChar(',','1,2') as ch;
 SELECT * FROM (SELECT [1,2] x) AS t1 ARRAY JOIN t1.*;
+-- ARRAY join followed by WHERE / PREWHERE / GROUP BY (regression for #7836)
+SELECT col FROM (SELECT [1, 2] AS arr) AS t1 ARRAY JOIN arr AS col WHERE col != 0;
+SELECT col FROM (SELECT [1, 2] AS arr) AS t1 LEFT ARRAY JOIN arr AS col PREWHERE col > 0;
+SELECT col, count(*) AS cnt FROM (SELECT [1, 1, 2] AS arr) AS t1 ARRAY JOIN arr AS col WHERE col > 0 GROUP BY col ORDER BY col;
+SELECT * FROM (SELECT [1, 2] AS arr) AS t1 ARRAY JOIN arr WHERE arr != 0;
+SELECT * FROM (SELECT [1, 2] AS arr) AS t1 ARRAY JOIN arr PREWHERE arr > 0;
+SELECT arr, count(*) AS cnt FROM (SELECT [1, 1, 2] AS arr) AS t1 ARRAY JOIN arr GROUP BY arr;
+SELECT * FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr ARRAY JOIN arr2 WHERE arr2 > 0;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/join.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/join.yml
@@ -3468,3 +3468,394 @@ file:
                 - dot: .
                 - star: '*'
 - statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: col
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: col
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: col
+        - comparison_operator:
+          - raw_comparison_operator: '!'
+          - raw_comparison_operator: =
+        - numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: col
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: LEFT
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: col
+    - pre_where_clause:
+      - keyword: PREWHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: col
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: col
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: cnt
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: col
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: col
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: col
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: col
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: arr
+        - comparison_operator:
+          - raw_comparison_operator: '!'
+          - raw_comparison_operator: =
+        - numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+    - pre_where_clause:
+      - keyword: PREWHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: arr
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: arr
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - star: '*'
+              - end_bracket: )
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: cnt
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: arr
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - bracketed:
+              - start_bracket: (
+              - select_statement:
+                - select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr
+                  - comma: ','
+                  - select_clause_element:
+                    - array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '3'
+                      - comma: ','
+                      - numeric_literal: '4'
+                      - end_square_bracket: ']'
+                    - alias_expression:
+                      - keyword: AS
+                      - naked_identifier: arr2
+              - end_bracket: )
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t1
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr
+        - array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+            - column_reference:
+              - naked_identifier: arr2
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: arr2
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '0'
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `a276af13212f085c050f421550dfe840c2db03b7`.
Part of #2910.

## What changed

- Allowed `WHERE`, `PREWHERE`, and later clauses to follow ClickHouse `ARRAY JOIN`.
- Stopped array-join expressions from consuming clause keywords as implicit aliases.
- Added fixture coverage for aliased, unaliased, and repeated `ARRAY JOIN` clause-boundary cases.