### PR TITLE
fix(duckdb): parse named parameters in FROM-first queries

### DIFF
--- a/crates/lib-dialects/src/duckdb.rs
+++ b/crates/lib-dialects/src/duckdb.rs
@@ -8,7 +8,8 @@ use sqruff_lib_core::parser::grammar::delimited::Delimited;
 use sqruff_lib_core::parser::grammar::sequence::{Bracketed, Sequence};
 use sqruff_lib_core::parser::lexer::Matcher;
 use sqruff_lib_core::parser::matchable::MatchableTrait;
-use sqruff_lib_core::parser::parsers::StringParser;
+use sqruff_lib_core::parser::node_matcher::NodeMatcher;
+use sqruff_lib_core::parser::parsers::{StringParser, TypedParser};
 use sqruff_lib_core::parser::segments::meta::MetaSegment;
 
 use crate::{ansi, postgres};
@@ -36,6 +37,18 @@ pub fn raw_dialect() -> Dialect {
     duckdb_dialect.add_keyword_to_set("reserved_keywords", "MACRO");
 
     duckdb_dialect.add([
+        (
+            "NamedParameterSegment".into(),
+            TypedParser::new(SyntaxKind::Variable, SyntaxKind::Parameter)
+                .to_matchable()
+                .into(),
+        ),
+        (
+            "DoubleEqualsSegment".into(),
+            StringParser::new("==", SyntaxKind::ComparisonOperator)
+                .to_matchable()
+                .into(),
+        ),
         (
             "SingleIdentifierGrammar".into(),
             one_of(vec![
@@ -144,7 +157,34 @@ pub fn raw_dialect() -> Dialect {
             .to_matchable()
             .into(),
         ),
+        (
+            "FromFirstSelectStatementSegment".into(),
+            NodeMatcher::new(SyntaxKind::SelectStatement, |_| {
+                Sequence::new(vec![
+                    Ref::new("FromClauseSegment").to_matchable(),
+                    Ref::new("SelectClauseSegment").optional().to_matchable(),
+                    Ref::new("WhereClauseSegment").optional().to_matchable(),
+                    Ref::new("GroupByClauseSegment").optional().to_matchable(),
+                    Ref::new("HavingClauseSegment").optional().to_matchable(),
+                    Ref::new("NamedWindowSegment").optional().to_matchable(),
+                    Ref::new("OrderByClauseSegment").optional().to_matchable(),
+                    Ref::new("LimitClauseSegment").optional().to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
     ]);
+
+    duckdb_dialect.insert_lexer_matchers(
+        vec![Matcher::string(
+            "double_equals",
+            "==",
+            SyntaxKind::ComparisonOperator,
+        )],
+        "equals",
+    );
 
     duckdb_dialect.insert_lexer_matchers(
         vec![Matcher::string(
@@ -154,6 +194,45 @@ pub fn raw_dialect() -> Dialect {
         )],
         "divide",
     );
+
+    duckdb_dialect.insert_lexer_matchers(
+        vec![Matcher::regex(
+            "named_parameter",
+            r"\$[a-zA-Z_][0-9a-zA-Z_]*",
+            SyntaxKind::Variable,
+        )],
+        "word",
+    );
+
+    let literal_grammar = duckdb_dialect.grammar("LiteralGrammar").copy(
+        Some(vec![Ref::new("NamedParameterSegment").to_matchable()]),
+        None,
+        None,
+        None,
+        Vec::new(),
+        false,
+    );
+    duckdb_dialect.replace_grammar("LiteralGrammar", literal_grammar);
+
+    let comparison_operator_grammar = duckdb_dialect.grammar("ComparisonOperatorGrammar").copy(
+        Some(vec![Ref::new("DoubleEqualsSegment").to_matchable()]),
+        None,
+        None,
+        None,
+        Vec::new(),
+        false,
+    );
+    duckdb_dialect.replace_grammar("ComparisonOperatorGrammar", comparison_operator_grammar);
+
+    let from_clause_terminators = duckdb_dialect.grammar("FromClauseTerminatorGrammar").copy(
+        Some(vec![Ref::keyword("SELECT").to_matchable()]),
+        None,
+        None,
+        None,
+        Vec::new(),
+        false,
+    );
+    duckdb_dialect.replace_grammar("FromClauseTerminatorGrammar", from_clause_terminators);
 
     duckdb_dialect.replace_grammar(
         "SelectClauseElementSegment",
@@ -376,6 +455,7 @@ pub fn raw_dialect() -> Dialect {
         "StatementSegment",
         postgres::statement_segment().copy(
             Some(vec![
+                Ref::new("FromFirstSelectStatementSegment").to_matchable(),
                 Ref::new("LoadStatementSegment").to_matchable(),
                 Ref::new("SummarizeStatementSegment").to_matchable(),
                 Ref::new("DescribeStatementSegment").to_matchable(),

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/from_first_named_parameters.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/from_first_named_parameters.sql
@@ -1,0 +1,19 @@
+FROM Stream.Stream
+WHERE
+    (
+        ($create_at_start IS NULL)
+        OR (create_at >= $create_at_start)
+    )
+    AND (($create_at IS NULL) OR (create_at == $create_at))
+ORDER BY channel;
+
+FROM Stream.Stream
+SELECT channel
+WHERE $stream_id IS NULL;
+
+SELECT
+    CASE
+        WHEN $target == 'stream_id' THEN stream_id
+        WHEN $target == 'name' THEN name
+    END AS mapping
+FROM Stream.Mapping;

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/from_first_named_parameters.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqruff/from_first_named_parameters.yml
@@ -1,0 +1,129 @@
+file:
+- statement:
+  - select_statement:
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: Stream
+              - dot: .
+              - naked_identifier: Stream
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - bracketed:
+          - start_bracket: (
+          - expression:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - parameter: $create_at_start
+                - keyword: IS
+                - null_literal: 'NULL'
+              - end_bracket: )
+            - binary_operator: OR
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: create_at
+                - comparison_operator:
+                  - raw_comparison_operator: '>'
+                  - raw_comparison_operator: =
+                - parameter: $create_at_start
+              - end_bracket: )
+          - end_bracket: )
+        - binary_operator: AND
+        - bracketed:
+          - start_bracket: (
+          - expression:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - parameter: $create_at
+                - keyword: IS
+                - null_literal: 'NULL'
+              - end_bracket: )
+            - binary_operator: OR
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - column_reference:
+                  - naked_identifier: create_at
+                - comparison_operator: ==
+                - parameter: $create_at
+              - end_bracket: )
+          - end_bracket: )
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: channel
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: Stream
+              - dot: .
+              - naked_identifier: Stream
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: channel
+    - where_clause:
+      - keyword: WHERE
+      - expression:
+        - parameter: $stream_id
+        - keyword: IS
+        - null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - expression:
+          - case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - parameter: $target
+                - comparison_operator: ==
+                - quoted_literal: '''stream_id'''
+              - keyword: THEN
+              - expression:
+                - column_reference:
+                  - naked_identifier: stream_id
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - parameter: $target
+                - comparison_operator: ==
+                - quoted_literal: '''name'''
+              - keyword: THEN
+              - expression:
+                - column_reference:
+                  - naked_identifier: name
+            - keyword: END
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: mapping
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: Stream
+              - dot: .
+              - naked_identifier: Mapping
+- statement_terminator: ;


### PR DESCRIPTION
Closes #2586

## What changed

- parse DuckDB `$name` prepared-statement parameters as native parameters
- parse DuckDB's `==` comparison operator
- support DuckDB `FROM`-first queries with an optional `SELECT` clause
- add a combined parser regression fixture covering the issue examples

## Root cause and impact

The DuckDB lexer and grammar did not recognize named prepared-statement parameters or `==`, and statements could not begin with a `FROM` clause. As a result, valid DuckDB queries were marked unparsable and formatting rules could not correct their indentation.

Current SQLFluff `main` (`4561940f694639b7d9976850cb13ce05e9c30c3b`) was also checked and still does not parse the reported examples cleanly, so this is implemented directly in Sqruff.

## Validation

- `cargo fmt --check`
- `cargo test -p sqruff-lib-dialects --test dialects -- duckdb`
- `cargo test -p sqruff-lib-core`
- `git diff --check`

The broader `cargo test -p sqruff-lib` command could not start in the local environment because `pyo3` could not find a Python 3 interpreter.