### PR TITLE
chore: advance SQLFluff SHA for annotation docs (#5450)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-cae3f932ca6b3be21b06fec5e370d4b7bbb50c50
+44143cfdad24d17585f68cbc4e7f57aad0d6a7fa


### PR DESCRIPTION
> Stacked on sqruff #3433. Merge #3433 first.

## Summary
- Advance `.sqlfluff-sha` by exactly one first-parent SQLFluff commit.
- Confirm the upstream patch only updates SQLFluff documentation about GitHub annotation limits.
- No sqruff code, fixture, or generated-documentation change is needed.
- Local validation: exact SHA progression and `bazelisk test //...` with all 34 tests passing.

## Upstream
- https://github.com/sqlfluff/sqlfluff/pull/5450
- https://github.com/sqlfluff/sqlfluff/commit/44143cfdad24d17585f68cbc4e7f57aad0d6a7fa