### PR TITLE
fix(clickhouse): parse multi-column limit by

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -3623,7 +3623,8 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     Ref::keyword("BY").to_matchable(),
                     one_of(vec![
                         Ref::new("BracketedColumnReferenceListGrammar").to_matchable(),
-                        Ref::new("ColumnReferenceSegment").to_matchable(),
+                        Delimited::new(vec![Ref::new("ColumnReferenceSegment").to_matchable()])
+                            .to_matchable(),
                     ])
                     .to_matchable(),
                 ])

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/limit_by.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/limit_by.sql
@@ -5,3 +5,9 @@ with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 by id;
 with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2 OFFSET 1 by id;
 
 with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2, 1 by (id, name);
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 by id, name;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2 OFFSET 1 by id, name;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2, 1 by id, name;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/limit_by.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/limit_by.yml
@@ -187,3 +187,148 @@ file:
             - naked_identifier: name
           - end_bracket: )
 - statement_terminator: ;
+- statement:
+  - with_compound_statement:
+    - keyword: with
+    - common_table_expression:
+      - naked_identifier: toto
+      - keyword: as
+      - bracketed:
+        - start_bracket: (
+        - select_statement:
+          - select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+              - numeric_literal: '1'
+              - alias_expression:
+                - keyword: as
+                - naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+              - quoted_literal: '''test'''
+              - alias_expression:
+                - keyword: as
+                - naked_identifier: name
+        - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: toto
+      - limit_clause:
+        - keyword: LIMIT
+        - numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+          - naked_identifier: id
+        - comma: ','
+        - column_reference:
+          - naked_identifier: name
+- statement_terminator: ;
+- statement:
+  - with_compound_statement:
+    - keyword: with
+    - common_table_expression:
+      - naked_identifier: toto
+      - keyword: as
+      - bracketed:
+        - start_bracket: (
+        - select_statement:
+          - select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+              - numeric_literal: '1'
+              - alias_expression:
+                - keyword: as
+                - naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+              - quoted_literal: '''test'''
+              - alias_expression:
+                - keyword: as
+                - naked_identifier: name
+        - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: toto
+      - limit_clause:
+        - keyword: LIMIT
+        - numeric_literal: '2'
+        - keyword: OFFSET
+        - numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+          - naked_identifier: id
+        - comma: ','
+        - column_reference:
+          - naked_identifier: name
+- statement_terminator: ;
+- statement:
+  - with_compound_statement:
+    - keyword: with
+    - common_table_expression:
+      - naked_identifier: toto
+      - keyword: as
+      - bracketed:
+        - start_bracket: (
+        - select_statement:
+          - select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+              - numeric_literal: '1'
+              - alias_expression:
+                - keyword: as
+                - naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+              - quoted_literal: '''test'''
+              - alias_expression:
+                - keyword: as
+                - naked_identifier: name
+        - end_bracket: )
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: toto
+      - limit_clause:
+        - keyword: LIMIT
+        - numeric_literal: '2'
+        - comma: ','
+        - numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+          - naked_identifier: id
+        - comma: ','
+        - column_reference:
+          - naked_identifier: name
+- statement_terminator: ;


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `a96a252215fff0c7889e2bc8f66a122f845db0cc`.
Part of #2910.

## What changed

- Allows unbracketed ClickHouse LIMIT BY clauses to use delimited column lists.
- Preserves existing single-column and bracketed LIMIT BY column list support.
- Adds fixture coverage for plain, OFFSET, and comma-offset multi-column LIMIT BY forms.