### PR TITLE
chore: advance sqlfluff-sha for CI comment workflow update (#5201)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-394a95a90e40399fac00ef1b8edc029fbb57d1f2
+b6c74836b2069edd64fbd5df6defbc6e32fff1de


### PR DESCRIPTION
> Stacked on sqruff #3275. Merge #3275 first.
>
> Base PR: https://github.com/quarylabs/sqruff/pull/3275

## Summary
- Advance `.sqlfluff-sha` to track SQLFluff's `ci-pr-comments.yml` workflow tweak (use `await fs.readFile` instead of the synchronous read, and coerce to `Number` at the call site).
- This is a change to SQLFluff's own GitHub Actions tooling with no equivalent in sqruff, so no code or fixture changes are required — a skip-only SHA advance.

Ported from SQLFluff b6c74836b2069edd64fbd5df6defbc6e32fff1de
https://github.com/sqlfluff/sqlfluff/pull/5201
https://github.com/sqlfluff/sqlfluff/commit/b6c74836b2069edd64fbd5df6defbc6e32fff1de

---

Note: `bazel test //...` could not be run in this environment — the org egress policy blocks the Bazel module registry (`bcr.bazel.build` returns 403 through the proxy), so Bazel cannot fetch its dependencies. The change touches only the `.sqlfluff-sha` tracking file (no Rust code or fixtures), and CI on this PR runs the full Bazel suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCv5CjRVWzqWa3a7Himaue)_