### PR TITLE
fix(clickhouse): parse ORDER BY WITH FILL INTERPOLATE

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -779,46 +779,105 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         .to_matchable(),
     );
 
+    let order_by_sort_key = |with_fill: Option<bool>| {
+        let mut elements = vec![
+            one_of(vec![
+                Ref::new("ColumnReferenceSegment").to_matchable(),
+                Ref::new("NumericLiteralSegment").to_matchable(),
+                Ref::new("ExpressionSegment").to_matchable(),
+            ])
+            .to_matchable(),
+            one_of(vec![
+                Ref::keyword("ASC").to_matchable(),
+                Ref::keyword("DESC").to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("NULLS").to_matchable(),
+                one_of(vec![
+                    Ref::keyword("FIRST").to_matchable(),
+                    Ref::keyword("LAST").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+        ];
+
+        match with_fill {
+            Some(true) => elements.push(Ref::new("WithFillSegment").to_matchable()),
+            Some(false) => {}
+            None => elements.push(Ref::new("WithFillSegment").optional().to_matchable()),
+        }
+
+        Sequence::new(elements).to_matchable()
+    };
+
+    let interpolate_clause = || {
+        Sequence::new(vec![
+            Ref::keyword("INTERPOLATE").to_matchable(),
+            Bracketed::new(vec![
+                Delimited::new(vec![
+                    Sequence::new(vec![
+                        Ref::new("ColumnReferenceSegment").to_matchable(),
+                        Sequence::new(vec![
+                            Ref::keyword("AS").to_matchable(),
+                            Ref::new("ExpressionSegment").to_matchable(),
+                        ])
+                        .config(|this| this.optional())
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+        ])
+        .to_matchable()
+    };
+
     clickhouse_dialect.replace_grammar(
         "OrderByClauseSegment",
         Sequence::new(vec![
             Ref::keyword("ORDER").to_matchable(),
             Ref::keyword("BY").to_matchable(),
             MetaSegment::indent().to_matchable(),
-            Delimited::new(vec![
+            one_of(vec![
                 Sequence::new(vec![
-                    one_of(vec![
-                        Ref::new("ColumnReferenceSegment").to_matchable(),
-                        Ref::new("NumericLiteralSegment").to_matchable(),
-                        Ref::new("ExpressionSegment").to_matchable(),
-                    ])
-                    .to_matchable(),
-                    one_of(vec![
-                        Ref::keyword("ASC").to_matchable(),
-                        Ref::keyword("DESC").to_matchable(),
-                    ])
-                    .config(|this| this.optional())
-                    .to_matchable(),
                     Sequence::new(vec![
-                        Ref::keyword("NULLS").to_matchable(),
-                        one_of(vec![
-                            Ref::keyword("FIRST").to_matchable(),
-                            Ref::keyword("LAST").to_matchable(),
+                        AnyNumberOf::new(vec![
+                            Sequence::new(vec![
+                                order_by_sort_key(Some(false)),
+                                Ref::new("CommaSegment").to_matchable(),
+                            ])
+                            .to_matchable(),
+                        ])
+                        .to_matchable(),
+                        order_by_sort_key(Some(true)),
+                        AnyNumberOf::new(vec![
+                            Sequence::new(vec![
+                                Ref::new("CommaSegment").to_matchable(),
+                                order_by_sort_key(None),
+                            ])
+                            .to_matchable(),
                         ])
                         .to_matchable(),
                     ])
-                    .config(|this| this.optional())
                     .to_matchable(),
-                    Ref::new("WithFillSegment").optional().to_matchable(),
+                    interpolate_clause(),
                 ])
                 .to_matchable(),
+                Delimited::new(vec![order_by_sort_key(None)])
+                    .config(|this| {
+                        this.terminators = vec![
+                            Ref::keyword("LIMIT").to_matchable(),
+                            Ref::new("FrameClauseUnitGrammar").to_matchable(),
+                        ]
+                    })
+                    .to_matchable(),
             ])
-            .config(|this| {
-                this.terminators = vec![
-                    Ref::keyword("LIMIT").to_matchable(),
-                    Ref::new("FrameClauseUnitGrammar").to_matchable(),
-                ]
-            })
             .to_matchable(),
             MetaSegment::dedent().to_matchable(),
         ])

--- a/crates/lib-dialects/src/clickhouse_keywords.rs
+++ b/crates/lib-dialects/src/clickhouse_keywords.rs
@@ -87,6 +87,7 @@ pub(crate) const UNRESERVED_KEYWORDS: &[&str] = &[
     "INF",
     "INJECTIVE",
     "INSERT",
+    "INTERPOLATE",
     "INTERVAL",
     "INTO",
     "INVOKER",

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/order_by_with_fill.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/order_by_with_fill.sql
@@ -32,3 +32,18 @@ WHERE (number % 3) = 1
 ORDER BY
     d1 WITH FILL STEP INTERVAL 1 DAY,
     d2 WITH FILL;
+
+SELECT a, b FROM t ORDER BY a WITH FILL INTERPOLATE (b AS b + 1);
+
+SELECT a, b, c FROM t
+ORDER BY a WITH FILL FROM 1 TO 10 STEP 2 INTERPOLATE (b AS b + 1, c);
+
+SELECT a, b FROM t ORDER BY a WITH FILL INTERPOLATE;
+
+-- INTERPOLATE applies to the whole ORDER BY list, so it may trail a later
+-- column that itself has no WITH FILL.
+SELECT ts, id, value FROM t
+ORDER BY ts WITH FILL, id INTERPOLATE (value);
+
+SELECT sensor_id, timestamp, value FROM t
+ORDER BY sensor_id, timestamp WITH FILL INTERPOLATE (value AS 9999);

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/order_by_with_fill.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/order_by_with_fill.yml
@@ -362,3 +362,202 @@ file:
       - keyword: WITH
       - keyword: FILL
 - statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: FILL
+      - keyword: INTERPOLATE
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: b
+        - keyword: AS
+        - expression:
+          - column_reference:
+            - naked_identifier: b
+          - binary_operator: +
+          - numeric_literal: '1'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: c
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: FILL
+      - keyword: FROM
+      - expression:
+        - numeric_literal: '1'
+      - keyword: TO
+      - expression:
+        - numeric_literal: '10'
+      - keyword: STEP
+      - numeric_literal: '2'
+      - keyword: INTERPOLATE
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: b
+        - keyword: AS
+        - expression:
+          - column_reference:
+            - naked_identifier: b
+          - binary_operator: +
+          - numeric_literal: '1'
+        - comma: ','
+        - column_reference:
+          - naked_identifier: c
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: FILL
+      - keyword: INTERPOLATE
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: ts
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: value
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: ts
+      - keyword: WITH
+      - keyword: FILL
+      - comma: ','
+      - column_reference:
+        - naked_identifier: id
+      - keyword: INTERPOLATE
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: value
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: sensor_id
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: timestamp
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: value
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: sensor_id
+      - comma: ','
+      - column_reference:
+        - naked_identifier: timestamp
+      - keyword: WITH
+      - keyword: FILL
+      - keyword: INTERPOLATE
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: value
+        - keyword: AS
+        - expression:
+          - numeric_literal: '9999'
+        - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `115c35ba6f9d657253590ffbac34b4a372db0644`.
Part of #2910.

## What changed

- Added ClickHouse parsing for `ORDER BY ... WITH FILL ... INTERPOLATE`.
- Required `INTERPOLATE` to follow an `ORDER BY` list containing at least one `WITH FILL` sort key.
- Registered `INTERPOLATE` as a ClickHouse unreserved keyword.
- Kept ordinary `ORDER BY` parsing separate so `interpolate` can still be used as an identifier.
- Added fixture coverage for upstream `INTERPOLATE` cases and a documented multi-key `WITH FILL` form.