### PR TITLE
fix(clickhouse): parse group by modifiers

### DIFF
--- a/crates/lib-dialects/src/clickhouse.rs
+++ b/crates/lib-dialects/src/clickhouse.rs
@@ -1457,6 +1457,52 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             ),
     );
 
+    clickhouse_dialect.replace_grammar(
+        "GroupByClauseSegment",
+        Sequence::new(vec![
+            Ref::keyword("GROUP").to_matchable(),
+            Ref::keyword("BY").to_matchable(),
+            MetaSegment::indent().to_matchable(),
+            one_of(vec![
+                Ref::keyword("ALL").to_matchable(),
+                Ref::new("GroupingSetsClauseSegment").to_matchable(),
+                Ref::new("CubeRollupClauseSegment").to_matchable(),
+                Delimited::new(vec![
+                    one_of(vec![
+                        Ref::new("ColumnReferenceSegment").to_matchable(),
+                        Ref::new("NumericLiteralSegment").to_matchable(),
+                        Ref::new("ExpressionSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .config(|this| {
+                    this.terminators =
+                        vec![Ref::new("GroupByClauseTerminatorGrammar").to_matchable()];
+                })
+                .to_matchable(),
+            ])
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("WITH").to_matchable(),
+                one_of(vec![
+                    Ref::keyword("ROLLUP").to_matchable(),
+                    Ref::keyword("CUBE").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("WITH").to_matchable(),
+                Ref::keyword("TOTALS").to_matchable(),
+            ])
+            .config(|this| this.optional())
+            .to_matchable(),
+            MetaSegment::dedent().to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
     clickhouse_dialect.add([(
         "WithFillSegment".into(),
         Sequence::new(vec![

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_group_by_modifiers.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_group_by_modifiers.sql
@@ -1,0 +1,23 @@
+-- ClickHouse GROUP BY modifiers: WITH ROLLUP / WITH CUBE / WITH TOTALS.
+
+SELECT a, count() FROM t GROUP BY ALL;
+
+SELECT a, count() FROM t GROUP BY ALL WITH TOTALS;
+
+SELECT a, count() FROM t GROUP BY a WITH TOTALS;
+
+SELECT a, count() FROM t GROUP BY a WITH ROLLUP;
+
+SELECT a, count() FROM t GROUP BY a WITH CUBE;
+
+SELECT a, count() FROM t GROUP BY ROLLUP(a);
+
+SELECT a, count() FROM t GROUP BY CUBE(a);
+
+SELECT a, b, count() FROM t GROUP BY GROUPING SETS ((a), (b)) WITH TOTALS;
+
+SELECT a, b, count() FROM t GROUP BY a, b WITH ROLLUP WITH TOTALS;
+
+SELECT a, b, count() FROM t GROUP BY a, b WITH CUBE WITH TOTALS;
+
+SELECT a, count() FROM t GROUP BY a WITH TOTALS HAVING count() > 1;

--- a/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_group_by_modifiers.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/clickhouse/sqlfluff/select_group_by_modifiers.yml
@@ -1,0 +1,403 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - keyword: ALL
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - keyword: ALL
+      - keyword: WITH
+      - keyword: TOTALS
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: TOTALS
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: ROLLUP
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: CUBE
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - cube_rollup_clause:
+        - function_name:
+          - function_name_identifier: ROLLUP
+        - bracketed:
+          - start_bracket: (
+          - grouping_expression_list:
+            - column_reference:
+              - naked_identifier: a
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - cube_rollup_clause:
+        - function_name:
+          - function_name_identifier: CUBE
+        - bracketed:
+          - start_bracket: (
+          - grouping_expression_list:
+            - column_reference:
+              - naked_identifier: a
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+          - start_bracket: (
+          - grouping_expression_list:
+            - expression:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: a
+                - end_bracket: )
+            - comma: ','
+            - expression:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: b
+                - end_bracket: )
+          - end_bracket: )
+      - keyword: WITH
+      - keyword: TOTALS
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: b
+      - keyword: WITH
+      - keyword: ROLLUP
+      - keyword: WITH
+      - keyword: TOTALS
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - comma: ','
+      - column_reference:
+        - naked_identifier: b
+      - keyword: WITH
+      - keyword: CUBE
+      - keyword: WITH
+      - keyword: TOTALS
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: t
+    - groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: a
+      - keyword: WITH
+      - keyword: TOTALS
+    - having_clause:
+      - keyword: HAVING
+      - expression:
+        - function:
+          - function_name:
+            - function_name_identifier: count
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - end_bracket: )
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+        - numeric_literal: '1'
+- statement_terminator: ;

--- a/crates/lib/src/tests.rs
+++ b/crates/lib/src/tests.rs
@@ -497,6 +497,67 @@ fn test_clickhouse_tuple_element_access_parse_boundaries() {
     );
 }
 
+#[test]
+fn test_clickhouse_group_by_totals_inside_indent() {
+    let config = FluffConfig::new(
+        HashMap::from([(
+            "core".into(),
+            Value::Map(HashMap::from([(
+                "dialect".into(),
+                Value::String("clickhouse".into()),
+            )])),
+        )]),
+        None,
+        None,
+    );
+    let lnt = Linter::new(config, None, None, true).unwrap();
+    let tables = Tables::default();
+
+    let parsed = lnt
+        .parse_string(
+            &tables,
+            "SELECT a, count() FROM t GROUP BY a WITH TOTALS HAVING count() > 1;",
+            None,
+        )
+        .unwrap();
+    assert!(
+        parsed.violations.is_empty(),
+        "expected ClickHouse GROUP BY WITH TOTALS to parse cleanly: {:?}",
+        parsed.violations
+    );
+
+    let tree = parsed.tree.unwrap();
+    let groupby = tree
+        .recursive_crawl(
+            &SyntaxSet::new(&[SyntaxKind::GroupbyClause]),
+            true,
+            &SyntaxSet::EMPTY,
+            true,
+        )
+        .into_iter()
+        .next()
+        .expect("expected a groupby_clause");
+
+    let segments = groupby.segments();
+    let indent_index = segments
+        .iter()
+        .position(|segment| segment.is_indent() && segment.indent_val() > 0)
+        .expect("expected groupby_clause indent");
+    let totals_index = segments
+        .iter()
+        .position(|segment| segment.raw().as_str().eq_ignore_ascii_case("TOTALS"))
+        .expect("expected WITH TOTALS inside groupby_clause");
+    let dedent_index = segments
+        .iter()
+        .position(|segment| segment.is_indent() && segment.indent_val() < 0)
+        .expect("expected groupby_clause dedent");
+
+    assert!(
+        indent_index < totals_index && totals_index < dedent_index,
+        "expected WITH TOTALS to stay inside the GROUP BY indent scope"
+    );
+}
+
 /// LT12 is a source-file rule. A templated file can render with a final newline
 /// while the source file still lacks one because trailing Jinja blocks render to
 /// zero length.


### PR DESCRIPTION
Ports ClickHouse grammar updates from SQLFluff commit `05c054d94a902724ab1b8d3f13e344f6bdad04e5`.
Part of #2910.

## What changed

- Added ClickHouse `GROUP BY` parsing for trailing `WITH ROLLUP`, `WITH CUBE`, and `WITH TOTALS` modifiers.
- Preserved support for `GROUP BY ALL`, `GROUPING SETS`, and function-style `ROLLUP(...)` / `CUBE(...)` forms.
- Added fixture coverage for ClickHouse group-by modifier variants.
- Added a parser regression test to keep `WITH TOTALS` inside the `GROUP BY` indent scope while leaving `HAVING` outside.