### PR TITLE
ci: validate sqlfluff sha in merge queue

### DIFF
--- a/.github/workflows/sqlfluff-sha-advance.yml
+++ b/.github/workflows/sqlfluff-sha-advance.yml
@@ -1,8 +1,9 @@
 on:
   pull_request:
-    paths:
-      - .sqlfluff-sha
+  merge_group:
 name: SQLFluff SHA Advance Check
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,13 +17,13 @@ jobs:
           fetch-depth: 0
       - name: Validate SHA advance
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          # The SHA on the PR's base branch (before this change).
+          # The SQLFluff SHA before and after this PR or merge-queue entry.
           OLD=$(git show "${BASE_SHA}:.sqlfluff-sha" | tr -d '[:space:]')
-          # The SHA proposed by this PR.
-          NEW=$(tr -d '[:space:]' < .sqlfluff-sha)
+          NEW=$(git show "${HEAD_SHA}:.sqlfluff-sha" | tr -d '[:space:]')
           echo "Base .sqlfluff-sha: ${OLD}"
-          echo "PR   .sqlfluff-sha: ${NEW}"
+          echo "Head .sqlfluff-sha: ${NEW}"
           ./.hacking/scripts/check_sqlfluff_sha_advance.sh "$OLD" "$NEW"

--- a/.github/workflows/sqlfluff-sha-advance.yml
+++ b/.github/workflows/sqlfluff-sha-advance.yml
@@ -18,12 +18,15 @@ jobs:
       - name: Validate SHA advance
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          # For pull requests, github.sha is the synthetic merge commit, so an
+          # unrelated stale branch inherits the current base branch's marker.
+          # Merge groups expose their candidate merge explicitly as head_sha.
+          RESULT_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          # The SQLFluff SHA before and after this PR or merge-queue entry.
+          # The SQLFluff SHA before and after the candidate merge.
           OLD=$(git show "${BASE_SHA}:.sqlfluff-sha" | tr -d '[:space:]')
-          NEW=$(git show "${HEAD_SHA}:.sqlfluff-sha" | tr -d '[:space:]')
+          NEW=$(git show "${RESULT_SHA}:.sqlfluff-sha" | tr -d '[:space:]')
           echo "Base .sqlfluff-sha: ${OLD}"
-          echo "Head .sqlfluff-sha: ${NEW}"
+          echo "Result .sqlfluff-sha: ${NEW}"
           ./.hacking/scripts/check_sqlfluff_sha_advance.sh "$OLD" "$NEW"


### PR DESCRIPTION
## Summary

- run the SQLFluff SHA advance validator for pull requests and merge groups
- compare the explicit event base and head commits, including stacked PR bases
- run without path filtering so the check can report for every required-check candidate
- grant only read access to repository contents

## Why

The SHA-only detector already runs in merge groups and skips expensive jobs, but the dedicated one-commit advance validator previously ran only for pull requests. This left merge-queue results without validation.

## Verification

- replayed a current stacked-PR transition successfully
- replayed a real merge-queue transition successfully
- confirmed an unchanged marker succeeds for unrelated changes
- confirmed a two-commit jump is rejected with the expected next SHA
- ran Prettier and git diff --check

## Follow-up

After this workflow is present on main, add Validate .sqlfluff-sha advances one commit to the required status checks for main.