### PR TITLE
build(bazel): pin rustfmt to Rust toolchain version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -108,6 +108,7 @@ rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
     extra_target_triples = ["wasm32-unknown-unknown"],
+    rustfmt_version = "1.97.1",
     versions = ["1.97.1"],
 )
 use_repo(rust, "rust_toolchains")


### PR DESCRIPTION
## Summary

- pin the Bazel rustfmt toolchain to Rust 1.97.1
- keep rustfmt aligned with the repository Rust toolchain
- replace the implicit nightly rustfmt toolchain

## Verification

- `bazelisk test //:rustfmt_check`
- `git diff --check`

## Note

`rules_rust` still materializes a dedicated rustfmt repository containing rustc. This change removes the separate nightly compiler version and version drift, but does not eliminate that repository or its extracted compiler payload.