### PR TITLE
chore(sqlfluff): advance 3.1.0 release metadata (5998)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-dae258eade3dbd59fbbd096f4ed5cb774b3ddb9e
+3ef765df7af5d6a2b7a02d729e6eacfb49cfa408


### PR DESCRIPTION
> Stacked on sqruff #3679. Merge #3679 first.

Base PR: https://github.com/quarylabs/sqruff/pull/3679

## Summary
- advance the SQLFluff SHA across the 3.1.0 release-preparation commit
- skip sqruff code changes because upstream only updates the changelog, documentation, and Python package version metadata

## Testing
- cargo build
- cargo test
- bazel test //... (34/34 test targets passed)
- bazel test //:verify_sqlfluff_sha (after advancing the SHA)
- cargo fmt --all -- --check
- git diff --check

Ported from SQLFluff 3ef765df7af5d6a2b7a02d729e6eacfb49cfa408
https://github.com/sqlfluff/sqlfluff/pull/5998
https://github.com/sqlfluff/sqlfluff/commit/3ef765df7af5d6a2b7a02d729e6eacfb49cfa408