### PR TITLE
fix(postgres): lex the jsonb operators @?, @@, ?| and ?&

### DIFF
--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -431,9 +431,15 @@ pub fn raw_dialect() -> Dialect {
             r#"(?s)U&".+?"(\s*UESCAPE\s*\'[^0-9A-Fa-f\'+\-\s)]\')?"#,
             SyntaxKind::UnicodeDoubleQuote
         ),
+        // Verbatim from sqlfluff#6323, which fixed `@?`, `@@`, `?|` and `?&` (we
+        // track a 2023 sha, so this is pre-applied ahead of that port). The
+        // optional quantifiers matter: the lexer's combined regex is
+        // leftmost-first, not leftmost-longest, so spelling these as separate
+        // alternatives would need every operator ordered ahead of its own
+        // prefix.
         Matcher::regex(
             "json_operator",
-            r#"->>|#>>|->|#>|@>|<@|\?\|_|\?|\?&|#-"#,
+            r#"->>?|#>>?|@[>@?]|<@|\?[|&]?|#-"#,
             SyntaxKind::JsonOperator
         ),
         Matcher::string(

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/jsonb_operators.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/jsonb_operators.sql
@@ -1,0 +1,21 @@
+-- Does the key exist?
+SELECT '{"a":1, "b":2}'::jsonb ? 'b';
+-- Do any of the keys exist?
+SELECT '{"a":1, "b":2, "c":3}'::jsonb ?| ARRAY['b', 'd'];
+-- Do all of the keys exist?
+SELECT '["a", "b", "c"]'::jsonb ?& ARRAY['a', 'b'];
+-- Does the JSON path return any item?
+SELECT '{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)';
+-- Does the JSON path predicate hold?
+SELECT '{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2';
+-- Delete the value at the path
+SELECT '["a", {"b":1}]'::jsonb #- '{1,b}';
+-- The whole family in a WHERE clause
+SELECT *
+FROM mytable
+WHERE
+  doc ? 'a'
+  AND doc ?| ARRAY['b']
+  AND doc ?& ARRAY['c']
+  AND doc @? '$.d'
+  AND doc @@ '$.e == 1';

--- a/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/jsonb_operators.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/jsonb_operators.yml
@@ -1,0 +1,156 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''{"a":1, "b":2}'''
+            - casting_operator: '::'
+            - data_type:
+              - keyword: jsonb
+          - binary_operator: '?'
+          - quoted_literal: '''b'''
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''{"a":1, "b":2, "c":3}'''
+            - casting_operator: '::'
+            - data_type:
+              - keyword: jsonb
+          - binary_operator: ?|
+          - typed_array_literal:
+            - array_type:
+              - keyword: ARRAY
+            - array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: '''b'''
+              - comma: ','
+              - quoted_literal: '''d'''
+              - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''["a", "b", "c"]'''
+            - casting_operator: '::'
+            - data_type:
+              - keyword: jsonb
+          - binary_operator: ?&
+          - typed_array_literal:
+            - array_type:
+              - keyword: ARRAY
+            - array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: '''a'''
+              - comma: ','
+              - quoted_literal: '''b'''
+              - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''{"a":[1,2,3,4,5]}'''
+            - casting_operator: '::'
+            - data_type:
+              - keyword: jsonb
+          - binary_operator: '@?'
+          - quoted_literal: '''$.a[*] ? (@ > 2)'''
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''{"a":[1,2,3,4,5]}'''
+            - casting_operator: '::'
+            - data_type:
+              - keyword: jsonb
+          - binary_operator: '@@'
+          - quoted_literal: '''$.a[*] > 2'''
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - cast_expression:
+            - quoted_literal: '''["a", {"b":1}]'''
+            - casting_operator: '::'
+            - data_type:
+              - keyword: jsonb
+          - binary_operator: '#-'
+          - quoted_literal: '''{1,b}'''
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: mytable
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - column_reference:
+          - naked_identifier: doc
+        - binary_operator: '?'
+        - quoted_literal: '''a'''
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: doc
+        - binary_operator: ?|
+        - typed_array_literal:
+          - array_type:
+            - keyword: ARRAY
+          - array_literal:
+            - start_square_bracket: '['
+            - quoted_literal: '''b'''
+            - end_square_bracket: ']'
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: doc
+        - binary_operator: ?&
+        - typed_array_literal:
+          - array_type:
+            - keyword: ARRAY
+          - array_literal:
+            - start_square_bracket: '['
+            - quoted_literal: '''c'''
+            - end_square_bracket: ']'
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: doc
+        - binary_operator: '@?'
+        - quoted_literal: '''$.d'''
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: doc
+        - binary_operator: '@@'
+        - quoted_literal: '''$.e == 1'''
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #3018.

Takes the `json_operator` lexer regex verbatim from [SQLFluff #6323](https://github.com/sqlfluff/sqlfluff/pull/6323) ([`0a32baa`](https://github.com/sqlfluff/sqlfluff/commit/0a32baa44f55b40e6384482bd316234146cd27d1)), which fixed exactly these four operators upstream in October 2024. `.sqlfluff-sha` is still on a 2023-07-02 commit, so this is that port applied ahead of the queue rather than a divergence — when the port reaches #6323 this line will be a no-op.

```diff
-r#"->>|#>>|->|#>|@>|<@|\?\|_|\?|\?&|#-"#
+r#"->>?|#>>?|@[>@?]|<@|\?[|&]?|#-"#
```

## What was wrong

Three separate things, which is why it took four operators down:

- `@?` (`jsonb_path_exists`) and `@@` (`jsonb_path_match`, and also the text-search match operator) were absent from the alternation, so they fell through to the bare `at` matcher on the following lines and lexed as two `At` tokens.
- `\?\|_` carried a stray literal underscore, so it only ever matched `?|_` and never `?|`. The 2023 sha we track spells it `\?\|`, so this one was a porting typo rather than an upstream bug — `?|` worked in sqlfluff and was broken on the way in.
- `\?` was ordered ahead of `\?&`. The lexer compiles every matcher into a single `regex_automata::meta::Regex::new_many` (`crates/lib-core/src/parser/lexer.rs:480`) matched with `Anchored::Yes` (`:576`), which is leftmost-**first** rather than leftmost-longest, so the bare `?` won and the trailing `&` was left dangling.

That last point is the argument for taking #6323's regex as-is rather than hand-reordering the alternation: its optional quantifiers remove the ordering constraint instead of merely satisfying it. A hand-ordered list has to keep every operator ahead of anything it is a prefix of, and that requirement is invisible until it silently breaks an operator — which is precisely how `?&` broke here.

No grammar change is needed: `JsonOperatorSegment` is already part of postgres's `BinaryOperatorGrammar`, which is why `@>` and `<@` have always worked.

`tsvector @@ to_tsquery(...)` was unparsable for the same reason and now parses too.

## Why it is worth fixing ahead of the port

The parse error is invisible unless you pass `--parsing-errors`, and an unparsable section can suppress lint violations elsewhere in the same file — so `sqruff fix` exits 0 having quietly left part of the file unformatted. #3018 has a minimal reproduction: two identical misindented statements, both flagged; add `@?` to the first predicate and the second statement's violations disappear.

Worth noting the history, since it is not a new report: #1587 hit this from the symptom end in 2025 (`fix` turning `@@` into `@ @`, producing malformed SQL) and was closed for reporter inactivity rather than resolution. #2762 later stopped reflow splitting operators inside unparsable sections, which masked that corruption without lexing the operators — so the failure changed shape rather than going away.

## Testing

- `cargo test --manifest-path crates/cli/Cargo.toml` and `cargo test --all --all-features --exclude sqruff` — 20 targets, 187 tests, 0 failures.
- `cargo fmt --check` and `cargo clippy -p sqruff-lib-dialects` clean.
- All twelve postgres JSON/JSONB operators parse, both spaced and unspaced (`d@?'$.a'`, `d?|ARRAY['a']`, …).
- New fixture `crates/lib-dialects/test/fixtures/dialects/postgres/sqruff/jsonb_operators.sql` covers the six `?`/`@`-family operators standalone and chained in a `WHERE`; expectations generated with `UPDATE_EXPECT=1`, and each operator lands as a single `binary_operator`. It is named `jsonb_operators` so it will not collide with the `json_operators` fixture #6323 also extends, when that lands.
- Lint output is byte-identical to the 0.39.0 release across a ~90-file postgres schema tree I had to hand, so no existing formatting shifts.
- greenplum, redshift and duckdb inherit the matcher and improve accordingly; no existing fixture in the tree contains any of the four operators, so nothing needed regenerating.

I could not run the Bazel targets in this environment (the network policy blocks the bazel download), so verification is the cargo suites above.

*Disclosure: prepared with Claude Code; I have reproduced the bug, verified the claims and reviewed the change myself, and will handle follow-ups here.*