### PR TITLE
chore: update Rust to 1.97.1

### DIFF
--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -28,7 +28,7 @@ runs:
       with:
         command: build
         target: ${{ matrix.platform.target }}
-        toolchain: stable
+        toolchain: 1.97.1
         args: --locked --release --bin sqruff --package sqruff
         strip: true
     - name: Package as archive

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup rust toolchain, cache and cargo-codspeed binary
         uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # ratchet:moonrepo/setup-rust@v1
         with:
-          channel: stable
+          channel: 1.97.1
           cache-target: release
           bins: cargo-codspeed
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # ratchet:actions/setup-python@v7.0.0
         with:
           python-version: 3.x
-      - run: rustup toolchain install stable-x86_64-unknown-linux-gnu
+      - run: rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # ratchet:PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # ratchet:actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.97.1
           profile: minimal
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # ratchet:rust-lang/crates-io-auth-action@v1

--- a/.hacking/scripts/cargo_test.sh
+++ b/.hacking/scripts/cargo_test.sh
@@ -23,7 +23,7 @@ export CARGO_TARGET_DIR="$WORKDIR/target"
 # Use system cargo if available, otherwise install rustup
 if ! command -v cargo &> /dev/null; then
     export RUSTUP_HOME="$WORKDIR/.rustup"
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.97.1 --no-modify-path
     export PATH="$CARGO_HOME/bin:$PATH"
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # Builder stage
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.97.1-bookworm AS builder
 
 WORKDIR /usr/src/sqruff
 COPY . .

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,5 +1,5 @@
 # Builder stage
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.97.1-bookworm AS builder
 
 # Install Python development headers
 RUN apt-get update && apt-get install -y \

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,7 +93,7 @@ rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
     extra_target_triples = ["wasm32-unknown-unknown"],
-    versions = ["1.96.1"],
+    versions = ["1.97.1"],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.97.1"


### PR DESCRIPTION
## What

- update Bazel, rust-toolchain, Docker, CI, release, and helper-script Rust pins to 1.97.1
- keep Cargo package manifests and their existing MSRV declarations unchanged

## Why

Rust 1.97.1 is the current stable point release: https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/

## Impact

Development, Bazel builds, CI, Docker images, release builds, and Cargo helper jobs now use the same Rust release. This does not raise the MSRV advertised by library packages, so downstream consumers are not required to use Rust 1.97.

## Checks

- `cargo metadata --locked --no-deps`
- `git diff --check`
- `bazelisk test //...` — all compiler, build, lint, feature-matrix, unit, Python, and browser targets passed; `//:codegen_docs_check` completed successfully but hit its aggregate-run timeout under parallel Cargo load
- `bazelisk test //:codegen_docs_check` — passed independently in 28.7s
- `bazelisk test //crates/lib-core:sqruff-lib-core-test` — passed after restoring the existing MSRV behavior

Originally stacked on #3036; rebased onto `main` after that PR merged.