### PR TITLE
fix(clickhouse): parse double-equals comparisons

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -107,6 +107,14 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         )],
         "dot",
     );
+    clickhouse_dialect.insert_lexer_matchers(
+        vec![Matcher::string(
+            "double_equals",
+            "==",
+            SyntaxKind::RawComparisonOperator,
+        )],
+        "equals",
+    );
 
     clickhouse_dialect.replace_grammar(
         "AccessorGrammar",
@@ -176,6 +184,34 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 Ref::new("ExpressionSegment").to_matchable(),
             ])
             .config(|this| this.optional())
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    clickhouse_dialect.replace_grammar(
+        "ComparisonOperatorGrammar",
+        one_of(vec![
+            Ref::new("EqualsSegment").to_matchable(),
+            Ref::new("DoubleEqualsSegment").to_matchable(),
+            Ref::new("GreaterThanSegment").to_matchable(),
+            Ref::new("LessThanSegment").to_matchable(),
+            Ref::new("GreaterThanOrEqualToSegment").to_matchable(),
+            Ref::new("LessThanOrEqualToSegment").to_matchable(),
+            Ref::new("NotEqualToSegment").to_matchable(),
+            Ref::new("LikeOperatorSegment").to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("IS").to_matchable(),
+                Ref::keyword("DISTINCT").to_matchable(),
+                Ref::keyword("FROM").to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("IS").to_matchable(),
+                Ref::keyword("NOT").to_matchable(),
+                Ref::keyword("DISTINCT").to_matchable(),
+                Ref::keyword("FROM").to_matchable(),
+            ])
             .to_matchable(),
         ])
         .to_matchable(),
@@ -1152,6 +1188,20 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             TypedParser::new(SyntaxKind::Lambda, SyntaxKind::Lambda)
                 .to_matchable()
                 .into(),
+        ),
+        (
+            "RawDoubleEqualsSegment".into(),
+            StringParser::new("==", SyntaxKind::RawComparisonOperator)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "DoubleEqualsSegment".into(),
+            NodeMatcher::new(SyntaxKind::ComparisonOperator, |_| {
+                Ref::new("RawDoubleEqualsSegment").to_matchable()
+            })
+            .to_matchable()
+            .into(),
         ),
     ]);
 

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/comparison_operators.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/comparison_operators.sql
@@ -1,0 +1,9 @@
+SELECT a FROM t WHERE a == 1;
+
+SELECT a == b AS same_value FROM t;
+
+SELECT count() FROM t WHERE number % 2 == 0;
+
+SELECT a FROM t WHERE a IS NOT DISTINCT FROM b;
+
+SELECT a == b ? 1 : 0 AS same_value FROM t;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/comparison_operators.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/comparison_operators.yml
@@ -1,0 +1,132 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: ==
+        - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: a
+          - comparison_operator:
+            - raw_comparison_operator: ==
+          - column_reference:
+            - naked_identifier: b
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: same_value
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: number
+        - binary_operator: '%'
+        - numeric_literal: '2'
+        - comparison_operator:
+          - raw_comparison_operator: ==
+        - numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: a
+        - keyword: IS
+        - keyword: NOT
+        - keyword: DISTINCT
+        - keyword: FROM
+        - column_reference:
+          - naked_identifier: b
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: a
+          - comparison_operator:
+            - raw_comparison_operator: ==
+          - column_reference:
+            - naked_identifier: b
+          - question: '?'
+          - expression:
+            - numeric_literal: '1'
+          - ternary_colon: ':'
+          - expression:
+            - numeric_literal: '0'
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: same_value
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `870f0ad6375e6642427285577d42b71ac70aa634`.
Part of #2910.

## What changed

- Added ClickHouse lexing and parsing for `==` as a comparison operator.
- Preserved inherited comparison operators, including `IS DISTINCT FROM` and `IS NOT DISTINCT FROM`.
- Added fixture coverage for `WHERE`, select-list comparisons, arithmetic predicates, and ternary conditions using `==`.