### PR TITLE
fix: Jinja rendered-to-source position markers

### DIFF
--- a/crates/cli-python/tests/dbt/output.stderr
+++ b/crates/cli-python/tests/dbt/output.stderr
@@ -1,18 +1,18 @@
 == [models/customers.sql] FAIL
-L:  22 | P:  16 | LT02 | Expected indent of 4 spaces. [layout.indent]
-L:  42 | P:  27 | LT02 | Expected line break and indent of 4 spaces before "on".
+L:  21 | P:   1 | LT02 | Expected indent of 4 spaces. [layout.indent]
+L:  41 | P:  21 | LT02 | Expected line break and indent of 4 spaces before "on".
                        | [layout.indent]
-L:  42 | P:  31 | LT02 | Expected indent of 12 spaces. [layout.indent]
-L:  65 | P:  41 | LT01 | Expected only single space before "customers". Found " 
+L:  42 | P:   1 | LT02 | Expected indent of 12 spaces. [layout.indent]
+L:  65 | P:  11 | LT01 | Expected only single space before "customers". Found " 
                        | ". [layout.spacing]
 == [models/disabled_model.sql] SKIP: dbt model disabled
 == [models/staging/stg_incremental.sql] FAIL
-L:  10 | P:  23 | LT12 | Files must end with a single trailing newline.
-                       | [layout.end_of_file]
 L:  14 | P:   6 | JJ01 | Jinja tags should have a single whitespace on either
                        | side: `{{ref('raw_orders')}}` -> `{{ ref('raw_orders')
                        | }}` [jinja.padding]
 L:  17 | P:  49 | JJ01 | Jinja tags should have a single whitespace on either
                        | side: `{{this}}` -> `{{ this }}` [jinja.padding]
+L:  18 | P:  12 | LT12 | Files must end with a single trailing newline.
+                       | [layout.end_of_file]
 The linter processed 8 file(s).
 All Finished

--- a/crates/cli-python/tests/python/python.stderr
+++ b/crates/cli-python/tests/python/python.stderr
@@ -1,6 +1,6 @@
 == [tests/ui_with_python/python.sql] FAIL
-L:   1 | P:  23 | LT01 | Unnecessary trailing whitespace. [layout.spacing]
-L:   1 | P:  25 | LT12 | Files must end with a single trailing newline.
+L:   1 | P:  25 | LT01 | Unnecessary trailing whitespace. [layout.spacing]
+L:   2 | P:   1 | LT12 | Files must end with a single trailing newline.
                        | [layout.end_of_file]
 The linter processed 1 file(s).
 All Finished

--- a/crates/lib-core/src/parser/lexer.rs
+++ b/crates/lib-core/src/parser/lexer.rs
@@ -893,7 +893,7 @@ fn iter_segments(
 
     // Now work out source slices, and add in template placeholders.
     for element in lexed_elements {
-        let consumed_element_length = 0;
+        let mut consumed_element_length = 0;
         let mut stashed_source_idx = None;
 
         for (idx, tfs) in templated_file_slices
@@ -949,9 +949,11 @@ fn iter_segments(
                     ));
 
                     // If it was an exact match, consume the templated element too.
-                    if element.template_slice.end == tfs.templated_slice.end {
-                        tfs_idx += 1
-                    }
+                    tfs_idx = if element.template_slice.end == tfs.templated_slice.end {
+                        idx + 1
+                    } else {
+                        idx
+                    };
                     // In any case, we're done with this element. Move on
                     break;
                 } else if element.template_slice.start >= tfs.templated_slice.end {
@@ -1005,6 +1007,7 @@ fn iter_segments(
                             ),
                             offset_slice(consumed_element_length, incremental_length).into(),
                         ));
