### PR TITLE
chore: advance sqlfluff-sha past quoted ST09 fix (#5087)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-fdf2f68ab3bb3f5352f1cbbe218f1938840650ea
+cd52dcaaf570b3a36edce2bccefcb032d5abc47c


### PR DESCRIPTION
## Summary
- Advance the SQLFluff compatibility marker by one first-parent commit.
- Record SQLFluff ST09 quoted-identifier handling as already present in sqruff code and fixtures.

Ported from SQLFluff cd52dcaaf570b3a36edce2bccefcb032d5abc47c
https://github.com/sqlfluff/sqlfluff/pull/5087
https://github.com/sqlfluff/sqlfluff/commit/cd52dcaaf570b3a36edce2bccefcb032d5abc47c