### PR TITLE
chore: advance SQLFluff SHA for Ruff import sorting (#5289)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-4d5af85abe6a8da0b4c8aae3d22e799af08d37d9
+eb6b96ba64a2d9968353fc54a6c8a1f07debd4fa


### PR DESCRIPTION
> Stacked on sqruff #3341. Merge #3341 first.
>
> Base PR: https://github.com/quarylabs/sqruff/pull/3341

## Summary
- Advance `.sqlfluff-sha` over SQLFluff's Ruff/isort migration.
- The upstream changes are Python lint configuration and mechanical import ordering; Sqruff's Rust workspace has no corresponding code delta.

## Validation
- `cargo build`
- `cargo test`
- `bazelisk test //:verify_sqlfluff_sha`

Ported from SQLFluff eb6b96ba64a2d9968353fc54a6c8a1f07debd4fa
https://github.com/sqlfluff/sqlfluff/pull/5289
https://github.com/sqlfluff/sqlfluff/commit/eb6b96ba64a2d9968353fc54a6c8a1f07debd4fa
