### PR TITLE
feat(exasol): type password literals as password_literal (#5205)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-ec514ebbdb411fd1f65f1e167c1855b4943c9dfc
+715d184bdc980d1cb519fff33ea6ded430deaadc

--- a/crates/lib-core/src/dialects/syntax.rs
+++ b/crates/lib-core/src/dialects/syntax.rs
@@ -879,6 +879,7 @@ pub enum SyntaxKind {
     PartitionbyClause,
     PartitionedBySegment,
     PasswordAuth,
+    PasswordLiteral,
     PasswordPolicyOptions,
     PasswordPolicyReference,
     PathSegment,

--- a/crates/lib-dialects/src/exasol.rs
+++ b/crates/lib-dialects/src/exasol.rs
@@ -126,6 +126,14 @@ pub fn raw_dialect() -> Dialect {
 
     exasol.add([
         (
+            // NOTE: The purpose of the password_literal is that it has different layout
+            // rules. It assumes no whitespace on either side.
+            "PasswordLiteralSegment".into(),
+            TypedParser::new(SyntaxKind::DoubleQuote, SyntaxKind::PasswordLiteral)
+                .to_matchable()
+                .into(),
+        ),
+        (
             "UDFParameterDotSyntaxSegment".into(),
             TypedParser::new(SyntaxKind::UdfParamDotSyntax, SyntaxKind::Identifier)
                 .to_matchable()
@@ -2932,7 +2940,7 @@ pub fn raw_dialect() -> Dialect {
             NodeMatcher::new(SyntaxKind::PasswordAuth, |_| {
                 Sequence::new(vec![
                     Ref::keyword("BY").to_matchable(),
-                    Ref::new("QuotedIdentifierSegment").to_matchable(),
+                    Ref::new("PasswordLiteralSegment").to_matchable(),
                 ])
                 .to_matchable()
             })
@@ -2944,7 +2952,7 @@ pub fn raw_dialect() -> Dialect {
             NodeMatcher::new(SyntaxKind::PasswordAuth, |_| {
                 Sequence::new(vec![
                     Ref::keyword("REPLACE").to_matchable(),
-                    Ref::new("QuotedIdentifierSegment").to_matchable(),
+                    Ref::new("PasswordLiteralSegment").to_matchable(),
                 ])
                 .to_matchable()
             })

--- a/crates/lib-dialects/test/fixtures/dialects/exasol/sqlfluff/alter_user.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/exasol/sqlfluff/alter_user.yml
@@ -8,10 +8,10 @@ file:
     - keyword: IDENTIFIED
     - password_auth:
       - keyword: BY
-      - quoted_identifier: '"h22_xhz"'
+      - password_literal: '"h22_xhz"'
     - password_auth:
       - keyword: REPLACE
-      - quoted_identifier: '"h12_xhz"'
+      - password_literal: '"h12_xhz"'
 - statement_terminator: ;
 - statement:
   - alter_user_statement:
@@ -22,7 +22,7 @@ file:
     - keyword: IDENTIFIED
     - password_auth:
       - keyword: BY
-      - quoted_identifier: '"h12_xhz"'
+      - password_literal: '"h12_xhz"'
 - statement_terminator: ;
 - statement:
   - alter_user_statement:

--- a/crates/lib-dialects/test/fixtures/dialects/exasol/sqlfluff/create_user.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/exasol/sqlfluff/create_user.yml
@@ -8,7 +8,7 @@ file:
     - keyword: IDENTIFIED
     - password_auth:
       - keyword: BY
-      - quoted_identifier: '"h12_xhz"'
+      - password_literal: '"h12_xhz"'
 - statement_terminator: ;
 - statement:
   - create_user_statement:

--- a/crates/lsp/src/semantic.rs
+++ b/crates/lsp/src/semantic.rs
@@ -103,6 +103,7 @@ pub(crate) fn classify(kind: SyntaxKind) -> Option<Highlight> {
         | DateConstructorLiteral
         | FileLiteral
         | DollarLiteral
+        | PasswordLiteral
         | AtSignLiteral => Highlight::String,
 
         // Comments.


### PR DESCRIPTION
> Stacked on sqruff #3280. Merge #3280 first.
> Base PR: https://github.com/quarylabs/sqruff/pull/3280

## Summary
- Add a `PasswordLiteral` syntax kind and an exasol `PasswordLiteralSegment` (a `double_quote`-typed parser) so `CREATE`/`ALTER USER ... IDENTIFIED BY`/`REPLACE` passwords parse as `password_literal` instead of `quoted_identifier`, matching SQLFluff's dedicated layout rules for password literals.
- Regenerate the affected exasol parse fixtures (`alter_user.yml`, `create_user.yml`) and classify the new kind as a string highlight in the LSP.
- The remaining parts of upstream #5205 — layout config for `dot`/`colon_delimiter`/`path_segment`/`sql_conf_option`/`sqlcmd_operator`/`pattern_expression`, the RF06 `execute_as_clause` ignore, the `within == "any"` respace handling, and the ansi/hive/snowflake/sparksql/tsql grammar and rule-test changes — were already present in sqruff, so this commit only ports the outstanding exasol piece and advances `.sqlfluff-sha`.

Ported from SQLFluff 715d184bdc980d1cb519fff33ea6ded430deaadc
https://github.com/sqlfluff/sqlfluff/pull/5205
https://github.com/sqlfluff/sqlfluff/commit/715d184bdc980d1cb519fff33ea6ded430deaadc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe458xCvivbSrdXo1PqGjK)_