### PR TITLE
build(bazel): omit unused wasm browser tools

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,11 +3,27 @@ load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:prettier/package_json.bzl", prettier_bin = "bin")
 load("@rules_rust//rust:defs.bzl", "rust_clippy", "rustfmt_test")
+load("@rules_rust_wasm_bindgen//:defs.bzl", "rust_wasm_bindgen_toolchain")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_shellcheck//:def.bzl", "shellcheck_test")
 load(":cargo_build.bzl", "cargo_run", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv", "python_venv_provider", "uv_python_install", "uv_python_venv")
 load(":linters.bzl", "keep_sorted_test")
+
+# Production WASM bindings only need the wasm-bindgen CLI. The upstream
+# default toolchain also includes browser testing tools that this repository
+# does not use.
+rust_wasm_bindgen_toolchain(
+    name = "wasm_bindgen_cli_only_toolchain_impl",
+    wasm_bindgen_cli = "@rules_rust_wasm_bindgen//3rdparty:wasm_bindgen_cli",
+)
+
+toolchain(
+    name = "wasm_bindgen_cli_only_toolchain",
+    toolchain = ":wasm_bindgen_cli_only_toolchain_impl",
+    toolchain_type = "@rules_rust_wasm_bindgen//:toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 # Link all npm packages into node_modules
 npm_link_all_packages(name = "node_modules")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -114,6 +114,7 @@ use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")
 register_toolchains("@rules_rust_pyo3//toolchains:toolchain")
+register_toolchains("//:wasm_bindgen_cli_only_toolchain")
 
 # Required for WASM cross-compilation
 register_toolchains("@rules_rust//rust/private/dummy_cc_toolchain:dummy_cc_wasm32_toolchain")


### PR DESCRIPTION
## Summary

- register a minimal `rules_rust_wasm_bindgen` toolchain
- include only the `wasm-bindgen` CLI used to build production bindings
- avoid fetching the unused browser-testing tools from the default toolchain

## Motivation

Sqruff does not run the `wasm-bindgen-test-runner` browser tooling through Bazel, so downloading and building those tools adds unnecessary setup work.