### PR TITLE
ci: use sandbox-local Cargo home

### DIFF
--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -40,6 +40,7 @@ unset RUSTUP_HOME RUSTUP_TOOLCHAIN
 "$RUSTC_BIN" --version
 
 WORK_DIR=$(mktemp -d)
+export CARGO_HOME="$WORK_DIR/.cargo"
 
 # Copy all Cargo.toml / Cargo.lock files preserving structure
 for src in {srcs}; do


### PR DESCRIPTION
## What changed

Set `CARGO_HOME` to a writable temporary directory created inside the Bazel Cargo vendoring action.

## Why

The action inherited the host Cargo home (`~/.cargo`), which Bazel mounts read-only in the sandbox. When vendoring needed to download a missing crate, Cargo failed while creating its registry cache and prevented the test suite from building.

Using the action-local working directory keeps Cargo writes sandboxed and avoids depending on a writable host home directory. Bazel still caches the declared vendored dependency output across unchanged builds.

## Validation

- `bazelisk build --config=ci //:cargo_vendor` passes
- Cargo downloads and registry data are written under the action-local `/tmp/.../.cargo`
- `git diff --check` passes
- `bazelisk test --config=ci //...` proceeds beyond Cargo vendoring; it later stops on a separate `code-server` lifecycle failure because `node-gyp` cannot locate Python