### PR TITLE
fix(clickhouse): parse ternary conditional operator

### DIFF
--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -461,6 +461,7 @@ pub enum SyntaxKind {
     Meta,
     #[default]
     Colon,
+    TernaryColon,
     StatementTerminator,
     StartSquareBracket,
     EndSquareBracket,

--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -166,6 +166,22 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     );
 
     clickhouse_dialect.replace_grammar(
+        "Expression_A_Grammar",
+        Sequence::new(vec![
+            clickhouse_dialect.grammar("Expression_A_Grammar"),
+            Sequence::new(vec![
+                Ref::new("QuestionMarkSegment").to_matchable(),
+                Ref::new("ExpressionSegment").to_matchable(),
+                Ref::new("TernaryColonSegment").to_matchable(),
+                Ref::new("ExpressionSegment").to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    clickhouse_dialect.replace_grammar(
         "AccessPermissionSegment",
         one_of(vec![
             Sequence::new(vec![
@@ -987,6 +1003,20 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         vec![Matcher::string("lambda", "->", SyntaxKind::Lambda)],
         "newline",
     );
+
+    clickhouse_dialect.add([(
+        "QuestionMarkSegment".into(),
+        StringParser::new("?", SyntaxKind::Question)
+            .to_matchable()
+            .into(),
+    )]);
+
+    clickhouse_dialect.add([(
+        "TernaryColonSegment".into(),
+        StringParser::new(":", SyntaxKind::TernaryColon)
+            .to_matchable()
+            .into(),
+    )]);
 
     clickhouse_dialect.add(vec![
         (

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/ternary_operator.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/ternary_operator.sql
@@ -1,0 +1,24 @@
+-- ClickHouse C-style ternary conditional operator `cond ? then : else`,
+-- shorthand for if(cond, then, else).
+-- https://clickhouse.com/docs/en/sql-reference/functions/conditional-functions#ternary-operator
+SELECT col = '' ? 0 : 1 AS x FROM t;
+
+SELECT a ? b : c AS x FROM t;
+
+-- Right-associative chaining in the else branch.
+SELECT a ? b : c ? d : e AS x FROM t;
+
+-- Nested ternary in the then branch.
+SELECT a ? b ? c : d : e AS x FROM t;
+
+SELECT number % 2 ? 'odd' : 'even' AS parity FROM numbers(10);
+
+SELECT (a ? b : c) + d AS x FROM t;
+
+SELECT if(a ? b : c, d, e) FROM t;
+
+SELECT * FROM t WHERE a ? b : c;
+
+SELECT a FROM t ORDER BY b ? c : d;
+
+SELECT a?b:c AS x FROM t;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/ternary_operator.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/ternary_operator.yml
@@ -1,0 +1,318 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: col
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - quoted_literal: ''''''
+          - question: '?'
+          - expression:
+            - numeric_literal: '0'
+          - ternary_colon: ':'
+          - expression:
+            - numeric_literal: '1'
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: x
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: a
+          - question: '?'
+          - expression:
+            - column_reference:
+              - naked_identifier: b
+          - ternary_colon: ':'
+          - expression:
+            - column_reference:
+              - naked_identifier: c
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: x
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: a
+          - question: '?'
+          - expression:
+            - column_reference:
+              - naked_identifier: b
+          - ternary_colon: ':'
+          - expression:
+            - column_reference:
+              - naked_identifier: c
+            - question: '?'
+            - expression:
+              - column_reference:
+                - naked_identifier: d
+            - ternary_colon: ':'
+            - expression:
+              - column_reference:
+                - naked_identifier: e
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: x
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: a
+          - question: '?'
+          - expression:
+            - column_reference:
+              - naked_identifier: b
+            - question: '?'
+            - expression:
+              - column_reference:
+                - naked_identifier: c
+            - ternary_colon: ':'
+            - expression:
+              - column_reference:
+                - naked_identifier: d
+          - ternary_colon: ':'
+          - expression:
+            - column_reference:
+              - naked_identifier: e
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: x
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: number
+          - binary_operator: '%'
+          - numeric_literal: '2'
+          - question: '?'
+          - expression:
+            - quoted_literal: '''odd'''
+          - ternary_colon: ':'
+          - expression:
+            - quoted_literal: '''even'''
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: parity
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - function:
+              - function_name:
+                - function_name_identifier: numbers
+              - function_contents:
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                    - numeric_literal: '10'
+                  - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - bracketed:
+            - start_bracket: (
+            - expression:
+              - column_reference:
+                - naked_identifier: a
+              - question: '?'
+              - expression:
+                - column_reference:
+                  - naked_identifier: b
+              - ternary_colon: ':'
+              - expression:
+                - column_reference:
+                  - naked_identifier: c
+            - end_bracket: )
+          - binary_operator: +
+          - column_reference:
+            - naked_identifier: d
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: x
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: if
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: a
+                - question: '?'
+                - expression:
+                  - column_reference:
+                    - naked_identifier: b
+                - ternary_colon: ':'
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: d
+              - comma: ','
+              - expression:
+                - column_reference:
+                  - naked_identifier: e
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - question: '?'
+        - expression:
+          - column_reference:
+            - naked_identifier: b
+        - ternary_colon: ':'
+        - expression:
+          - column_reference:
+            - naked_identifier: c
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - expression:
+        - column_reference:
+          - naked_identifier: b
+        - question: '?'
+        - expression:
+          - column_reference:
+            - naked_identifier: c
+        - ternary_colon: ':'
+        - expression:
+          - column_reference:
+            - naked_identifier: d
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: a
+          - question: '?'
+          - expression:
+            - column_reference:
+              - naked_identifier: b
+          - ternary_colon: ':'
+          - expression:
+            - column_reference:
+              - naked_identifier: c
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: x
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;

--- a/crates/lib/src/tests.rs
+++ b/crates/lib/src/tests.rs
@@ -712,6 +712,39 @@ fn test_clickhouse_select_apply_spacing_fix() {
 }
 
 #[test]
+fn test_clickhouse_ternary_spacing_no_false_positive() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([
+                ("dialect".into(), Value::String("clickhouse".into())),
+                ("rules".into(), Value::String("LT01".into())),
+            ])),
+        )]),
+        None,
+        None,
+    );
+    let mut lnt = Linter::new(config, None, None, true).unwrap();
+    let sql = concat!(
+        "SELECT a ? b : c AS x FROM t;\n",
+        "SELECT col = '' ? 0 : 1 AS x FROM t;\n",
+    );
+
+    let linted = lnt.lint_string_wrapped(sql, false).unwrap();
+    let lt01: Vec<_> = linted
+        .violations()
+        .iter()
+        .filter(|v| v.rule_code() == "LT01")
+        .map(|v| (v.rule_code(), v.line_no, v.line_pos))
+        .collect();
+
+    assert!(
+        lt01.is_empty(),
+        "unexpected LT01 violations for correctly spaced ternary expressions: {lt01:?}"
+    );
+}
+
+#[test]
 fn test_clickhouse_datetime64_rejects_timezone_without_precision() {
     let config = FluffConfig::new(
         HashMap::from([(

--- a/crates/lsp/src/semantic.rs
+++ b/crates/lsp/src/semantic.rs
@@ -587,6 +587,7 @@ pub(crate) fn classify(kind: SyntaxKind) -> Option<Highlight> {
         | Literal
         | Meta
         | Colon
+        | TernaryColon
         | StatementTerminator
         | StartSquareBracket
         | EndSquareBracket


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `d909e772c7b918c111f2401abddb0ecadfee4299`.
Part of #2910.

## What changed

- Added ClickHouse parsing for C-style ternary expressions: `condition ? then : else`.
- Preserved ternary precedence across comparison, arithmetic, nested branches, function arguments, `WHERE`, and `ORDER BY` contexts.
- Added a ternary-specific colon segment so conventional `? ... : ...` spacing does not raise LT01 false positives.
- Added ClickHouse fixture coverage and a focused LT01 regression test.