### PR TITLE
fix(sqlite): SQLite CREATE TRIGGER parsing

### DIFF
--- a/crates/lib-dialects/src/sqlite.rs
+++ b/crates/lib-dialects/src/sqlite.rs
@@ -461,6 +461,21 @@ pub fn raw_dialect() -> Dialect {
                 ])
                 .to_matchable(),
                 Ref::new("IndexColumnDefinitionSegment").to_matchable(),
+                one_of(vec![
+                    Ref::keyword("IGNORE").to_matchable(),
+                    Sequence::new(vec![
+                        one_of(vec![
+                            Ref::keyword("ABORT").to_matchable(),
+                            Ref::keyword("FAIL").to_matchable(),
+                            Ref::keyword("ROLLBACK").to_matchable(),
+                        ])
+                        .to_matchable(),
+                        Ref::new("CommaSegment").to_matchable(),
+                        Ref::new("QuotedLiteralSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
             ])
             .to_matchable()
             .into(),
@@ -1006,7 +1021,8 @@ pub fn raw_dialect() -> Dialect {
             .to_matchable(),
             Sequence::new(vec![
                 Ref::keyword("WHEN").to_matchable(),
-                Bracketed::new(vec![Ref::new("ExpressionSegment").to_matchable()]).to_matchable(),
+                optionally_bracketed(vec![Ref::new("ExpressionSegment").to_matchable()])
+                    .to_matchable(),
             ])
             .config(|config| {
                 config.optional();

--- a/crates/lib-dialects/src/sqlite_keywords.rs
+++ b/crates/lib-dialects/src/sqlite_keywords.rs
@@ -4,7 +4,6 @@
 
 pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
     "ABORT",
-    "ACTION",
     "ADD",
     "AFTER",
     "ALL",
@@ -152,6 +151,7 @@ pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
 ];
 
 pub(crate) const UNRESERVED_KEYWORDS: &[&str] = &[
+    "ACTION",
     "KEY",
     "INT",
     "INTEGER",

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_trigger.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_trigger.sql
@@ -47,4 +47,15 @@ INSERT INTO emp_log(emp_id,salary,edittime)
          VALUES(NEW.employee_id,NEW.salary,current_date);
 END;
 
+CREATE TRIGGER x
+AFTER INSERT ON y
+WHEN new.z IS NULL   -- putting this expression in parens allows parsing
+BEGIN
+UPDATE y SET z = TRUE WHERE rowid = new.rowid;
+END;
 
+CREATE TRIGGER trigger_name
+AFTER UPDATE ON table_name
+BEGIN
+    INSERT INTO table_name_history (action) VALUES ('UPDATE');
+END;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_trigger.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqlfluff/create_trigger.yml
@@ -246,3 +246,81 @@ file:
     - statement_terminator: ;
     - keyword: END
 - statement_terminator: ;
+- statement:
+  - create_trigger_statement:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+      - naked_identifier: x
+    - keyword: AFTER
+    - keyword: INSERT
+    - keyword: ON
+    - table_reference:
+      - naked_identifier: y
+    - keyword: WHEN
+    - expression:
+      - column_reference:
+        - naked_identifier: new
+        - dot: .
+        - naked_identifier: z
+      - keyword: IS
+      - keyword: 'NULL'
+    - keyword: BEGIN
+    - update_statement:
+      - keyword: UPDATE
+      - table_reference:
+        - naked_identifier: y
+      - set_clause_list:
+        - keyword: SET
+        - set_clause:
+          - column_reference:
+            - naked_identifier: z
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - boolean_literal: 'TRUE'
+      - where_clause:
+        - keyword: WHERE
+        - expression:
+          - column_reference:
+            - naked_identifier: rowid
+          - comparison_operator:
+            - raw_comparison_operator: =
+          - column_reference:
+            - naked_identifier: new
+            - dot: .
+            - naked_identifier: rowid
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+  - create_trigger_statement:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+      - naked_identifier: trigger_name
+    - keyword: AFTER
+    - keyword: UPDATE
+    - keyword: ON
+    - table_reference:
+      - naked_identifier: table_name
+    - keyword: BEGIN
+    - insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+        - naked_identifier: table_name_history
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+          - naked_identifier: action
+        - end_bracket: )
+      - values_clause:
+        - keyword: VALUES
+        - bracketed:
+          - start_bracket: (
+          - expression:
+            - quoted_literal: '''UPDATE'''
+          - end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqruff/create_trigger.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqruff/create_trigger.sql
@@ -1,0 +1,6 @@
+CREATE TRIGGER ok
+BEFORE INSERT ON whatever
+WHEN 1 = 1
+BEGIN
+    SELECT RAISE(ABORT, 'Son😭😭😭😭😭😭');
+END;

--- a/crates/lib-dialects/test/fixtures/dialects/sqlite/sqruff/create_trigger.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sqlite/sqruff/create_trigger.yml
@@ -1,0 +1,36 @@
+file:
+- statement:
+  - create_trigger_statement:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+      - naked_identifier: ok
+    - keyword: BEFORE
+    - keyword: INSERT
+    - keyword: ON
+    - table_reference:
+      - naked_identifier: whatever
+    - keyword: WHEN
+    - expression:
+      - numeric_literal: '1'
+      - comparison_operator:
+        - raw_comparison_operator: =
+      - numeric_literal: '1'
+    - keyword: BEGIN
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - function:
+            - function_name:
+              - function_name_identifier: RAISE
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - keyword: ABORT
+                - comma: ','
+                - quoted_literal: '''Son😭😭😭😭😭😭'''
+                - end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #3014.

## What changed

- Allow SQLite trigger `WHEN` expressions with or without parentheses.
- Support SQLite `RAISE(IGNORE)` and `RAISE(ABORT|FAIL|ROLLBACK, message)` function contents.
- Align `ACTION` with SQLFluff's SQLite unreserved keyword classification.
- Update the SQLFluff `create_trigger` fixture as an exact upstream replica.
- Add the issue-specific regression case under the Sqruff fixture directory.

## Root cause

Sqruff required trigger `WHEN` expressions to be parenthesized and lacked SQLite-specific parsing for `RAISE()` arguments. Its keyword classification also prevented the latest upstream SQLFluff trigger fixture from parsing an `action` column name.

## Validation

- `cargo fmt --all`
- `cargo test -p sqruff-lib-dialects --test dialects -- sqlite`
- `git diff --check`
- Byte-for-byte SHA-256 comparison of the SQLFluff SQL fixture against upstream