### PR TITLE
feat: support DuckDB non-standard joins (#5544)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-a524ba9cb1e1f2716dd591a33aa46b3b64b19a4a
+c37deca8cbdcefacfae6345f68a56ff349ab5942

--- a/crates/lib-dialects/src/ansi.rs
+++ b/crates/lib-dialects/src/ansi.rs
@@ -1026,10 +1026,16 @@ pub fn raw_dialect() -> Dialect {
             .into(),
         ),
         (
+            // Extensible in individual dialects.
+            "NonStandardJoinTypeKeywordsGrammar".into(),
+            Nothing::new().to_matchable().into(),
+        ),
+        (
             "ConditionalJoinKeywordsGrammar".into(),
             one_of(vec![
                 Ref::new("JoinTypeKeywordsGrammar").to_matchable(),
                 Ref::new("ConditionalCrossJoinKeywordsGrammar").to_matchable(),
+                Ref::new("NonStandardJoinTypeKeywordsGrammar").to_matchable(),
             ])
             .to_matchable()
             .into(),
@@ -1059,10 +1065,16 @@ pub fn raw_dialect() -> Dialect {
             Nothing::new().to_matchable().into(),
         ),
         (
+            // Some dialects support a row-by-row horizontal join between tables.
+            "HorizontalJoinKeywordsGrammar".into(),
+            Nothing::new().to_matchable().into(),
+        ),
+        (
             "UnconditionalJoinKeywordsGrammar".into(),
             one_of(vec![
                 Ref::new("NaturalJoinKeywordsGrammar").to_matchable(),
                 Ref::new("UnconditionalCrossJoinKeywordsGrammar").to_matchable(),
+                Ref::new("HorizontalJoinKeywordsGrammar").to_matchable(),
             ])
             .to_matchable()
             .into(),

--- a/crates/lib-dialects/src/duckdb.rs
+++ b/crates/lib-dialects/src/duckdb.rs
@@ -41,6 +41,10 @@ pub fn raw_dialect() -> Dialect {
     duckdb_dialect.add_keyword_to_set("reserved_keywords", "PIVOT_LONGER");
     duckdb_dialect.add_keyword_to_set("reserved_keywords", "PIVOT_WIDER");
     duckdb_dialect.add_keyword_to_set("reserved_keywords", "UNPIVOT");
+    duckdb_dialect.add_keyword_to_set("unreserved_keywords", "ANTI");
+    duckdb_dialect.add_keyword_to_set("unreserved_keywords", "ASOF");
+    duckdb_dialect.add_keyword_to_set("unreserved_keywords", "POSITIONAL");
+    duckdb_dialect.add_keyword_to_set("unreserved_keywords", "SEMI");
     duckdb_dialect.add_keyword_to_set("unreserved_keywords", "VIRTUAL");
 
     duckdb_dialect.add([
@@ -209,6 +213,31 @@ pub fn raw_dialect() -> Dialect {
             Vec::new(),
             false,
         ),
+    );
+
+    duckdb_dialect.replace_grammar(
+        "NonStandardJoinTypeKeywordsGrammar",
+        one_of(vec![
+            Ref::keyword("ANTI").to_matchable(),
+            Ref::keyword("SEMI").to_matchable(),
+            Sequence::new(vec![
+                Ref::keyword("ASOF").to_matchable(),
+                one_of(vec![
+                    Ref::new("JoinTypeKeywordsGrammar").to_matchable(),
+                    Ref::keyword("ANTI").to_matchable(),
+                    Ref::keyword("SEMI").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+            ])
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    duckdb_dialect.replace_grammar(
+        "HorizontalJoinKeywordsGrammar",
+        Ref::keyword("POSITIONAL").to_matchable(),
     );
 
     duckdb_dialect.replace_grammar(

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/anti_semi_join.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/anti_semi_join.sql
@@ -1,0 +1,15 @@
+SELECT cars.name, cars.manufacturer
+FROM cars SEMI JOIN region
+ON cars.region = region.id;
+
+SELECT cars.name, cars.manufacturer
+FROM cars ANTI JOIN safety_data
+ON cars.safety_report_id = safety_data.report_id;
+
+SELECT cars.name, cars.manufacturer
+FROM cars SEMI JOIN region
+USING (region_id);
+
+SELECT cars.name, cars.manufacturer
+FROM cars ANTI JOIN region
+USING (region_id);

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/anti_semi_join.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/anti_semi_join.yml
@@ -1,0 +1,157 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: cars
+        - join_clause:
+          - keyword: SEMI
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: region
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: cars
+                - dot: .
+                - naked_identifier: region
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: region
+                - dot: .
+                - naked_identifier: id
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: cars
+        - join_clause:
+          - keyword: ANTI
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: safety_data
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: cars
+                - dot: .
+                - naked_identifier: safety_report_id
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: safety_data
+                - dot: .
+                - naked_identifier: report_id
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: cars
+        - join_clause:
+          - keyword: SEMI
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: region
+          - keyword: USING
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: region_id
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: cars
+        - join_clause:
+          - keyword: ANTI
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: region
+          - keyword: USING
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: region_id
+            - end_bracket: )
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/asof_join.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/asof_join.sql
@@ -1,0 +1,40 @@
+SELECT
+    t.*,
+    p.price
+FROM trades AS t ASOF JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF LEFT JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF RIGHT JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF FULL OUTER JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF ANTI JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF SEMI JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+
+-- ASOF joins can also specify join conditions on matching column names with
+-- the USING syntax, but the last attribute in the list must be the inequality,
+-- which will be greater than or equal to (>=):
+SELECT *
+FROM trades ASOF JOIN prices USING (symbol, "when");
+-- Returns symbol, trades.when, price (but NOT prices.when)
+
+SELECT
+    t.symbol,
+    t.when AS trade_when,
+    p.when AS price_when,
+    price
+FROM trades AS t ASOF LEFT JOIN prices AS p USING (symbol, "when");

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/asof_join.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/asof_join.yml
@@ -1,0 +1,429 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - naked_identifier: t
+            - dot: .
+            - star: '*'
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: price
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: when
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: when
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: RIGHT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: when
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: FULL
+          - keyword: OUTER
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: when
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: ANTI
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: when
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: SEMI
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - join_on_condition:
+            - keyword: ON
+            - expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: when
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+        - join_clause:
+          - keyword: ASOF
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+          - keyword: USING
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: symbol
+            - comma: ','
+            - quoted_identifier: '"when"'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: symbol
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: when
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: trade_when
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: when
+        - alias_expression:
+          - keyword: AS
+          - naked_identifier: price_when
+      - comma: ','
+      - select_clause_element:
+        - column_reference:
+          - naked_identifier: price
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: trades
+          - alias_expression:
+            - keyword: AS
+            - naked_identifier: t
+        - join_clause:
+          - keyword: ASOF
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: prices
+            - alias_expression:
+              - keyword: AS
+              - naked_identifier: p
+          - keyword: USING
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: symbol
+            - comma: ','
+            - quoted_identifier: '"when"'
+            - end_bracket: )
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/positional_join.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/positional_join.sql
@@ -1,0 +1,5 @@
+-- treat two data frames as a single table
+SELECT
+    df1.*,
+    df2.*
+FROM df1 POSITIONAL JOIN df2;

--- a/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/positional_join.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/duckdb/sqlfluff/positional_join.yml
@@ -1,0 +1,33 @@
+file:
+- statement:
+  - select_statement:
+    - select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - naked_identifier: df1
+            - dot: .
+            - star: '*'
+      - comma: ','
+      - select_clause_element:
+        - wildcard_expression:
+          - wildcard_identifier:
+            - naked_identifier: df2
+            - dot: .
+            - star: '*'
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: df1
+        - join_clause:
+          - keyword: POSITIONAL
+          - keyword: JOIN
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - naked_identifier: df2
+- statement_terminator: ;


### PR DESCRIPTION
Ports SQLFluff #5544.\n\n- advances .sqlfluff-sha from a524ba9cb1e1f2716dd591a33aa46b3b64b19a4a to c37deca8cbdcefacfae6345f68a56ff349ab5942\n- adds extensible non-standard and horizontal join grammar hooks to ANSI\n- supports DuckDB ANTI, SEMI, ASOF, and POSITIONAL joins\n- adds all upstream fixtures and generated snapshots\n\nLocal verification:\n- exact SQLFluff SHA progression check\n- SQLFluff SHA existence check\n- all 22 DuckDB fixture files passed with no unparsable nodes\n- bazelisk test //:cargo_fmt_check //:cargo_clippy --jobs=2 --test_timeout=1800