### PR TITLE
fix(postgres): gate extension keywords by config

### DIFF
--- a/crates/lib-dialects/src/postgres.rs
+++ b/crates/lib-dialects/src/postgres.rs
@@ -18,7 +18,7 @@ use sqruff_lib_core::parser::segments::meta::MetaSegment;
 use sqruff_lib_core::parser::types::ParseMode;
 
 use super::ansi;
-use super::postgres_keywords::POSTGRES_POSTGIS_DATATYPE_KEYWORDS;
+use super::postgres_keywords::{POSTGRES_PGVECTOR_KEYWORDS, POSTGRES_POSTGIS_DATATYPE_KEYWORDS};
 use crate::postgres_keywords::{get_keywords, postgres_keywords};
 use sqruff_lib_core::dialects::init::DialectConfig;
 use sqruff_lib_core::value::Value;
@@ -50,6 +50,12 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     }
 
     if dialect_config.pgvector {
+        postgres.sets_mut("unreserved_keywords").extend(
+            POSTGRES_PGVECTOR_KEYWORDS
+                .iter()
+                .map(|(keyword, _)| *keyword),
+        );
+
         postgres.replace_grammar("DatatypeSegment", build_datatype_segment_grammar(true));
 
         // Add pgvector distance operators: <-> (L2), <=> (cosine), <+> (L1), <#> (inner product)
@@ -78,6 +84,34 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
     }
 
     postgres.config(|dialect| dialect.expand())
+}
+
+#[cfg(test)]
+mod tests {
+    use hashbrown::HashMap;
+    use sqruff_lib_core::value::Value;
+
+    use super::dialect;
+
+    const PGVECTOR_KEYWORDS: [&str; 3] = ["VECTOR", "HALFVEC", "SPARSEVEC"];
+
+    #[test]
+    fn pgvector_keywords_follow_extension_config() {
+        let postgres = dialect(None);
+        let unreserved_keywords = postgres.sets("unreserved_keywords");
+
+        for keyword in PGVECTOR_KEYWORDS {
+            assert!(!unreserved_keywords.contains(keyword));
+        }
+
+        let config = Value::Map(HashMap::from([("pgvector".into(), Value::Bool(true))]));
+        let postgres_with_pgvector = dialect(Some(&config));
+        let unreserved_keywords = postgres_with_pgvector.sets("unreserved_keywords");
+
+        for keyword in PGVECTOR_KEYWORDS {
+            assert!(unreserved_keywords.contains(keyword));
+        }
+    }
 }
 
 /// Build the ComparisonOperatorGrammar, optionally including pgvector operators.

--- a/crates/lib-dialects/src/postgres_keywords.rs
+++ b/crates/lib-dialects/src/postgres_keywords.rs
@@ -1029,7 +1029,6 @@ pub(crate) fn postgres_keywords() -> Vec<(&'static str, &'static str)> {
         POSTGRES_NONDOCS_KEYWORDS,
         POSTGRES_POSTGIS_DATATYPE_KEYWORDS,
         POSTGRES_POSTGIS_OTHER_KEYWORDS,
-        POSTGRES_PGVECTOR_KEYWORDS,
     ])
 }
 


### PR DESCRIPTION
## Summary

- remove pgvector keywords from PostgreSQL's unconditional base keyword set
- register `VECTOR`, `HALFVEC`, and `SPARSEVEC` only when the `pgvector` dialect extension is enabled
- add regression coverage for both disabled and enabled configurations

## Why

PostgreSQL extension keywords should follow the same configuration gate as their extension grammar and operators. Previously, pgvector's keywords were treated as enabled even under the default PostgreSQL configuration.

## Impact

Default PostgreSQL parsing no longer treats pgvector-specific names as keywords. Enabling `pgvector = true` preserves the existing pgvector datatype and operator behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sqruff-lib-dialects --all-features --lib pgvector_keywords_follow_extension_config`
- `cargo test -p sqruff-lib-dialects --all-features --test dialects postgres`
- `bazelisk test //...` (34/34 targets passed)

Closes #2406