### PR TITLE
build(bazel): unify Cargo test compilation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -506,13 +506,13 @@ cargo_test(
 # Build Python extension (maturin uses the vendored cargo + pre-cached venv)
 (cd crates/cli-python && maturin develop --locked --offline)
 
-# Run cargo tests (same as GitHub Action)
-cargo test --manifest-path ./crates/cli/Cargo.toml --locked --offline
 # Crates that don't need the Python/maturin setup run natively via rust_test:
 #   //crates/lib-core:sqruff-lib-core-test
 #   //crates/sqlinference:sqruff-sqlinference-test
 #   //crates/lineage:lineage-test
-cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-sqlinference --exclude lineage --locked --offline
+# Enable every library feature explicitly, while leaving the sqruff CLI on its
+# default features. The CLI's codegen-docs feature changes its runtime behavior.
+cargo test --all --features sqruff-lib/parser,sqruff-lib/python,sqruff-cli-lib/parser,sqruff-cli-lib/codegen-docs --exclude sqruff-lib-core --exclude sqruff-sqlinference --exclude lineage --locked --offline
 """,
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -419,15 +419,45 @@ sh_test(
     tags = ["exclusive"],
 )
 
-# Cargo check - type-check all crates with all features, tests, and benches
-# This replicates the "Rust Check" GitHub action job
-# Uses vendored dependencies for hermetic builds
+# Cargo compiler checks share one writable target directory. Keeping these in a
+# single Bazel test lets Cargo reuse dependency artifacts between check, clippy,
+# and the per-feature cargo-hack checks.
 cargo_test(
-    name = "cargo_check",
+    name = "cargo_compile_checks",
     python_venv = ":python_deps",
+    size = "enormous",
     srcs = [":cargo_srcs"],
+    tools = ["@cargo_hack//:cargo-hack"],
     vendor = ":cargo_deps",
-    script = "cargo check --all --all-features --tests --benches --locked --offline",
+    script = """
+echo "::group::Cargo check"
+cargo check --all --all-features --tests --benches --locked --offline
+echo "::endgroup::"
+
+echo "::group::Cargo clippy"
+cargo clippy --all --all-features --offline -- -D warnings
+echo "::endgroup::"
+
+echo "::group::Cargo hack"
+cargo hack check --each-feature --exclude-features=codegen-docs --offline
+echo "::endgroup::"
+""",
+)
+
+# Preserve the existing test labels while running the shared compilation target.
+test_suite(
+    name = "cargo_check",
+    tests = [":cargo_compile_checks"],
+)
+
+test_suite(
+    name = "cargo_clippy",
+    tests = [":cargo_compile_checks"],
+)
+
+test_suite(
+    name = "cargo_hack_check",
+    tests = [":cargo_compile_checks"],
 )
 
 # Cargo build release - build release binaries with all features
@@ -440,16 +470,6 @@ cargo_test(
     srcs = [":cargo_srcs"],
     vendor = ":cargo_deps",
     script = "cargo build --locked --release --all-features --offline",
-)
-
-# Cargo clippy - run clippy with all features
-# Uses vendored dependencies for hermetic builds
-cargo_test(
-    name = "cargo_clippy",
-    python_venv = ":python_deps",
-    srcs = [":cargo_srcs"],
-    vendor = ":cargo_deps",
-    script = "cargo clippy --all --all-features --offline -- -D warnings",
 )
 
 # Cargo fmt check - verify code formatting
@@ -494,19 +514,6 @@ cargo test --manifest-path ./crates/cli/Cargo.toml --locked --offline
 #   //crates/lineage:lineage-test
 cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-sqlinference --exclude lineage --locked --offline
 """,
-)
-
-# Cargo hack check - verify each feature compiles in isolation
-# This ensures no feature combination is broken
-# Uses vendored dependencies for hermetic builds
-cargo_test(
-    name = "cargo_hack_check",
-    size = "enormous",
-    srcs = [":cargo_srcs"],
-    python_venv = ":python_deps",
-    tools = ["@cargo_hack//:cargo-hack"],
-    vendor = ":cargo_deps",
-    script = "cargo hack check --each-feature --exclude-features=codegen-docs --offline",
 )
 
 # Zensical docs build - verify documentation builds successfully

