### PR TITLE
fix(dialects): preserve Databricks CTE references

### DIFF
--- a/crates/lib-dialects/src/databricks.rs
+++ b/crates/lib-dialects/src/databricks.rs
@@ -1,11 +1,13 @@
 use crate::databricks_keywords::{RESERVED_KEYWORDS, UNRESERVED_KEYWORDS};
 use crate::sparksql;
 use sqruff_lib_core::dialects::init::DialectConfig;
+use sqruff_lib_core::dialects::syntax::SyntaxKind;
 use sqruff_lib_core::helpers::Config;
 use sqruff_lib_core::parser::grammar::anyof::one_of;
 use sqruff_lib_core::parser::grammar::delimited::Delimited;
 use sqruff_lib_core::parser::grammar::sequence::Bracketed;
 use sqruff_lib_core::parser::matchable::MatchableTrait;
+use sqruff_lib_core::parser::node_matcher::NodeMatcher;
 use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::{
     dialects::{Dialect, init::DialectKind},
@@ -201,7 +203,11 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
         (
             // A reference to an table, CTE, subquery or alias.
             "TableReferenceSegment".into(),
-            Ref::new("ObjectReferenceSegment").to_matchable().into(),
+            NodeMatcher::new(SyntaxKind::TableReference, |_| {
+                Ref::new("ObjectReferenceSegment").to_matchable()
+            })
+            .to_matchable()
+            .into(),
         ),
         (
             // A reference to a schema.

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/alter_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/alter_table.yml
@@ -3,10 +3,12 @@ file:
   - alter_table_statement:
     - keyword: ALTER
     - keyword: TABLE
-    - object_reference:
-      - naked_identifier: Student
+    - table_reference:
+      - object_reference:
+        - naked_identifier: Student
     - keyword: RENAME
     - keyword: TO
-    - object_reference:
-      - naked_identifier: StudentInfo
+    - table_reference:
+      - object_reference:
+        - naked_identifier: StudentInfo
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/alter_view.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/alter_view.yml
@@ -3,33 +3,37 @@ file:
   - alter_view_statement:
     - keyword: ALTER
     - keyword: VIEW
-    - object_reference:
-      - naked_identifier: tempsc1
-      - dot: .
-      - naked_identifier: v1
+    - table_reference:
+      - object_reference:
+        - naked_identifier: tempsc1
+        - dot: .
+        - naked_identifier: v1
     - keyword: RENAME
     - keyword: TO
-    - object_reference:
-      - naked_identifier: tempsc1
-      - dot: .
-      - naked_identifier: v2
+    - table_reference:
+      - object_reference:
+        - naked_identifier: tempsc1
+        - dot: .
+        - naked_identifier: v2
 - statement_terminator: ;
 - statement:
   - alter_view_statement:
     - keyword: ALTER
     - keyword: VIEW
-    - object_reference:
-      - keyword: IDENTIFIER
-      - bracketed:
-        - start_bracket: (
-        - quoted_identifier: '''tempsc1.v1'''
-        - end_bracket: )
+    - table_reference:
+      - object_reference:
+        - keyword: IDENTIFIER
+        - bracketed:
+          - start_bracket: (
+          - quoted_identifier: '''tempsc1.v1'''
+          - end_bracket: )
     - keyword: RENAME
     - keyword: TO
-    - object_reference:
-      - keyword: IDENTIFIER
-      - bracketed:
-        - start_bracket: (
-        - quoted_identifier: '''tempsc1.v2'''
-        - end_bracket: )
+    - table_reference:
+      - object_reference:
+        - keyword: IDENTIFIER
+        - bracketed:
+          - start_bracket: (
+          - quoted_identifier: '''tempsc1.v2'''
+          - end_bracket: )
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/comment_on.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/comment_on.yml
@@ -39,8 +39,9 @@ file:
   - keyword: COMMENT
   - keyword: ON
   - keyword: TABLE
-  - object_reference:
-    - naked_identifier: my_table
+  - table_reference:
+    - object_reference:
+      - naked_identifier: my_table
   - keyword: IS
   - quoted_literal: '''This is my table'''
 - statement_terminator: ;
@@ -48,8 +49,9 @@ file:
   - keyword: COMMENT
   - keyword: ON
   - keyword: TABLE
-  - object_reference:
-    - naked_identifier: my_table
+  - table_reference:
+    - object_reference:
+      - naked_identifier: my_table
   - keyword: IS
   - keyword: 'NULL'
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/create_table.yml
@@ -3,8 +3,9 @@ file:
   - create_table_statement:
     - keyword: CREATE
     - keyword: TABLE
-    - object_reference:
-      - naked_identifier: tablename
+    - table_reference:
+      - object_reference:
+        - naked_identifier: tablename
     - bracketed:
       - start_bracket: (
       - column_definition:
@@ -35,13 +36,15 @@ file:
 - statement_terminator: ;
 - statement:
   - keyword: OPTIMIZE
-  - object_reference:
-    - naked_identifier: tablename
+  - table_reference:
+    - object_reference:
+      - naked_identifier: tablename
 - statement_terminator: ;
 - statement:
   - keyword: OPTIMIZE
-  - object_reference:
-    - naked_identifier: tablename
+  - table_reference:
+    - object_reference:
+      - naked_identifier: tablename
   - keyword: WHERE
   - expression:
     - column_reference:

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/date_functions.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/date_functions.yml
@@ -19,15 +19,17 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: my_table
+            - table_reference:
+              - object_reference:
+                - naked_identifier: my_table
         - join_clause:
           - keyword: LEFT
           - keyword: JOIN
           - from_expression_element:
             - table_expression:
-              - object_reference:
-                - naked_identifier: other_table
+              - table_reference:
+                - object_reference:
+                  - naked_identifier: other_table
           - join_on_condition:
             - keyword: ON
             - expression:
@@ -269,6 +271,7 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: my_table
+            - table_reference:
+              - object_reference:
+                - naked_identifier: my_table
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/insert_by_name.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/insert_by_name.yml
@@ -3,8 +3,9 @@ file:
   - insert_statement:
     - keyword: INSERT
     - keyword: INTO
-    - object_reference:
-      - naked_identifier: target
+    - table_reference:
+      - object_reference:
+        - naked_identifier: target
     - keyword: BY
     - keyword: NAME
     - select_statement:
@@ -49,8 +50,9 @@ file:
   - insert_statement:
     - keyword: INSERT
     - keyword: INTO
-    - object_reference:
-      - naked_identifier: target
+    - table_reference:
+      - object_reference:
+        - naked_identifier: target
     - keyword: BY
     - keyword: NAME
     - select_statement:
@@ -97,8 +99,9 @@ file:
   - insert_statement:
     - keyword: INSERT
     - keyword: INTO
-    - object_reference:
-      - naked_identifier: target
+    - table_reference:
+      - object_reference:
+        - naked_identifier: target
     - keyword: BY
     - keyword: NAME
     - select_statement:
@@ -139,8 +142,9 @@ file:
   - insert_statement:
     - keyword: INSERT
     - keyword: INTO
-    - object_reference:
-      - naked_identifier: target
+    - table_reference:
+      - object_reference:
+        - naked_identifier: target
     - keyword: BY
     - keyword: NAME
     - select_statement:
@@ -187,8 +191,9 @@ file:
   - insert_statement:
     - keyword: INSERT
     - keyword: INTO
-    - object_reference:
-      - naked_identifier: target
+    - table_reference:
+      - object_reference:
+        - naked_identifier: target
     - keyword: BY
     - keyword: NAME
     - select_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/pivot.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/pivot.yml
@@ -31,8 +31,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: sales
+            - table_reference:
+              - object_reference:
+                - naked_identifier: sales
         - pivot_clause:
           - keyword: PIVOT
           - bracketed:
@@ -125,8 +126,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: sales
+            - table_reference:
+              - object_reference:
+                - naked_identifier: sales
         - pivot_clause:
           - keyword: PIVOT
           - bracketed:
@@ -301,8 +303,9 @@ file:
                   - from_expression:
                     - from_expression_element:
                       - table_expression:
-                        - object_reference:
-                          - naked_identifier: sales
+                        - table_reference:
+                          - object_reference:
+                            - naked_identifier: sales
               - end_bracket: )
           - alias_expression:
             - keyword: AS
@@ -420,8 +423,9 @@ file:
                   - from_expression:
                     - from_expression_element:
                       - table_expression:
-                        - object_reference:
-                          - naked_identifier: sales
+                        - table_reference:
+                          - object_reference:
+                            - naked_identifier: sales
               - end_bracket: )
           - alias_expression:
             - keyword: AS

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/select.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/select.yml
@@ -12,10 +12,11 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: shopify_cz
-              - dot: .
-              - naked_identifier: order
+            - table_reference:
+              - object_reference:
+                - naked_identifier: shopify_cz
+                - dot: .
+                - naked_identifier: order
 - statement_terminator: ;
 - statement:
   - select_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/select_group_by.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/select_group_by.yml
@@ -26,8 +26,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -66,8 +67,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -119,8 +121,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -160,8 +163,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -210,8 +214,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -254,8 +259,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -333,8 +339,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -417,8 +424,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -502,8 +510,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -555,8 +564,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: dealer
+            - table_reference:
+              - object_reference:
+                - naked_identifier: dealer
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -597,8 +607,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: person
+            - table_reference:
+              - object_reference:
+                - naked_identifier: person
 - statement_terminator: ;
 - statement:
   - select_statement:
@@ -655,8 +666,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: person
+            - table_reference:
+              - object_reference:
+                - naked_identifier: person
 - statement_terminator: ;
 - statement:
   - select_statement:
@@ -687,8 +699,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: people
+            - table_reference:
+              - object_reference:
+                - naked_identifier: people
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -730,8 +743,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: people
+            - table_reference:
+              - object_reference:
+                - naked_identifier: people
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -774,8 +788,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: people
+            - table_reference:
+              - object_reference:
+                - naked_identifier: people
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -821,8 +836,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: people
+            - table_reference:
+              - object_reference:
+                - naked_identifier: people
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -868,8 +884,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: people
+            - table_reference:
+              - object_reference:
+                - naked_identifier: people
     - groupby_clause:
       - keyword: GROUP
       - keyword: BY

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/select_window.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/select_window.yml
@@ -30,10 +30,11 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: schema
-              - dot: .
-              - naked_identifier: test_table
+            - table_reference:
+              - object_reference:
+                - naked_identifier: schema
+                - dot: .
+                - naked_identifier: test_table
 - statement_terminator: ;
 - statement:
   - select_statement:
@@ -72,8 +73,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: schema
-              - dot: .
-              - naked_identifier: test_table
+            - table_reference:
+              - object_reference:
+                - naked_identifier: schema
+                - dot: .
+                - naked_identifier: test_table
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/unpivot.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/unpivot.yml
@@ -12,8 +12,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: sales
+            - table_reference:
+              - object_reference:
+                - naked_identifier: sales
         - unpivot_clause:
           - keyword: UNPIVOT
           - keyword: INCLUDE
@@ -67,8 +68,9 @@ file:
       - from_expression:
         - from_expression_element:
           - table_expression:
-            - object_reference:
-              - naked_identifier: oncall
+            - table_reference:
+              - object_reference:
+                - naked_identifier: oncall
         - unpivot_clause:
           - keyword: UNPIVOT
           - bracketed:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/ST03.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/ST03.yml
@@ -13,6 +13,18 @@ test_pass_cte_defined_and_used_1:
     )
     select * from cte
 
+test_pass_databricks_cte_defined_and_used:
+  pass_str: |
+    WITH base AS (
+        SELECT 1 AS x
+    )
+
+    SELECT *
+    FROM base
+  configs:
+    core:
+      dialect: databricks
+
 test_pass_cte_defined_and_used_2:
   pass_str: |
     WITH cte1 AS (


### PR DESCRIPTION
Closes #3077.

### Summary
- Preserve common table expression references when applying the Databricks dialect.
- Add an ST03 regression fixture covering a Databricks CTE referenced by the outer query.

### Validation

- `PYO3_PYTHON="$PWD/.venv/bin/python" uv run make rust_test`

---

Note this was made with Claude.