### PR TITLE
build(bazel): use minimal Python runtime for compiler actions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -321,6 +321,13 @@ python_venv_provider(
     venv = ":python_venv",
 )
 
+# Compiler-only Cargo actions need Python and libpython for PyO3, but not the
+# hundreds of MB of test dependencies layered onto the standalone runtime.
+python_venv_provider(
+    name = "python_runtime",
+    venv = ":pytest_py312_python",
+)
+
 # Rust format check
 rustfmt_test(
     name = "rustfmt_check",
@@ -344,7 +351,7 @@ cargo_test(
         "docs/reference/templaters.md",
     ],
     vendor = ":cargo_deps",
-    python_venv = ":python_deps",
+    python_venv = ":python_runtime",
     script = """
 # Build the codegen binary
 cargo build --bin sqruff -F codegen-docs --locked --offline
@@ -389,7 +396,7 @@ cargo_run(
         "docs/reference/templaters.md",
     ],
     vendor = ":cargo_deps",
-    python_venv = ":python_deps",
+    python_venv = ":python_runtime",
     script = """
 # Build the codegen binary
 cargo build --bin sqruff -F codegen-docs --locked --offline
@@ -424,7 +431,7 @@ sh_test(
 # and the per-feature cargo-hack checks.
 cargo_test(
     name = "cargo_compile_checks",
-    python_venv = ":python_deps",
+    python_venv = ":python_runtime",
     size = "enormous",
     srcs = [":cargo_srcs"],
     tools = ["@cargo_hack//:cargo-hack"],
@@ -465,7 +472,7 @@ test_suite(
 # Uses vendored dependencies for hermetic builds
 cargo_test(
     name = "cargo_build_release",
-    python_venv = ":python_deps",
+    python_venv = ":python_runtime",
     size = "enormous",
     srcs = [":cargo_srcs"],
     vendor = ":cargo_deps",

--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -280,13 +280,12 @@ python_venv = rule(
 )
 
 def _python_venv_provider_impl(ctx):
-    """Wrapper that provides PythonVenvInfo from python_venv output."""
+    """Wraps a single Python environment directory in PythonVenvInfo."""
     venv_files = ctx.attr.venv[DefaultInfo].files.to_list()
-    venv_dir = None
-
-    for f in venv_files:
-        if f.is_directory and f.basename == "python_venv":
-            venv_dir = f
+    venv_dirs = [f for f in venv_files if f.is_directory]
+    if len(venv_dirs) != 1:
+        fail("Expected exactly one Python environment directory")
+    venv_dir = venv_dirs[0]
 
     return [
         DefaultInfo(files = depset(venv_files)),
@@ -300,7 +299,7 @@ python_venv_provider = rule(
     attrs = {
         "venv": attr.label(
             mandatory = True,
-            doc = "python_venv target",
+            doc = "Target providing one Python environment directory",
         ),
     },
 )


### PR DESCRIPTION
## Summary

- add a provider for the bare Bazel-managed Python runtime
- use it for Cargo compiler-only actions that need Python/libpython for PyO3
- keep the dependency-filled Python environment only on `cargo_test`, where maturin and the Python packages are actually used

This avoids copying the full Python test environment into four Bazel action sandboxes. In the measured output tree, the copied environment falls from 339 MB / 5,932 files to 90 MB / 3,695 files per action.

## Benchmark

Same warm checkout and command, with test-result caching disabled:

```text
bazelisk test //:cargo_build_release //:cargo_compile_checks \
  --nocache_test_results --test_output=errors --noshow_progress

parent:    300.084s total
candidate: 288.703s total  (-11.381s, -3.8%)

cargo_build_release:  286.9s -> 275.0s (-11.9s)
cargo_compile_checks: 268.4s -> 262.5s ( -5.9s)
```

The full-suite profile also showed these large Cargo actions competing to stage and copy Python environments concurrently, so reducing each action's inputs should lower filesystem pressure beyond the isolated pair.

## Validation

Rebased onto current `main` after the consolidated compiler checks from #3699 merged. All affected test targets pass:

```text
bazelisk test --lockfile_mode=error \
  //:codegen_docs_check \
  //:cargo_compile_checks \
  //:cargo_build_release \
  --nocache_test_results --test_output=errors --noshow_progress
```

- 3/3 tests passed
- `git diff --check` passed
