### PR TITLE
build(bazel): optimize release artifacts explicitly

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
-# Build with optimizations
-build --compilation_mode=opt
+# Build published artifacts with optimizations
+build:release --compilation_mode=opt
 
 # Use remote cache for CI (can be configured per-environment)
 # build --remote_cache=...

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install LLD
         run: sudo apt-get update --yes && sudo apt-get install --yes lld
       - name: Build website
-        run: bazelisk build //:website
+        run: bazelisk build --config=release //:website
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # ratchet:actions/configure-pages@v6.0.0
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install LLD
         run: sudo apt-get update --yes && sudo apt-get install --yes lld
       - name: Build VS Code extension
-        run: bazel build //editors/code:vscode_extension
+        run: bazel build --config=release //editors/code:vscode_extension
       - name: Copy VSIX to expected location
         run: cp bazel-bin/editors/code/*.vsix editors/code/
       - name: Generate artifact attestation


### PR DESCRIPTION
## Summary

- move `--compilation_mode=opt` from every Bazel build to the `release` config
- opt release and deployment artifacts into that config explicitly
- keep routine development and CI builds on Bazel’s faster default compilation mode

## Motivation

The repository currently compiles every target with release optimizations, including local development and CI validation. Restricting optimization to published artifacts reduces unnecessary compilation work without changing release output.