### PR TITLE
refactor: finish GreedyUntil removal (#5263)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-8e14e5ab3f7afe1aa5de370a269dfc08c4452283
+72dde7ded4d58a5de418f5ccdba881af6adfdd38

--- a/crates/lib-core/src/parser/grammar.rs
+++ b/crates/lib-core/src/parser/grammar.rs
@@ -185,6 +185,7 @@ impl MatchableTrait for Ref {
 pub struct Anything {
     cache_key: MatchableCacheKey,
     terminators: Vec<Matchable>,
+    reset_terminators: bool,
 }
 
 impl PartialEq for Anything {
@@ -205,11 +206,17 @@ impl Anything {
         Self {
             cache_key: next_matchable_cache_key(),
             terminators: Vec::new(),
+            reset_terminators: false,
         }
     }
 
     pub fn terminators(mut self, terminators: Vec<Matchable>) -> Self {
         self.terminators = terminators;
+        self
+    }
+
+    pub fn reset_terminators(mut self) -> Self {
+        self.reset_terminators = true;
         self
     }
 }
@@ -234,7 +241,9 @@ impl MatchableTrait for Anything {
         }
 
         let mut terminators = self.terminators.clone();
-        terminators.extend_from_slice(&parse_context.terminators);
+        if !self.reset_terminators {
+            terminators.extend_from_slice(&parse_context.terminators);
+        }
 
         greedy_match(segments, idx, parse_context, &terminators, false, true)
     }

--- a/crates/lib-dialects/src/exasol.rs
+++ b/crates/lib-dialects/src/exasol.rs
@@ -4370,6 +4370,7 @@ pub fn raw_dialect() -> Dialect {
                     .terminators(vec![
                         Ref::new("FunctionScriptTerminatorSegment").to_matchable(),
                     ])
+                    .reset_terminators()
                     .to_matchable()
             })
             .to_matchable()


### PR DESCRIPTION
> Stacked on sqruff #3322. Merge #3322 first.

Base: https://github.com/quarylabs/sqruff/pull/3322

## Summary
- let `Anything` reset inherited parser terminators
- use that behavior for Exasol script bodies so only the script terminator ends their content
- advance `.sqlfluff-sha` to SQLFluff commit [72dde7ded](https://github.com/sqlfluff/sqlfluff/commit/72dde7ded4d58a5de418f5ccdba881af6adfdd38) / [#5263](https://github.com/sqlfluff/sqlfluff/pull/5263)

## Validation
- exact first-parent SHA advance check
- `cargo fmt --check`
- focused Exasol dialect fixtures
- `cargo build`
- `cargo test`
- `bazelisk test --test_output=errors //:verify_sqlfluff_sha`
- full Bazel baseline on the preceding code layer: non-browser checks green; local Playwright targets blocked by missing host libraries