+                        consumed_element_length += incremental_length;
                         // Continue to the next slice to process remaining whitespace
                         continue;
                     } else {
@@ -1013,7 +1016,11 @@ fn iter_segments(
                         // set the start yet, stash it too.
                         log::debug!("Spilling over literal slice.");
                         if stashed_source_idx.is_none() {
-                            stashed_source_idx = (element.template_slice.start + idx).into();
+                            let source_start = element.template_slice.start as isize + tfs_offset;
+                            stashed_source_idx =
+                                Some(source_start.try_into().unwrap_or_else(|_| {
+                                    panic!("Cannot convert {source_start} to usize")
+                                }));
                             log::debug!("Stashing a source start. {stashed_source_idx:?}");
                         }
                         // Continue to next slice regardless of whether we stashed
@@ -1060,9 +1067,11 @@ fn iter_segments(
                         ));
 
                         // If it was an exact match, consume the templated element too.
-                        if element.template_slice.end == tfs.templated_slice.end {
-                            tfs_idx += 1
-                        }
+                        tfs_idx = if element.template_slice.end == tfs.templated_slice.end {
+                            idx + 1
+                        } else {
+                            idx
+                        };
                         // Carry on to the next lexed element
                         break;
                     } else {

--- a/crates/lib-core/src/parser/markers.rs
+++ b/crates/lib-core/src/parser/markers.rs
@@ -158,7 +158,7 @@ impl PositionMarker {
     /// Return the line and position of this marker in the source.
     pub fn source_position(&self) -> (usize, usize) {
         self.templated_file
-            .get_line_pos_of_char_pos(self.templated_slice.start, true)
+            .get_line_pos_of_char_pos(self.source_slice.start, true)
     }
 
     /// Return the line and position of this marker in the source.
@@ -305,6 +305,32 @@ mod tests {
 
     use crate::parser::markers::PositionMarker;
     use crate::templaters::TemplatedFile;
+
+    #[test]
+    fn test_source_position_uses_source_slice() {
+        let templated_file = TemplatedFile::new(
+            "source line one\nsource line two".into(),
+            "test.sql".into(),
+            Some("rendered".into()),
+            Some(vec![crate::templaters::TemplatedFileSlice::new_typed(
+                crate::templaters::TemplateSliceKind::Templated,
+                16..31,
+                0..8,
+            )]),
+            Some(vec![crate::templaters::RawFileSlice::new_typed(
+                "source line one\nsource line two".into(),
+                crate::templaters::TemplateSliceKind::Templated,
+                0,
+                None,
+                None,
+            )]),
+        )
+        .unwrap();
+        let marker = PositionMarker::new(16..31, 0..8, templated_file, None, None);
+
+        assert_eq!(marker.source_position(), (2, 1));
+        assert_eq!(marker.templated_position(), (1, 1));
+    }
 
     /// Test that we can correctly infer positions from strings.
     #[test]

--- a/crates/lib/src/utils/reflow/reindent.rs
+++ b/crates/lib/src/utils/reflow/reindent.rs
@@ -1306,7 +1306,7 @@ pub fn lint_indent_points(
 
 fn source_char_len(elements: &[ReflowElement]) -> usize {
     let mut char_len = 0;
-    let mut furthest_source_idx: Option<usize> = None;
+    let mut last_source_slice = None;
 
     for seg in elements.iter().flat_map(|elem| elem.segments()) {
         if seg.is_type(SyntaxKind::Indent) || seg.is_type(SyntaxKind::Dedent) {
@@ -1317,64 +1317,28 @@ fn source_char_len(elements: &[ReflowElement]) -> usize {
             break;
         };
 
-        if seg.raw().is_empty()
-            && matches!(
-                seg.block_type(),
-                Some(
-                    BlockType::BlockStart
-                        | BlockType::BlockMid
-                        | BlockType::BlockEnd
-                        | BlockType::SkippedSource
-                )
-            )
-        {
-            continue;
-        }
-
         let source_slice = pos_marker.source_slice.clone();
         let source_str = pos_marker.source_str();
 
-        if let Some(furthest_source_idx) = furthest_source_idx
-            && source_slice.start > furthest_source_idx
-            && pos_marker.templated_file.source_str[furthest_source_idx..source_slice.start]
-                .contains('\n')
-        {
+        if let Some(pos) = source_str.find('\n') {
+            char_len += pos;
             break;
         }
 
         let slice_len = source_slice.end - source_slice.start;
-        let newline_pos = source_str.find('\n');
-        let source_end = newline_pos
-            .map(|pos| source_slice.start + pos)
-            .unwrap_or(source_slice.end);
 
-        if !seg.raw().is_empty() && slice_len == 0 {
-            char_len += seg.raw().chars().count();
-        } else if slice_len != 0 {
-            let uncovered_start = furthest_source_idx
-                .map(|idx| idx.max(source_slice.start))
-                .unwrap_or(source_slice.start);
-
-            if source_end > uncovered_start {
-                if pos_marker.is_literal() && uncovered_start == source_slice.start {
-                    // Literal slices normally map one-to-one, so retain character-aware
-                    // counting for multibyte source text.
-                    let raw = newline_pos
-                        .map(|pos| &source_str[..pos])
-                        .unwrap_or(seg.raw());
-                    char_len += raw.chars().count();
-                } else {
-                    // Templated tokens can have successively larger, overlapping source
-                    // slices. Only count the portion not covered by an earlier token.
-                    char_len += source_end - uncovered_start;
-                }
+        if Some(source_slice.clone()) != last_source_slice {
+            if !seg.raw().is_empty() && slice_len == 0 {
+                char_len += seg.raw().chars().count();
+            } else if slice_len == 0 {
+                continue;
+            } else if pos_marker.is_literal() {
+                char_len += seg.raw().chars().count();
+                last_source_slice = Some(source_slice);
+            } else {
+                char_len += source_slice.end - source_slice.start;
+                last_source_slice = Some(source_slice);
             }
-
-            furthest_source_idx = Some(furthest_source_idx.unwrap_or(source_end).max(source_end));
-        }
-
-        if newline_pos.is_some() {
-            break;
         }
     }
 

--- a/crates/lib/src/utils/reflow/reindent.rs
+++ b/crates/lib/src/utils/reflow/reindent.rs
@@ -1306,7 +1306,7 @@ pub fn lint_indent_points(
 
 fn source_char_len(elements: &[ReflowElement]) -> usize {
     let mut char_len = 0;
-    let mut last_source_slice = None;
+    let mut furthest_source_idx: Option<usize> = None;
 
     for seg in elements.iter().flat_map(|elem| elem.segments()) {
         if seg.is_type(SyntaxKind::Indent) || seg.is_type(SyntaxKind::Dedent) {
@@ -1317,28 +1317,64 @@ fn source_char_len(elements: &[ReflowElement]) -> usize {
             break;
         };
 
+        if seg.raw().is_empty()
+            && matches!(
+                seg.block_type(),
+                Some(
+                    BlockType::BlockStart
+                        | BlockType::BlockMid
+                        | BlockType::BlockEnd
+                        | BlockType::SkippedSource
+                )
+            )
+        {
+            continue;
+        }
+
         let source_slice = pos_marker.source_slice.clone();
         let source_str = pos_marker.source_str();
 
-        if let Some(pos) = source_str.find('\n') {
-            char_len += pos;
+        if let Some(furthest_source_idx) = furthest_source_idx
+            && source_slice.start > furthest_source_idx
+            && pos_marker.templated_file.source_str[furthest_source_idx..source_slice.start]
+                .contains('\n')
+        {
             break;
         }
 
         let slice_len = source_slice.end - source_slice.start;
+        let newline_pos = source_str.find('\n');
+        let source_end = newline_pos
+            .map(|pos| source_slice.start + pos)
+            .unwrap_or(source_slice.end);
 
-        if Some(source_slice.clone()) != last_source_slice {
-            if !seg.raw().is_empty() && slice_len == 0 {
-                char_len += seg.raw().chars().count();
-            } else if slice_len == 0 {
-                continue;
-            } else if pos_marker.is_literal() {
-                char_len += seg.raw().chars().count();
-                last_source_slice = Some(source_slice);
-            } else {
-                char_len += source_slice.end - source_slice.start;
-                last_source_slice = Some(source_slice);
+        if !seg.raw().is_empty() && slice_len == 0 {
+            char_len += seg.raw().chars().count();
+        } else if slice_len != 0 {
+            let uncovered_start = furthest_source_idx
+                .map(|idx| idx.max(source_slice.start))
+                .unwrap_or(source_slice.start);
+
+            if source_end > uncovered_start {
+                if pos_marker.is_literal() && uncovered_start == source_slice.start {
+                    // Literal slices normally map one-to-one, so retain character-aware
+                    // counting for multibyte source text.
+                    let raw = newline_pos
+                        .map(|pos| &source_str[..pos])
+                        .unwrap_or(seg.raw());
+                    char_len += raw.chars().count();
+                } else {
+                    // Templated tokens can have successively larger, overlapping source
+                    // slices. Only count the portion not covered by an earlier token.
+                    char_len += source_end - uncovered_start;
+                }
             }
+
+            furthest_source_idx = Some(furthest_source_idx.unwrap_or(source_end).max(source_end));
+        }
+
+        if newline_pos.is_some() {
+            break;
         }
     }
 

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -724,9 +724,9 @@ test_pass_window_function:
         ) as rnk
     from foo
 
-test_pass_jinja_block_source_line_length:
+test_jinja_block_source_line_length:
   # https://github.com/quarylabs/sqruff/issues/3122
-  pass_str: |
+  fail_str: |
     with
         totals as (
             select record_id, sum(metric_value) as total_value
@@ -744,13 +744,10 @@ test_pass_jinja_block_source_line_length:
         {% endif %}
         totals.total_value
     from base
-    inner join {{ ref("region_lookup") }} as region_lookup
-        on base.region_code = region_lookup.region_id
-    left join concept_lookup as concept_lookup
-        on base.record_id = concept_lookup.record_id
+    inner join {{ ref("region_lookup") }} as region_lookup on base.region_code = region_lookup.region_id
+    left join concept_lookup as concept_lookup on base.record_id = concept_lookup.record_id
     {% if var("feature_flag_enabled", true) %}
-        left join {{ ref("optional_lookup") }} as optional_lookup
-            on base.optional_code = optional_lookup.optional_code
+        left join {{ ref("optional_lookup") }} as optional_lookup on base.optional_code = optional_lookup.optional_code
     {% endif %}
     left join totals as totals on base.record_id = totals.record_id
     where base.created_at >= to_timestamp_ntz('2012-08-06')
@@ -764,6 +761,9 @@ test_pass_jinja_block_source_line_length:
       layout.long_lines:
         ignore_comment_clauses: true
         ignore_comment_lines: true
+  line_numbers:
+    - 18
+    - 21
 
 test_fix_where_on_separate_line:
   # https://github.com/quarylabs/sqruff/issues/1986

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -724,6 +724,47 @@ test_pass_window_function:
         ) as rnk
     from foo
 
+test_pass_jinja_block_source_line_length:
+  # https://github.com/quarylabs/sqruff/issues/3122
+  pass_str: |
+    with
+        totals as (
+            select record_id, sum(metric_value) as total_value
+            from {{ ref("upstream_metrics") }}
+            where endswith(year_code, '1')
+            group by record_id
+        )
+
+    select
+        base.*,
+        region_lookup.* exclude (region_id),
+        concept_lookup.concept_name,
+        {% if var("feature_flag_enabled", true) %}
+            optional_lookup.optional_attribute as selected_optional_attribute,
+        {% endif %}
+        totals.total_value
+    from base
+    inner join {{ ref("region_lookup") }} as region_lookup
+        on base.region_code = region_lookup.region_id
+    left join concept_lookup as concept_lookup
+        on base.record_id = concept_lookup.record_id
+    {% if var("feature_flag_enabled", true) %}
+        left join {{ ref("optional_lookup") }} as optional_lookup
+            on base.optional_code = optional_lookup.optional_code
+    {% endif %}
+    left join totals as totals on base.record_id = totals.record_id
+    where base.created_at >= to_timestamp_ntz('2012-08-06')
+    order by base.record_id
+  configs:
+    core:
+      dialect: snowflake
+      templater: jinja
+      max_line_length: 88
+    rules:
+      layout.long_lines:
+        ignore_comment_clauses: true
+        ignore_comment_lines: true
+
 test_fix_where_on_separate_line:
   # https://github.com/quarylabs/sqruff/issues/1986
   # When WHERE is on its own line, the conditions start on a new line


### PR DESCRIPTION
## Summary

- keep the Rust lexer’s template-slice cursor aligned with the slice actually consumed
- carry split-whitespace offsets forward and use SQLFluff’s source/templated offset when a token spans slices
- calculate source line positions from `source_slice`, not `templated_slice`
- add the complete Snowflake/Jinja reproduction from #3122 and assert the same LT05 lines as SQLFluff

## Root cause

Sqruff’s Rust port of SQLFluff’s lexer lost state while translating the inner template-slice loop:

- `tfs_idx` advanced from its old value instead of the slice index actually consumed
- `consumed_element_length` was not updated after split whitespace
- a stashed source position used the template-slice array index instead of `source_start - templated_start`

This produced cumulative mappings such as `471..497`, `471..498`, … `471..561`, so LT05 counted one rendered line as hundreds of source characters.

Separately, `PositionMarker::source_position()` looked up the source line using `templated_slice.start`. A correctly mapped source token at offset 460 was therefore reported at the templated offset’s source line (line 14) instead of line 18.

## SQLFluff parity

SQLFluff 4.2.2 reports only the genuinely long source lines in the reproduction:

- line 18: `100 > 88`
- line 21: `115 > 88`

With this change, Sqruff reports those same two lines and no violation on the 74-character line 14. LT05’s source-length implementation remains unchanged from SQLFluff.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sqruff-lib-core`
- `cargo test -p sqruff-lib --all-features`
- direct reproduction with SQLFluff 4.2.2

Fixes #3122