### PR TITLE
chore: decouple Cargo vendoring from Rust sources

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -253,11 +253,32 @@ filegroup(
     ],
 )
 
-# Vendor cargo dependencies and install Rust toolchain (cached until Cargo.lock changes)
+# Cargo metadata used to resolve and vendor dependencies. Keep this separate
+# from cargo_srcs so ordinary Rust source changes do not invalidate vendoring.
+filegroup(
+    name = "cargo_manifests",
+    srcs = [
+        "Cargo.lock",
+        "Cargo.toml",
+        "//crates/cli:Cargo.toml",
+        "//crates/cli-lib:Cargo.toml",
+        "//crates/cli-python:Cargo.toml",
+        "//crates/lib:Cargo.toml",
+        "//crates/lib-core:Cargo.toml",
+        "//crates/lib-dialects:Cargo.toml",
+        "//crates/lib-wasm:Cargo.toml",
+        "//crates/lineage:Cargo.toml",
+        "//crates/lsp:Cargo.toml",
+        "//crates/sqlinference:Cargo.toml",
+    ],
+)
+
+# Vendor cargo dependencies and install Rust toolchain (cached until dependency
+# manifests, Cargo.lock, or toolchain configuration changes).
 # Installs Rust via rustup with clippy and rustfmt components
 cargo_vendor(
     name = "cargo_vendor",
-    manifests = [":cargo_srcs"],
+    manifests = [":cargo_manifests"],
     rust_version = "1.96.1",
     components = [
         "clippy",

--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -62,6 +62,23 @@ for src in {srcs}; do
     cp "$src" "$WORK_DIR/$src"
 done
 
+# Cargo requires each workspace package to have at least one target before it
+# will resolve the workspace. Vendoring only depends on the manifests and
+# lockfile, so create disposable targets instead of declaring the real Rust
+# sources as inputs to this action.
+for manifest in {srcs}; do
+    case "$manifest" in
+        */Cargo.toml)
+            package_dir="$WORK_DIR/$(dirname "$manifest")"
+            mkdir -p "$package_dir/src/bin"
+            touch \
+                "$package_dir/src/lib.rs" \
+                "$package_dir/src/main.rs" \
+                "$package_dir/src/bin/bench.rs"
+            ;;
+    esac
+done
+
 cd "$WORK_DIR"
 
 cargo vendor "$EXEC_ROOT/{vendor_out}" 2>&1

--- a/crates/cli-lib/BUILD.bazel
+++ b/crates/cli-lib/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
+exports_files(["Cargo.toml"])
+
 rust_library(
     name = "sqruff-cli-lib",
     srcs = glob(["src/**/*.rs"]),

--- a/crates/cli/BUILD.bazel
+++ b/crates/cli/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
+exports_files(["Cargo.toml"])
+
 rust_binary(
     name = "sqruff",
     srcs = glob(["src/**/*.rs"]),

--- a/crates/lib-core/BUILD.bazel
+++ b/crates/lib-core/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
+exports_files(["Cargo.toml"])
+
 ALL_FEATURES = [
     "serde",
     "stringify",

--- a/crates/lib-dialects/BUILD.bazel
+++ b/crates/lib-dialects/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
+exports_files(["Cargo.toml"])
+
 ALL_FEATURES = [
     "athena",
     "bigquery",

--- a/crates/lib-wasm/BUILD.bazel
+++ b/crates/lib-wasm/BUILD.bazel
@@ -2,6 +2,8 @@ load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
 load("@rules_rust_wasm_bindgen//:defs.bzl", "rust_wasm_bindgen")
 
+exports_files(["Cargo.toml"])
+
 rust_library(
     name = "sqruff-wasm",
     srcs = glob(["src/**/*.rs"]),

--- a/crates/lib/BUILD.bazel
+++ b/crates/lib/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
 
+exports_files(["Cargo.toml"])
+
 ALL_FEATURES = [
     "parser",
 ]

--- a/crates/lineage/BUILD.bazel
+++ b/crates/lineage/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
+exports_files(["Cargo.toml"])
+
 rust_library(
     name = "lineage",
     srcs = glob(["src/**/*.rs"]),

--- a/crates/lsp/BUILD.bazel
+++ b/crates/lsp/BUILD.bazel
@@ -2,6 +2,8 @@ load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
 load("@rules_rust_wasm_bindgen//:defs.bzl", "rust_wasm_bindgen")
 
+exports_files(["Cargo.toml"])
+
 rust_library(
     name = "sqruff-lsp",
     srcs = glob(["src/**/*.rs"]),

--- a/crates/sqlinference/BUILD.bazel
+++ b/crates/sqlinference/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
+exports_files(["Cargo.toml"])
+
 rust_library(
     name = "sqruff-sqlinference",
     srcs = glob(["src/**/*.rs"]),


### PR DESCRIPTION
## Summary

- add a manifest-only Bazel filegroup for Cargo dependency resolution
- make the vendoring action depend only on `Cargo.toml` files and `Cargo.lock`
- create disposable Rust target placeholders inside the vendoring sandbox so Cargo can resolve the workspace without real source inputs
- export crate manifests for cross-package Bazel visibility

## Why

The vendoring target previously consumed `cargo_srcs`, which includes every crate's Rust sources, tests, and benches. As a result, an ordinary `.rs` edit invalidated the vendoring action and caused dependencies and the Rust toolchain to be vendored again even when dependency metadata had not changed.

After this change, vendoring is invalidated only by Cargo manifests, `Cargo.lock`, toolchain configuration, or the vendoring rule itself.

## Validation

- confirmed via Bazel `aquery` that `CargoVendor` has no `.rs` inputs
- completed source-free `cargo vendor --locked` successfully
- `bazelisk test //...` — 33/33 tests passed