### PR TITLE
build(bazel): use prebuilt keep-sorted

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,9 +18,6 @@ build:lint --aspects=//:linters.bzl%keep_sorted
 build:lint --output_groups=rules_lint_human
 build:lint --@aspect_rules_lint//lint:fail_on_violation
 
-# Required by rules_lint's isolated keep-sorted dependency extension.
-common --experimental_isolated_extension_usages
-
 # CI-specific settings
 build:ci --color=yes
 build:ci --curses=no

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,9 +7,9 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
-# Platform-aware tool downloads (ratchet, cargo-machete, cargo-hack, uv)
+# Platform-aware tool downloads
 tools = use_extension("//:tools.bzl", "tools")
-use_repo(tools, "cargo_hack", "cargo_machete", "ratchet", "uv")
+use_repo(tools, "cargo_hack", "cargo_machete", "keep_sorted", "ratchet", "uv")
 
 bazel_dep(name = "aspect_rules_js", version = "3.2.2")
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
@@ -39,20 +39,15 @@ use_repo(python, "python_3_12", "python_versions")
 register_toolchains("@python_versions//:all")
 
 bazel_dep(name = "aspect_rules_lint", version = "2.5.0")
-bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
+# Keep rules_lint's transitive rules_buf dependency on a Bazel 9-compatible
+# rules_go release. keep-sorted itself uses the prebuilt binary above.
+bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "gazelle", version = "0.50.0")
 bazel_dep(name = "rules_rust", version = "0.68.1")
 bazel_dep(name = "rules_rust_wasm_bindgen", version = "0.68.1")
 bazel_dep(name = "rules_rust_pyo3", version = "0.68.1")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_shellcheck", version = "0.4.0")
