### PR TITLE
ci: dialect grammar references

### DIFF
--- a/crates/lib-core/src/dialects.rs
+++ b/crates/lib-core/src/dialects.rs
@@ -5,6 +5,7 @@ pub mod syntax;
 
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::fmt::{Display, Formatter};
 
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
@@ -14,7 +15,7 @@ use crate::dialects::sets::DialectSetKey;
 use crate::dialects::syntax::SyntaxKind;
 use crate::helpers::ToMatchable;
 use crate::parser::lexer::{Lexer, Matcher};
-use crate::parser::matchable::Matchable;
+use crate::parser::matchable::{Matchable, MatchableTrait};
 use crate::parser::parsers::StringParser;
 use crate::parser::types::DialectElementType;
 
@@ -27,6 +28,35 @@ pub struct Dialect {
     pub bracket_collections: HashMap<&'static str, HashSet<BracketPair>>,
     lexer: Option<Lexer>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DialectValidationError {
+    path: Vec<String>,
+    missing_reference: String,
+}
+
+impl DialectValidationError {
+    pub fn path(&self) -> &[String] {
+        &self.path
+    }
+
+    pub fn missing_reference(&self) -> &str {
+        &self.missing_reference
+    }
+}
+
+impl Display for DialectValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Grammar reference path {} refers to '{}' which was not found in the dialect",
+            self.path.join(" -> "),
+            self.missing_reference,
+        )
+    }
+}
+
+impl std::error::Error for DialectValidationError {}
 
 impl PartialEq for Dialect {
     fn eq(&self, other: &Self) -> bool {
@@ -228,6 +258,69 @@ impl Dialect {
         }
     }
 
+    /// Validate references reachable from the grammar used to parse a file.
+    ///
+    /// Dialects inherit and replace grammar extensively. Validating only the
+    /// whole library would reject intentionally dormant inherited grammars, so
+    /// this follows the same graph the parser can reach from `FileSegment`.
+    pub fn validate(&self) -> Result<(), DialectValidationError> {
+        match self.validation_errors().into_iter().next() {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// Return every missing reference reachable from the file grammar.
+    pub fn validation_errors(&self) -> Vec<DialectValidationError> {
+        let root_name = "FileSegment";
+        let Some(DialectElementType::Matchable(root)) = self.library.get(root_name) else {
+            return vec![DialectValidationError {
+                path: vec![root_name.to_string()],
+                missing_reference: root_name.to_string(),
+            }];
+        };
+
+        let mut visited = HashSet::new();
+        let mut path = vec![root_name.to_string()];
+        let mut errors = Vec::new();
+        self.validate_matchable(root, &mut visited, &mut path, &mut errors);
+        errors
+    }
+
+    fn validate_matchable(
+        &self,
+        matchable: &Matchable,
+        visited: &mut HashSet<usize>,
+        path: &mut Vec<String>,
+        errors: &mut Vec<DialectValidationError>,
+    ) {
+        if !visited.insert(matchable.identity()) {
+            return;
+        }
+
+        if let Some(reference) = matchable.as_ref() {
+            let name = reference.reference();
+            path.push(name.to_string());
+            if let Some(DialectElementType::Matchable(target)) = self.library.get(name) {
+                self.validate_matchable(target, visited, path, errors);
+            } else {
+                errors.push(DialectValidationError {
+                    path: path.clone(),
+                    missing_reference: name.to_string(),
+                });
+            }
+            path.pop();
+        }
+
+        if let Some(grammar) = matchable.match_grammar(self) {
+            self.validate_matchable(&grammar, visited, path, errors);
+        }
+
+        for child in matchable.validation_children() {
+            self.validate_matchable(child, visited, path, errors);
+        }
+    }
+
     pub fn expand(&mut self) {
         // Temporarily take ownership of 'library' from 'self' to avoid borrow checker
         // errors during mutation.
@@ -267,3 +360,63 @@ impl Dialect {
 }
 
 pub type BracketPair = (&'static str, &'static str, &'static str, bool);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::grammar::Ref;
+
+    #[test]
+    fn validate_reports_reachable_missing_reference_with_path() {
+        let mut dialect = Dialect::new();
+        dialect.add([
+            (
+                "FileSegment".into(),
+                Ref::new("StatementSegment").to_matchable().into(),
+            ),
+            (
+                "StatementSegment".into(),
+                Ref::new("MissingSegment").to_matchable().into(),
+            ),
+        ]);
+
+        let error = dialect.validate().unwrap_err();
+        assert_eq!(error.missing_reference(), "MissingSegment");
+        assert_eq!(
+            error.path(),
+            ["FileSegment", "StatementSegment", "MissingSegment"]
+        );
+        assert_eq!(
+            error.to_string(),
+            "Grammar reference path FileSegment -> StatementSegment -> MissingSegment refers to \
+             'MissingSegment' which was not found in the dialect"
+        );
+    }
+
+    #[test]
+    fn validate_ignores_unreachable_inherited_grammar() {
+        let mut dialect = Dialect::new();
+        dialect.add([
+            (
+                "FileSegment".into(),
+                Ref::new("StatementSegment").to_matchable().into(),
+            ),
+            (
+                "StatementSegment".into(),
+                Ref::new("PresentSegment").to_matchable().into(),
+            ),
+            (
+                "PresentSegment".into(),
+                Ref::keyword("SELECT").to_matchable().into(),
+            ),
+            (
+                "DormantInheritedSegment".into(),
+                Ref::new("MissingSegment").to_matchable().into(),
+            ),
+        ]);
+        dialect.add_keyword_to_set("reserved_keywords", "SELECT");
+        dialect.expand();
+
+        assert_eq!(dialect.validate(), Ok(()));
+    }
+}

--- a/crates/lib-core/src/dialects.rs
+++ b/crates/lib-core/src/dialects.rs
@@ -316,6 +316,19 @@ impl Dialect {
             self.validate_matchable(&grammar, visited, path, errors);
         }
 
+        for reference in matchable.validation_references(self) {
+            path.push(reference.to_string());
+            if let Some(DialectElementType::Matchable(target)) = self.library.get(reference) {
+                self.validate_matchable(target, visited, path, errors);
+            } else {
+                errors.push(DialectValidationError {
+                    path: path.clone(),
+                    missing_reference: reference.to_string(),
+                });
+            }
+            path.pop();
+        }
+
         for child in matchable.validation_children() {
             self.validate_matchable(child, visited, path, errors);
         }
@@ -364,7 +377,8 @@ pub type BracketPair = (&'static str, &'static str, &'static str, bool);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::grammar::Ref;
+    use crate::parser::grammar::sequence::Bracketed;
+    use crate::parser::grammar::{Anything, Ref};
 
     #[test]
     fn validate_reports_reachable_missing_reference_with_path() {
@@ -418,5 +432,72 @@ mod tests {
         dialect.expand();
 
         assert_eq!(dialect.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_reports_missing_anything_terminator() {
+        let mut dialect = Dialect::new();
+        dialect.add([(
+            "FileSegment".into(),
+            Anything::new()
+                .terminators(vec![Ref::new("MissingSegment").to_matchable()])
+                .to_matchable()
+                .into(),
+        )]);
+
+        let error = dialect.validate().unwrap_err();
+        assert_eq!(error.missing_reference(), "MissingSegment");
+        assert_eq!(error.path(), ["FileSegment", "MissingSegment"]);
+    }
+
+    #[test]
+    fn validate_reports_missing_bracket_pair_reference() {
+        let mut dialect = Dialect::new();
+        let mut bracketed = Bracketed::new(vec![]);
+        bracketed.bracket_type("angle");
+        bracketed.bracket_pairs_set = "angle_bracket_pairs";
+        dialect.update_bracket_sets(
+            "angle_bracket_pairs",
+            vec![(
+                "angle",
+                "StartAngleBracketSegment",
+                "MissingEndSegment",
+                false,
+            )],
+        );
+        dialect.add([
+            ("FileSegment".into(), bracketed.to_matchable().into()),
+            (
+                "StartAngleBracketSegment".into(),
+                Anything::new().to_matchable().into(),
+            ),
+        ]);
+
+        let error = dialect.validate().unwrap_err();
+        assert_eq!(error.missing_reference(), "MissingEndSegment");
+        assert_eq!(error.path(), ["FileSegment", "MissingEndSegment"]);
+    }
+
+    #[test]
+    fn validate_reports_missing_default_bracket_pair_reference() {
+        let mut dialect = Dialect::new();
+        dialect.update_bracket_sets(
+            "bracket_pairs",
+            vec![("round", "MissingStartSegment", "EndBracketSegment", false)],
+        );
+        dialect.add([
+            (
+                "FileSegment".into(),
+                Bracketed::new(vec![]).to_matchable().into(),
+            ),
+            (
+                "EndBracketSegment".into(),
+                Anything::new().to_matchable().into(),
+            ),
+        ]);
+
+        let error = dialect.validate().unwrap_err();
+        assert_eq!(error.missing_reference(), "MissingStartSegment");
+        assert_eq!(error.path(), ["FileSegment", "MissingStartSegment"]);
     }
 }

--- a/crates/lib-core/src/parser/grammar.rs
+++ b/crates/lib-core/src/parser/grammar.rs
@@ -89,6 +89,10 @@ impl Ref {
 
         Ref::new(keyword)
     }
+
+    pub(crate) fn reference(&self) -> &str {
+        &self.reference
+    }
 }
 
 impl PartialEq for Ref {
@@ -105,6 +109,10 @@ impl Eq for Ref {}
 impl MatchableTrait for Ref {
     fn elements(&self) -> &[Matchable] {
         &[]
+    }
+
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.exclude.iter().chain(self.terminators.iter()).collect()
     }
 
     fn is_optional(&self) -> bool {

--- a/crates/lib-core/src/parser/grammar.rs
+++ b/crates/lib-core/src/parser/grammar.rs
@@ -219,6 +219,10 @@ impl MatchableTrait for Anything {
         &[]
     }
 
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.terminators.iter().collect()
+    }
+
     fn match_segments(
         &self,
         segments: &[ErasedSegment],

--- a/crates/lib-core/src/parser/grammar/anyof.rs
+++ b/crates/lib-core/src/parser/grammar/anyof.rs
@@ -144,6 +144,14 @@ impl MatchableTrait for AnyNumberOf {
         &self.elements
     }
 
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.elements
+            .iter()
+            .chain(self.exclude.iter())
+            .chain(self.terminators.iter())
+            .collect()
+    }
+
     fn is_optional(&self) -> bool {
         self.optional || self.min_times == 0
     }

--- a/crates/lib-core/src/parser/grammar/delimited.rs
+++ b/crates/lib-core/src/parser/grammar/delimited.rs
@@ -71,6 +71,14 @@ impl MatchableTrait for Delimited {
         &self.elements
     }
 
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.base
+            .validation_children()
+            .into_iter()
+            .chain(std::iter::once(&self.delimiter))
+            .collect()
+    }
+
     fn is_optional(&self) -> bool {
         self.optional || self.base.is_optional()
     }

--- a/crates/lib-core/src/parser/grammar/sequence.rs
+++ b/crates/lib-core/src/parser/grammar/sequence.rs
@@ -401,6 +401,15 @@ impl MatchableTrait for Bracketed {
         self.this.validation_children()
     }
 
+    fn validation_references(&self, dialect: &crate::dialects::Dialect) -> Vec<&'static str> {
+        dialect
+            .bracket_sets(self.bracket_pairs_set)
+            .into_iter()
+            .filter(|(bracket_type, _, _, _)| *bracket_type == self.bracket_type)
+            .flat_map(|(_, start_ref, end_ref, _)| [start_ref, end_ref])
+            .collect()
+    }
+
     fn is_optional(&self) -> bool {
         self.this.is_optional()
     }

--- a/crates/lib-core/src/parser/grammar/sequence.rs
+++ b/crates/lib-core/src/parser/grammar/sequence.rs
@@ -90,6 +90,13 @@ impl MatchableTrait for Sequence {
         &self.elements
     }
 
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.elements
+            .iter()
+            .chain(self.terminators.iter())
+            .collect()
+    }
+
     fn is_optional(&self) -> bool {
         self.is_optional
     }
@@ -388,6 +395,10 @@ impl DerefMut for Bracketed {
 impl MatchableTrait for Bracketed {
     fn elements(&self) -> &[Matchable] {
         &self.elements
+    }
+
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.this.validation_children()
     }
 
     fn is_optional(&self) -> bool {

--- a/crates/lib-core/src/parser/matchable.rs
+++ b/crates/lib-core/src/parser/matchable.rs
@@ -51,6 +51,10 @@ impl Matchable {
         Arc::make_mut(&mut self.inner)
     }
 
+    pub(crate) fn identity(&self) -> usize {
+        Arc::as_ptr(&self.inner) as usize
+    }
+
     pub fn as_conditional(&self) -> Option<&Conditional> {
         match self.inner.as_ref() {
             MatchableTraitImpl::Conditional(parser) => Some(parser),
@@ -144,6 +148,14 @@ pub trait MatchableTrait {
     }
 
     fn elements(&self) -> &[Matchable];
+
+    /// All nested matchables which can be evaluated while matching.
+    ///
+    /// Most matchers only contain `elements`; matchers with auxiliary grammar
+    /// such as exclusions, delimiters, or terminators override this method.
+    fn validation_children(&self) -> Vec<&Matchable> {
+        self.elements().iter().collect()
+    }
 
     // Return whether this element is optional.
     fn is_optional(&self) -> bool {

--- a/crates/lib-core/src/parser/matchable.rs
+++ b/crates/lib-core/src/parser/matchable.rs
@@ -157,6 +157,11 @@ pub trait MatchableTrait {
         self.elements().iter().collect()
     }
 
+    /// Dialect-library references selected dynamically while matching.
+    fn validation_references(&self, _dialect: &Dialect) -> Vec<&'static str> {
+        Vec::new()
+    }
+
     // Return whether this element is optional.
     fn is_optional(&self) -> bool {
         false

--- a/crates/lib-dialects/tests/dialects.rs
+++ b/crates/lib-dialects/tests/dialects.rs
@@ -83,7 +83,216 @@ fn dialect_for_fixture_dir(
     kind_to_dialect(&dialect_kind, config.as_ref())
 }
 
+fn known_missing_references(dialect: DialectKind) -> &'static [&'static str] {
+    match dialect {
+        DialectKind::Bigquery => &[
+            "ACTION",
+            "ASSIGNMENT",
+            "BEFORE",
+            "CONSTRUCTOR",
+            "DEFERRABLE",
+            "DEFERRED",
+            "EACH",
+            "FUNCTIONS",
+            "IMMEDIATE",
+            "INITIALLY",
+            "INSTANCE",
+            "INSTEAD",
+            "MATCH",
+            "METHOD",
+            "NEXT",
+            "OLD",
+            "ONLY",
+            "PARTIAL",
+            "PROCEDURES",
+            "REFERENCING",
+            "ROUTINES",
+            "SEQUENCES",
+            "SIMPLE",
+            "SPECIFIC",
+            "STAGES",
+            "STATEMENT",
+            "STATIC",
+            "STREAMS",
+            "TABLES",
+            "TASKS",
+            "VIEWS",
+        ],
+        DialectKind::Duckdb | DialectKind::Greenplum | DialectKind::Postgres => &["EXECUTION"],
+        DialectKind::Materialize => &["EXECUTION", "VARIADIC"],
+        DialectKind::Oracle => &[
+            "AUTHENTICATION",
+            "CREDENTIAL",
+            "EXCEPTIONS",
+            "HASH",
+            "METADATA",
+            "RETENTION",
+            "SETTINGS",
+            "STEP",
+            "UNUSED",
+        ],
+        DialectKind::Redshift => &[
+            "ALLOW_CONNECTIONS",
+            "DEPENDENCIES",
+            "ICU",
+            "IS_TEMPLATE",
+            "LC_COLLATE",
+            "LC_CTYPE",
+            "LIBC",
+            "LOCALE",
+            "MCV",
+            "NDISTINCT",
+            "PERMISSIVE",
+            "PROVIDER",
+            "RESTRICTIVE",
+            "SKIP_LOCKED",
+            "SUMMARY",
+            "TIMING",
+            "WAL",
+        ],
+        DialectKind::Snowflake => &[
+            "ACTION",
+            "ASSIGNMENT",
+            "CONSTRUCTOR",
+            "EACH",
+            "INSTANCE",
+            "INSTEAD",
+            "METHOD",
+            "NEW",
+            "OLD",
+            "PARTIAL",
+            "QuotedLiteralGrammar",
+            "REFERENCING",
+            "SIMPLE",
+            "SPECIFIC",
+            "STATIC",
+        ],
+        DialectKind::Sqlite => &[
+            "BINDING", "DATA", "INTERVAL", "MATCHED", "PARTIAL", "SCHEMA", "SIMPLE",
+        ],
+        DialectKind::Starrocks => &["BITMAP", "OPTIMIZER_COSTS"],
+        DialectKind::Trino => &[
+            "ACCOUNT",
+            "ACTION",
+            "APPLY",
+            "ASSIGNMENT",
+            "AUTO_INCREMENT",
+            "BEFORE",
+            "BINDING",
+            "CACHE",
+            "CHECK",
+            "COLLATE",
+            "CONNECT",
+            "CONSTRUCTOR",
+            "COPY",
+            "CYCLE",
+            "DATABASE",
+            "DEFERRABLE",
+            "DEFERRED",
+            "DOMAIN",
+            "EACH",
+            "EXECUTION",
+            "FOREIGN",
+            "FUNCTION",
+            "FUTURE",
+            "IMPORTED",
+            "INCREMENT",
+            "INDEX",
+            "INITIALLY",
+            "INSTANCE",
+            "INSTEAD",
+            "INTEGRATION",
+            "LANGUAGE",
+            "LARGE",
+            "MANAGE",
+            "MASKING",
+            "MAXVALUE",
+            "METHOD",
+            "MINVALUE",
+            "MODEL",
+            "MODIFY",
+            "MONITOR",
+            "NEW",
+            "NOCACHE",
+            "NOCYCLE",
+            "NOORDER",
+            "OLD",
+            "OPERATE",
+            "OPTIONS",
+            "OVERWRITE",
+            "OWNERSHIP",
+            "PARTIAL",
+            "PIPE",
+            "POLICY",
+            "PRIMARY",
+            "PROCEDURE",
+            "PROCEDURES",
+            "PUBLIC",
+            "REFERENCES",
+            "REFERENCE_USAGE",
+            "REFERENCING",
+            "RESOURCE",
+            "RETURNS",
+            "ROUTINE",
+            "ROUTINES",
+            "SEQUENCE",
+            "SEQUENCES",
+            "SERVER",
+            "SESSION_USER",
+            "SHARE",
+            "SIMPLE",
+            "SPECIFIC",
+            "STAGE",
+            "STAGES",
+            "STATEMENT",
+            "STATIC",
+            "STREAM",
+            "STREAMS",
+            "TABLESPACE",
+            "TASK",
+            "TASKS",
+            "TEMP",
+            "TEMPORARY",
+            "TRANSIENT",
+            "TRIGGER",
+            "USAGE",
+            "USE_ANY_ROLE",
+            "VIEWS",
+            "WAREHOUSE",
+        ],
+        _ => &[],
+    }
+}
+
+fn validate_dialect_reference_baseline() {
+    for dialect_kind in DialectKind::iter() {
+        let Some(dialect) = kind_to_dialect(&dialect_kind, None) else {
+            continue;
+        };
+        let actual = dialect
+            .validation_errors()
+            .into_iter()
+            .map(|error| error.missing_reference().to_string())
+            .collect::<HashSet<_>>();
+        let expected = known_missing_references(dialect_kind)
+            .iter()
+            .map(|reference| reference.to_string())
+            .collect::<HashSet<_>>();
+
+        let unexpected = actual.difference(&expected).sorted().collect_vec();
+        let stale = expected.difference(&actual).sorted().collect_vec();
+        assert!(
+            unexpected.is_empty() && stale.is_empty(),
+            "Dialect {} reference baseline changed. New missing references: {unexpected:?}. \
+             Fixed references to remove from known_missing_references: {stale:?}",
+            dialect_kind.as_ref(),
+        );
+    }
+}
+
 fn main() {
+    validate_dialect_reference_baseline();
+
     let args = std::env::args().skip(1).collect::<Vec<String>>();
 
     let mut arg_dialect = None;


### PR DESCRIPTION
## Summary

- add a validator that walks grammar reachable from `FileSegment` and reports missing references with their full reference path
- include auxiliary matcher grammar such as exclusions, delimiters, and terminators
- collect all validation errors while retaining a convenient single-error `validate()` API
- enforce an exact per-dialect baseline in the dialect fixture suite

## Why

A dialect can inherit grammar that references keywords or segments removed from its library. These mistakes currently remain latent until a particular SQL input reaches the reference, at which point parsing panics. This makes missing grammar references detectable during tests instead.

The per-dialect exception lists baseline existing problems. The test fails both when a new missing reference appears and when a listed exception has been fixed but was not removed, allowing the baseline to shrink over time.

## Validation

- `cargo test -p sqruff-lib-core dialects::tests`
- `cargo test -p sqruff-lib-dialects --test dialects`
- `cargo clippy -p sqruff-lib-core --tests -- -Dwarnings`
- `cargo fmt --check`
- `git diff --check`