### PR TITLE
test(clickhouse): cover tuple access on arbitrary expressions

### DIFF
--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.sql
@@ -12,3 +12,13 @@ SELECT
     test.1[2],
     test.1[2].3,
     test.2;
+
+-- Tuple element access on expressions that are not a bare or bracketed
+-- column reference: a function call, an array subscript and a tuple literal
+-- (https://github.com/sqlfluff/sqlfluff/issues/8032).
+SELECT
+    f(x).2,
+    arr[1].2,
+    (a, b).1,
+    f(x).1.2
+FROM t;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/tuple_element_access.yml
@@ -187,3 +187,69 @@ file:
             - tuple_element_access:
               - numeric_literal: '.2'
 - statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - function:
+            - function_name:
+              - function_name_identifier: f
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: x
+                - end_bracket: )
+          - tuple_element_access:
+            - numeric_literal: '.2'
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - column_reference:
+            - naked_identifier: arr
+          - array_accessor:
+            - start_square_bracket: '['
+            - numeric_literal: '1'
+            - end_square_bracket: ']'
+          - tuple_element_access:
+            - numeric_literal: '.2'
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+              - naked_identifier: a
+            - comma: ','
+            - column_reference:
+              - naked_identifier: b
+            - end_bracket: )
+          - tuple_element_access:
+            - numeric_literal: '.1'
+      - comma: ','
+      - select_clause_element:
+        - expression:
+          - function:
+            - function_name:
+              - function_name_identifier: f
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: x
+                - end_bracket: )
+          - tuple_element_access:
+            - numeric_literal: '.1'
+            - numeric_literal: '.2'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse fixture coverage from SQLFluff commit `4d335e9cfb3de272cbd943cd4861fffba7167a12`.
Part of #2910.

## What changed

- Added ClickHouse fixture coverage for tuple element access after function calls.
- Added coverage for tuple access after array subscripts.
- Added coverage for tuple access after tuple literals.
- Added chained tuple element access coverage.
- Reused Sqruff's existing `AccessorGrammar` tuple access implementation, which already covers the upstream grammar behavior.