### PR TITLE
chore: advance SQLFluff SHA for UUID int comparison optimization (#5332)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-7299f23a4f2f95c72d62ebf1f7adea9bd465aafe
+84a54fc827ab5be654c58ae903ec65eaaa2a4a3d


### PR DESCRIPTION
> Stacked on sqruff #3375. Merge #3375 first.
>
> Base PR: https://github.com/quarylabs/sqruff/pull/3375

## Summary
- Upstream [#5332](https://github.com/sqlfluff/sqlfluff/pull/5332) stores `uuid4().int` instead of the `UUID` object on segments so that identity comparisons operate on plain integers — a Python-internal micro-optimization.
- Sqruff has no equivalent construct: segments are identified by a `u64` `hash_value()` (derived from type, raw text, and source position) combined with `Rc` pointer identity, so there is no `UUID` object to unwrap into an int. The optimization is already inherent to sqruff's design.
- No Rust code change is required; this PR only advances `.sqlfluff-sha` so the port stack continues in upstream order.

Ported from SQLFluff 84a54fc827ab5be654c58ae903ec65eaaa2a4a3d
https://github.com/sqlfluff/sqlfluff/pull/5332
https://github.com/sqlfluff/sqlfluff/commit/84a54fc827ab5be654c58ae903ec65eaaa2a4a3d

---
_Generated by [Claude Code](https://claude.ai/code/session_016rzH6B1huyGrEfX9XQdRqJ)_