### PR TITLE
ci: make Bazel CI lockfile read-only

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,7 @@ build:lint --@aspect_rules_lint//lint:fail_on_violation
 common --experimental_isolated_extension_usages
 
 # CI-specific settings
+common:ci --lockfile_mode=error
 build:ci --color=yes
 build:ci --curses=no
 build:ci --show_timestamps

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -38,16 +38,16 @@ jobs:
           repository-cache: true
 
       - name: Run rustfmt
-        run: bazelisk run @rules_rust//:rustfmt
+        run: bazelisk run --lockfile_mode=error @rules_rust//:rustfmt
 
       - name: Run Prettier
-        run: bazelisk run //:prettier_fix
+        run: bazelisk run --lockfile_mode=error //:prettier_fix
 
       - name: Run ruff
-        run: bazelisk run //:ruff_fix
+        run: bazelisk run --lockfile_mode=error //:ruff_fix
 
       - name: Regenerate docs
-        run: bazelisk run //:codegen_docs_fix
+        run: bazelisk run --lockfile_mode=error //:codegen_docs_fix
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,36 +59,18 @@ jobs:
           # Only master (push to main) runs update the cache; PRs and merge
           # group jobs restore it read-only to avoid polluting/contending.
           cache-save: ${{ github.event_name == 'push' }}
+      - name: Check Bazel lockfile
+        run: |
+          if ! bazelisk mod deps --lockfile_mode=error; then
+            echo "::error::MODULE.bazel.lock is out of date. Run 'bazel mod deps --lockfile_mode=update' and commit the changes."
+            exit 1
+          fi
       - name: Install native build dependencies
         run: sudo apt-get update --yes && sudo apt-get install --yes libkrb5-dev lld
       - name: Build all targets
         run: bazelisk build --config=ci //...
       - name: Run all tests
         run: bazelisk test --config=ci //...
-  bazel-lockfile:
-    name: Bazel Lockfile Check
-    runs-on: ubuntu-latest
-    needs: sqlfluff-sha-only
-    if: needs.sqlfluff-sha-only.outputs.sqlfluff-sha-only != 'true'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
-      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # ratchet:bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
-          repository-cache: true
-          # Only master (push to main) runs update the cache; PRs and merge
-          # group jobs restore it read-only to avoid polluting/contending.
-          cache-save: ${{ github.event_name == 'push' }}
-      - name: Update lockfile
-        run: bazelisk mod deps --lockfile_mode=update
-      - name: Check lockfile is up to date
-        run: |
-          if ! git diff --quiet MODULE.bazel.lock; then
-            echo "::error::MODULE.bazel.lock is out of date. Run 'bazel mod deps --lockfile_mode=update' and commit the changes."
-            git diff MODULE.bazel.lock
-            exit 1
-          fi
   zed-extension:
     name: Zed Extension
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- run Bazel-backed autofix commands with `--lockfile_mode=error` so formatting cannot rewrite `MODULE.bazel.lock`
- validate the complete Bazel module graph at the start of the Bazel Lint job with `bazelisk mod deps --lockfile_mode=error`
- set `common:ci --lockfile_mode=error` so subsequent CI builds and tests remain read-only
- remove the redundant standalone Bazel Lockfile Check job while preserving failure guidance

## Validation

- `bazelisk run --lockfile_mode=error @rules_rust//:rustfmt`
- `bazelisk mod deps --lockfile_mode=error`
- `bazelisk test --config=ci //:prettier_check //:ratchet_check`
- confirmed `MODULE.bazel.lock` remains unchanged