### PR TITLE
ci: skip unaffected binary builds with bazel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,13 +89,92 @@ jobs:
             git diff MODULE.bazel.lock
             exit 1
           fi
+  binary-affected:
+    name: Detect affected CLI binary
+    runs-on: ubuntu-latest
+    needs: sqlfluff-sha-only
+    if: github.event_name != 'push'
+    outputs:
+      binary-build-needed: ${{ steps.detect.outputs.binary-build-needed }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        if: needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only != 'true'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # ratchet:bazel-contrib/setup-bazel@0.19.0
+        if: needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only != 'true'
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-affected
+          repository-cache: true
+          cache-save: false
+      - name: Detect whether the CLI binary is affected
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          SQLFLUFF_SHA_ONLY: ${{ needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only }}
+          BAZEL_DIFF_SHA256: d7bf5c6f74b582fa54b6a6da5b23f7d0e816a4c71af984645ec2d71aa8c37631
+          BAZEL_DIFF_URL: https://github.com/Tinder/bazel-diff/releases/download/v42.0.0/bazel-diff-rust-linux-amd64
+        run: |
+          set -euo pipefail
+
+          report() {
+            echo "binary-build-needed=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [ "${SQLFLUFF_SHA_ONLY}" = "true" ]; then
+            echo "Only .sqlfluff-sha changed; the CLI binary is unaffected."
+            report false
+          fi
+
+          BAZEL_DIFF="${RUNNER_TEMP}/bazel-diff"
+          if ! curl --fail --location --silent --show-error \
+            "${BAZEL_DIFF_URL}" --output "${BAZEL_DIFF}"; then
+            echo "::warning::Could not download bazel-diff; building binaries as a fallback."
+            report true
+          fi
+
+          if ! echo "${BAZEL_DIFF_SHA256}  ${BAZEL_DIFF}" | sha256sum --check --status; then
+            echo "::warning::bazel-diff checksum mismatch; building binaries as a fallback."
+            report true
+          fi
+          chmod +x "${BAZEL_DIFF}"
+
+          if AFFECTED=$(BAZEL_DIFF="${BAZEL_DIFF}" BAZEL="$(command -v bazelisk)" \
+            ./.hacking/scripts/bazel_target_affected.sh \
+            "${BASE_SHA}" "${HEAD_SHA}" //crates/cli:sqruff \
+            ':(top)Cargo.lock' \
+            ':(top)Cargo.toml' \
+            ':(top)rust-toolchain' \
+            ':(top)rust-toolchain.toml' \
+            ':(glob,top).cargo/**' \
+            ':(glob,top)crates/**/Cargo.toml' \
+            ':(glob,top)crates/**/build.rs' \
+            ':(glob,top).github/actions/build-binaries/**' \
+            ':(top).hacking/scripts/bazel_target_affected.sh' \
+            ':(top).github/workflows/pr.yml'); then
+            if [ "${AFFECTED}" = "true" ]; then
+              echo "The CLI binary or its Cargo build machinery is affected; building every binary target."
+            else
+              echo "The CLI binary and its Cargo build machinery are unaffected; using no-op matrix jobs."
+            fi
+            report "${AFFECTED}"
+          fi
+
+          echo "::warning::Bazel affectedness detection failed; building binaries as a fallback."
+          report true
   build-binaries:
     name: Build binaries for all platforms
     # Master pushes only need to refresh the Bazel cache; skip the binary
     # matrix there since it does not use that cache.
-    needs: sqlfluff-sha-only
+    needs: binary-affected
     if: github.event_name != 'push'
-    runs-on: ${{ matrix.platform.os }}
+    # Preserve every required matrix check, but use a Linux runner for the
+    # inexpensive no-op path instead of allocating macOS and Windows runners.
+    runs-on: ${{ needs.binary-affected.outputs.binary-build-needed == 'true' && matrix.platform.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -121,13 +200,13 @@ jobs:
             target: aarch64-apple-darwin
             bin: sqruff
     steps:
-      - name: Skip build for .sqlfluff-sha-only change
-        if: needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only == 'true'
-        run: echo "No binary build is needed when only .sqlfluff-sha changes."
+      - name: Skip unaffected binary build
+        if: needs.binary-affected.outputs.binary-build-needed != 'true'
+        run: echo "The CLI binary and its Cargo build machinery are unchanged from the comparison base."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
-        if: needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only != 'true'
+        if: needs.binary-affected.outputs.binary-build-needed == 'true'
       - uses: ./.github/actions/build-binaries
-        if: needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only != 'true'
+        if: needs.binary-affected.outputs.binary-build-needed == 'true'
         with:
           package: false
           publish: false

--- a/.hacking/scripts/bazel_target_affected.sh
+++ b/.hacking/scripts/bazel_target_affected.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Reports whether a Bazel target is affected between two Git revisions.
+#
+# Usage: bazel_target_affected.sh <base-sha> <head-sha> <target> [pathspec ...]
+#
+# Prints "true" or "false" to stdout. Tool output is sent to stderr so callers
+# can safely capture the result. BAZEL_DIFF and BAZEL may override the binaries
+# used for target hashing and Bazel queries. A change matching any optional Git
+# pathspec is treated as affecting the target without consulting Bazel. This is
+# useful for build inputs which the target graph does not model.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+    echo "Usage: $0 <base-sha> <head-sha> <target> [pathspec ...]" >&2
+    exit 2
+fi
+
+BASE_SHA=$1
+HEAD_SHA=$2
+TARGET=$3
+shift 3
+ALWAYS_AFFECTING_PATHS=("$@")
+BAZEL_DIFF=${BAZEL_DIFF:-bazel-diff}
+BAZEL=${BAZEL:-bazelisk}
+
+for sha in "$BASE_SHA" "$HEAD_SHA"; do
+    if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+        echo "ERROR: ${sha} is not an available Git commit" >&2
+        exit 1
+    fi
+done
+
+if [ "${#ALWAYS_AFFECTING_PATHS[@]}" -gt 0 ]; then
+    ALWAYS_AFFECTING_CHANGES=$(git diff --name-only --no-renames \
+        "$BASE_SHA" "$HEAD_SHA" -- "${ALWAYS_AFFECTING_PATHS[@]}")
+    if [ -n "$ALWAYS_AFFECTING_CHANGES" ]; then
+        echo "Changed build inputs not modeled by Bazel:" >&2
+        printf '%s\n' "$ALWAYS_AFFECTING_CHANGES" >&2
+        echo true
+        exit 0
+    fi
+fi
+
+if ! BAZEL_DIFF=$(command -v "$BAZEL_DIFF"); then
+    echo "ERROR: bazel-diff executable not found" >&2
+    exit 1
+fi
+
+if ! BAZEL=$(command -v "$BAZEL"); then
+    echo "ERROR: Bazel executable not found" >&2
+    exit 1
+fi
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/sqruff-bazel-affected.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+TEMP_WORKSPACE="${TEMP_DIR}/workspace"
+MODIFIED_FILES="${TEMP_DIR}/modified-files.txt"
+BASE_HASHES="${TEMP_DIR}/base-hashes.json"
+HEAD_HASHES="${TEMP_DIR}/head-hashes.json"
+IMPACTED_TARGETS="${TEMP_DIR}/impacted-targets.txt"
+
+# Disable rename collapsing so both sides of a rename are included. The
+# modified-file list must be a superset for bazel-diff's content-hash shortcut.
+git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" > "$MODIFIED_FILES"
+
+# Hash both revisions in one temporary checkout. Reusing its Bazel output base
+# lets the second query incrementally update the first graph instead of starting
+# a second Bazel server and resolving every external repository again.
+git clone --quiet --shared --no-checkout "$(git rev-parse --show-toplevel)" "$TEMP_WORKSPACE"
+git -C "$TEMP_WORKSPACE" reset --hard --quiet "$BASE_SHA"
+"$BAZEL_DIFF" generate-hashes \
+    --workspacePath "$TEMP_WORKSPACE" \
+    --bazelPath "$BAZEL" \
+    --excludeExternalTargets \
+    --modified-filepaths "$MODIFIED_FILES" \
+    "$BASE_HASHES" >&2
+
+git -C "$TEMP_WORKSPACE" reset --hard --quiet "$HEAD_SHA"
+"$BAZEL_DIFF" generate-hashes \
+    --workspacePath "$TEMP_WORKSPACE" \
+    --bazelPath "$BAZEL" \
+    --excludeExternalTargets \
+    --modified-filepaths "$MODIFIED_FILES" \
+    "$HEAD_HASHES" >&2
+
+"$BAZEL_DIFF" get-impacted-targets \
+    --workspacePath "$TEMP_WORKSPACE" \
+    --bazelPath "$BAZEL" \
+    --startingHashes "$BASE_HASHES" \
+    --finalHashes "$HEAD_HASHES" \
+    --output "$IMPACTED_TARGETS" >&2
+
+echo "Impacted Bazel targets:" >&2
+sed -n '1,200p' "$IMPACTED_TARGETS" >&2
+
+if grep -Fxq -- "$TARGET" "$IMPACTED_TARGETS"; then
+    echo true
+else
+    echo false
+fi


### PR DESCRIPTION
## Summary

- use Bazel target hashing to determine whether `//crates/cli:sqruff` is affected between the event base and head commits
- preserve every required binary matrix check while moving unaffected macOS and Windows entries to Ubuntu no-op jobs
- build all binaries as a fail-safe if affected-target detection fails
- use explicit event commits so the comparison works for stacked pull requests and merge groups

## Why

Changes outside the CLI target graph currently allocate every binary runner, including macOS and Windows machines. Bazel can identify whether the CLI target changed before those expensive runners are selected.

## Verification

- `bazelisk test //:shellcheck //:prettier_check //:ratchet_check --test_output=errors`
- confirmed a workflow-only delta reports the CLI target as unaffected
- confirmed a historical transitive Rust change reports the CLI target as affected
- `git diff --check`

## Stack

Built on top of #3246.