### PR TITLE
fix(postgres): preserve quoted type casing

### DIFF
--- a/crates/lib/src/rules/capitalisation/cp05.rs
+++ b/crates/lib/src/rules/capitalisation/cp05.rs
@@ -75,6 +75,7 @@ CREATE TABLE t (
             for seg in context.segment.segments() {
                 if seg.is_type(SyntaxKind::Symbol)
                     || seg.is_type(SyntaxKind::Identifier)
+                    || seg.is_type(SyntaxKind::QuotedIdentifier)
                     || seg.is_type(SyntaxKind::QuotedLiteral)
                     || !seg.segments().is_empty()
                 {

--- a/crates/lib/test/fixtures/rules/std_rule_cases/CP05.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/CP05.yml
@@ -162,3 +162,36 @@ test_pass_typless_structs_dont_trigger_rule:
     rules:
       capitalisation.types:
         extended_capitalisation_policy: upper
+
+# See https://github.com/quarylabs/sqruff/issues/3049
+test_pass_postgres_setof_quoted_custom_type:
+  pass_str: |
+    CREATE TABLE "companies_created_stats" (
+        "month" TIMESTAMPTZ NOT NULL,
+        "count" INT NOT NULL
+    );
+
+    CREATE OR REPLACE FUNCTION get_companies_created_stats()
+    RETURNS SETOF "companies_created_stats"
+    AS
+    $$
+    SELECT DATE_TRUNC('month', c.created_at) AS month, COUNT(*) AS count
+    FROM company c
+    GROUP BY month
+    ORDER BY month;
+    $$ LANGUAGE sql STABLE;
+  configs:
+    core:
+      dialect: postgres
+    rules:
+      capitalisation.types:
+        extended_capitalisation_policy: upper
+
+test_pass_postgres_quoted_custom_column_type:
+  pass_str: CREATE TABLE events (payload "eventPayload");
+  configs:
+    core:
+      dialect: postgres
+    rules:
+      capitalisation.types:
+        extended_capitalisation_policy: upper


### PR DESCRIPTION
## Summary

- preserve the case of quoted PostgreSQL custom type identifiers in CP05
- add regression fixtures for `RETURNS SETOF "companies_created_stats"` and quoted mixed-case column types

## Root cause

Sqruff represents quoted identifiers with a dedicated `QuotedIdentifier` syntax kind. CP05 excluded generic identifiers but not that specific kind, so quoted custom type names could be passed through datatype capitalisation.

## SQLFluff parity

SQLFluff CP05 skips identifier segments when capitalising datatypes. This change applies the equivalent behavior to Sqruff’s more specific syntax kinds.

## Validation

- focused CP05 fixture suite passed
- sqruff-lib unit tests passed: 89 passed, 1 ignored
- all supported rule fixtures passed

Fixes #3049