-
-# Fetch rules_lint's supported keep-sorted dependency in isolation from the
-# repository's other Go dependencies.
-keep_sorted_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", isolate = True)
-keep_sorted_deps.from_file(go_mod = "@aspect_rules_lint//lint/keep-sorted:go.mod")
-use_repo(keep_sorted_deps, "com_github_google_keep_sorted")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(node_version = "22.22.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -101,8 +101,7 @@
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
-    "https://bcr.bazel.build/modules/gazelle/0.50.0/MODULE.bazel": "5dce69aa1d7b5bc85d1e1cfe61f0a9a27426c46425ec1d064685f941a5977329",
-    "https://bcr.bazel.build/modules/gazelle/0.50.0/source.json": "3cadcd284172c4274dc44c71b571f08ec4f22b28d5e9ad2708347c6e6c3a41b9",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/source.json": "0823f097b127e0201ae55d85647c94095edfe27db0431a7ae880dcab08dfaa04",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -121,7 +120,6 @@
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
     "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
     "https://bcr.bazel.build/modules/package_metadata/0.0.6/MODULE.bazel": "341dab6f417197494517d54c8e557c0baee1de7aec83543a4fbefe57900acb7e",
     "https://bcr.bazel.build/modules/package_metadata/0.0.6/source.json": "9581d8b22db43550ac75ecc314ee4fa0a33400bfdc77d1317d8af6b18dca7756",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
@@ -137,7 +135,6 @@
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
-    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
@@ -191,7 +188,6 @@
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
-    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
     "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
     "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
@@ -310,7 +306,7 @@
   "moduleExtensions": {
     "//:tools.bzl%tools": {
       "general": {
-        "bzlTransitiveDigest": "7egann2c8H9XO2HbHf73NO04omFRlviENL9DHCclq78=",
+        "bzlTransitiveDigest": "nV13YAmxL+0na82/bB8mRJzcWA/BV/QUdTmdsB2qKzg=",
         "usagesDigest": "Im2V7yPlYEv4GHExi3pryxLYa0SN3bEhv6+M92OPojA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
@@ -328,6 +324,10 @@
           },
           "uv": {
             "repoRuleId": "@@//:tools.bzl%_uv_repo",
+            "attributes": {}
+          },
+          "keep_sorted": {
+            "repoRuleId": "@@//:tools.bzl%_keep_sorted_repo",
             "attributes": {}
           }
         }

--- a/linters.bzl
+++ b/linters.bzl
@@ -13,9 +13,9 @@ load("@aspect_rules_lint//lint:keep_sorted.bzl", "lint_keep_sorted_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 
 # keep-sorted (https://github.com/google/keep-sorted) is a language-agnostic
-# linter supplied through rules_lint's supported tool integration.
+# linter downloaded as a platform-specific release binary by //:tools.bzl.
 keep_sorted = lint_keep_sorted_aspect(
-    binary = Label("@com_github_google_keep_sorted//:keep-sorted"),
+    binary = Label("@keep_sorted//:keep-sorted"),
 )
 
 keep_sorted_test = lint_test(aspect = keep_sorted)

--- a/tools.bzl
+++ b/tools.bzl
@@ -89,6 +89,26 @@ _UV_PLATFORMS = {
     },
 }
 
+_KEEP_SORTED_VERSION = "0.10.0"
+_KEEP_SORTED_PLATFORMS = {
+    "linux_amd64": {
+        "url": "https://github.com/google/keep-sorted/releases/download/v{version}/keep-sorted_linux_amd64",
+        "sha256": "079710c01619cc3dc11c9ddce18ac8db8d86701e7d12f9c5b62b8c4c4a664cca",
+    },
+    "linux_arm64": {
+        "url": "https://github.com/google/keep-sorted/releases/download/v{version}/keep-sorted_linux_arm64",
+        "sha256": "fcb5543fcacaef8edd092f34182f137838e042125812ef0a22035e10f6698577",
+    },
+    "darwin_amd64": {
+        "url": "https://github.com/google/keep-sorted/releases/download/v{version}/keep-sorted_darwin_amd64",
+        "sha256": "1525efdae5bf90781367da4143c2f41a9b0add3b8ebc84de42ff7f9d574c7680",
+    },
+    "darwin_arm64": {
+        "url": "https://github.com/google/keep-sorted/releases/download/v{version}/keep-sorted_darwin_arm64",
+        "sha256": "713c2ea4a36304a185fde532db6d1f9303e4207bff1c641cf2a23e4a29479f2b",
+    },
+}
+
 def _get_platform(repository_ctx):
     """Detect the current platform."""
     os_name = repository_ctx.os.name.lower()
@@ -190,11 +210,43 @@ _uv_repo = repository_rule(
     attrs = {},
 )
 
+def _keep_sorted_repo_impl(repository_ctx):
+    platform = _get_platform(repository_ctx)
+    config = _KEEP_SORTED_PLATFORMS.get(platform)
+    if not config:
+        fail("Unsupported platform for keep-sorted: {}".format(platform))
+
+    url = config["url"].format(version = _KEEP_SORTED_VERSION)
+
+    repository_ctx.download(
+        url = url,
+        output = "keep-sorted.bin",
+        sha256 = config["sha256"],
+        executable = True,
+    )
+    repository_ctx.file(
+        "BUILD.bazel",
+        """load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+sh_binary(
+    name = "keep-sorted",
+    srcs = ["keep-sorted.bin"],
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+_keep_sorted_repo = repository_rule(
+    implementation = _keep_sorted_repo_impl,
+    attrs = {},
+)
+
 def _tools_impl(module_ctx):
     _ratchet_repo(name = "ratchet")
     _cargo_machete_repo(name = "cargo_machete")
     _cargo_hack_repo(name = "cargo_hack")
     _uv_repo(name = "uv")
+    _keep_sorted_repo(name = "keep_sorted")
 
 tools = module_extension(
     implementation = _tools_impl,


### PR DESCRIPTION
## Summary
- download official keep-sorted v0.10.0 release binaries for Linux and macOS on x86_64 and ARM64
- verify every binary with the SHA-256 digest published in the GitHub release metadata
- point the rules_lint aspect at the prebuilt executable and remove the isolated source-build extension
- retain rules_go 0.60 only as a Bazel 9 compatibility constraint for rules_lint's transitive rules_buf dependency

## Why
keep-sorted was compiled from Go source during Bazel builds. Using the official roughly 4.7 MB platform binary removes that compilation and its keep-sorted-specific Go dependency setup. rules_go itself remains transitive through aspect_rules_lint -> rules_buf.

## Validation
- `bazelisk test --config=ci //:keep_sorted_check`
- `bazelisk run @keep_sorted//:keep-sorted -- --version`
- `bazelisk mod deps --lockfile_mode=error`
- `git diff --check`

`bazelisk build --config=lint //...` reaches and runs the prebuilt binary, then fails on the existing unquoted fixture path `python copy.sql`; the same split arguments reproduce the failure with the previous compiled v0.6 binary.