--- a/crates/lib/tests/rules.rs
+++ b/crates/lib/tests/rules.rs
@@ -122,6 +122,9 @@ fn process_file(state: &mut RuleTestState, path: &Path, verbose: bool) {
     state.linter.config_mut().raw.extend(state.core.clone());
     state.linter.config_mut().reload_reflow();
 
+    // Reuse the expensive dialect, templater, and rule-pack setup for cases
+    // with identical configurations while keeping each configuration isolated.
+    let mut configured_linters = Vec::new();
     for case in file.cases {
         if verbose {
             println!("Processing case: {}", case.name);
@@ -145,16 +148,20 @@ fn process_file(state: &mut RuleTestState, path: &Path, verbose: bool) {
             continue;
         }
 
-        let has_config = !case.configs.is_empty();
         let rule = &file.rule;
-        if has_config {
-            *state.linter.config_mut() = FluffConfig::new(case.configs.clone(), None, None);
-            state.linter.config_mut().raw.extend(state.core.clone());
+        let configured_linter_index = if case.configs.is_empty() {
+            None
+        } else if let Some(index) = configured_linters
+            .iter()
+            .position(|(configs, _)| configs == &case.configs)
+        {
+            Some(index)
+        } else {
+            let mut config = FluffConfig::new(case.configs.clone(), None, None);
+            config.raw.extend(state.core.clone());
 
             if let Some(core) = case.configs.get("core").and_then(|it| it.as_map()) {
-                state
-                    .linter
-                    .config_mut()
+                config
                     .raw
                     .get_mut("core")
                     .unwrap()
@@ -163,7 +170,7 @@ fn process_file(state: &mut RuleTestState, path: &Path, verbose: bool) {
                     .extend(core.clone());
             }
 
-            for (config, value) in &case
+            for (config_name, value) in &case
                 .configs
                 .get("rules")
                 .cloned()
@@ -172,47 +179,49 @@ fn process_file(state: &mut RuleTestState, path: &Path, verbose: bool) {
                 .cloned()
                 .unwrap_or_default()
             {
-                if INDENT_CONFIG.contains(&config.as_str()) {
-                    state
-                        .linter
-                        .config_mut()
+                if INDENT_CONFIG.contains(&config_name.as_str()) {
+                    config
                         .raw
                         .get_mut("indentation")
                         .unwrap()
                         .as_map_mut()
                         .unwrap()
-                        .insert(config.clone(), value.clone());
+                        .insert(config_name.clone(), value.clone());
                 }
             }
 
-            state.linter.config_mut().reload_reflow();
+            config.reload_reflow();
 
-            // Recreate linter with proper templater after all config is set up
-            let templater = match Linter::get_templater(state.linter.config()) {
+            let templater = match Linter::get_templater(&config) {
                 Ok(t) => t,
                 Err(e) => {
                     if std::env::var("SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS").is_ok() {
                         println!("Skipping case '{}': {}", case.name, e);
-                        *state.linter.config_mut() = FluffConfig::default();
-                        state.linter.config_mut().raw.extend(state.core.clone());
-                        state.linter.config_mut().reload_reflow();
                         continue;
                     } else {
                         panic!(
                             "Unsupported templater in case '{}': {}. \
-                             Set SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS=1 to skip these tests.",
+                                 Set SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS=1 to skip these tests.",
                             case.name, e
                         );
                     }
                 }
             };
-            state.linter =
-                Linter::new(state.linter.config().clone(), None, Some(templater), true).unwrap();
-        }
+            configured_linters.push((
+                case.configs.clone(),
+                Linter::new(config, None, Some(templater), true).unwrap(),
+            ));
+            Some(configured_linters.len() - 1)
+        };
+
+        let linter = match configured_linter_index {
+            Some(index) => &mut configured_linters[index].1,
+            None => &mut state.linter,
+        };
 
         match case.kind {
             TestCaseKind::Pass { pass_str } => {
-                let result = state.linter.lint_string_wrapped(&pass_str, false).unwrap();
+                let result = linter.lint_string_wrapped(&pass_str, false).unwrap();
                 let error_string = format!(
                     r#"
 The following test test can be used to recreate the issue:
@@ -247,7 +256,7 @@ dialect = {dialect}
                 assert_eq!(&result.violations(), &[], "{}", error_string);
             }
             TestCaseKind::Fail { fail_str } => {
-                let file = state.linter.lint_string_wrapped(&fail_str, false).unwrap();
+                let file = linter.lint_string_wrapped(&fail_str, false).unwrap();
                 assert_ne!(&file.violations(), &[]);
                 if let Some(expected_line_numbers) = &case.line_numbers {
                     let actual_line_numbers = file
@@ -262,8 +271,7 @@ dialect = {dialect}
                     );
                 }
                 if case.expect_no_fix {
-                    let fixed = state
-                        .linter
+                    let fixed = linter
                         .lint_string_wrapped(&fail_str, true)
                         .unwrap()
                         .fix_string();
@@ -281,7 +289,7 @@ dialect = {dialect}
                     "Fail and fix strings should not be equal"
                 );
 
-                let linted = state.linter.lint_string_wrapped(&fail_str, true).unwrap();
+                let linted = linter.lint_string_wrapped(&fail_str, true).unwrap();
                 if let Some(expected_line_numbers) = &case.line_numbers {
                     let actual_line_numbers = linted
                         .violations()
@@ -298,19 +306,6 @@ dialect = {dialect}
 
                 pretty_assertions::assert_eq!(actual, fix_str);
             }
-        }
-
-        if has_config {
-            *state.linter.config_mut() = FluffConfig::default();
-            state.linter.config_mut().raw.extend(state.core.clone());
-            state.linter.config_mut().reload_reflow();
-
-            // Recreate linter with default templater to avoid leaking
-            // the custom templater (e.g. placeholder) into subsequent tests.
-            let templater = Linter::get_templater(state.linter.config())
-                .expect("Default config should have a valid templater");
-            state.linter =
-                Linter::new(state.linter.config().clone(), None, Some(templater), true).unwrap();
         }
     }
 }


### PR DESCRIPTION
Stacked on #3699.

## Summary

- replaces the separate CLI and workspace Cargo test invocations with one workspace invocation
- enables the library feature coverage explicitly while leaving the CLI itself on its normal runtime entry point
- avoids compiling the CLI dependency graph twice under different feature sets

## Benchmark

Warm Bazel dependency/build cache, forced test execution with `--nocache_test_results`:

- before: `//:cargo_test` 661.9s
- after: `//:cargo_test` 573.8s
- change: -88.1s (-13.3%)

## Validation

`bazelisk test //:cargo_test --nocache_test_results`

All Cargo tests pass. The CLI's `codegen-docs` feature is deliberately not enabled on the CLI package because it replaces the CLI runtime behavior; the equivalent library feature remains covered.
