### PR TITLE
build: generate templater docs without Python

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -351,7 +351,6 @@ cargo_test(
         "docs/reference/templaters.md",
     ],
     vendor = ":cargo_deps",
-    python_venv = ":python_runtime",
     script = """
 # Build the codegen binary
 cargo build --bin sqruff -F codegen-docs --locked --offline
@@ -396,7 +395,6 @@ cargo_run(
         "docs/reference/templaters.md",
     ],
     vendor = ":cargo_deps",
-    python_venv = ":python_runtime",
     script = """
 # Build the codegen binary
 cargo build --bin sqruff -F codegen-docs --locked --offline

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2638,7 +2638,7 @@
           "FILE:@@//Cargo.lock a7a7cde8a42b8d67a9881b80d781c7f8b533fd795f22318842ea972b034a53db",
           "FILE:@@//Cargo.toml b9d9f6c7d013a2c48525bcea442e30f3a4b794e909c7a0ab8cfab6d7dc6cb6b0",
           "FILE:@@//crates/cli/Cargo.toml 69789bdb7a1ada8e986afa284402986c9a6e64055744c4af2f209941e1525a27",
-          "FILE:@@//crates/cli-lib/Cargo.toml 6129e3a698dddc63bddfd2e11e0b97fcb5644a1054e8dba324530e7752402445",
+          "FILE:@@//crates/cli-lib/Cargo.toml 0e4ae582cfee5054016aa90498d536929c3e4368235c1f4f65cf5292479a908d",
           "FILE:@@//crates/cli-python/Cargo.toml 7a4307b8bf718c65f746fe859557c2f512e07dee134d9f66fb686e541cbf0d03",
           "FILE:@@//crates/lib/Cargo.toml b37090b55ba169d84535af30a8746e2572bda1d5eec572e833ef11208285bc84",
           "FILE:@@//crates/lib-core/Cargo.toml 6d5efc6ffa84b5a69c9fd863be45cb59d7845fc142ae5ce67ea70c5e46e31a1e",

--- a/crates/cli-lib/Cargo.toml
+++ b/crates/cli-lib/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 [features]
 parser = ["sqruff-lib/parser"]
 python = ["sqruff-lib/python", "pyo3"]
-codegen-docs = ["clap-markdown", "minijinja", "python"]
+codegen-docs = ["clap-markdown", "minijinja"]
 
 [dependencies]
 sqruff-lib.workspace = true

--- a/crates/cli-lib/src/docs.rs
+++ b/crates/cli-lib/src/docs.rs
@@ -12,7 +12,7 @@ use sqruff_lib::core::rules::ErasedRule;
 #[cfg(feature = "codegen-docs")]
 use sqruff_lib::rules::rules;
 #[cfg(feature = "codegen-docs")]
-use sqruff_lib::templaters::TEMPLATERS;
+use sqruff_lib::templaters::{TEMPLATER_DOCS, TemplaterDocumentation};
 #[cfg(feature = "codegen-docs")]
 use sqruff_lib_core::dialects::init::DialectKind;
 #[cfg(feature = "codegen-docs")]
@@ -57,7 +57,7 @@ pub(crate) fn codegen_docs() {
     env.add_template("templaters", TEMPLATERS_TEMPLATE).unwrap();
 
     let tmpl = env.get_template("templaters").unwrap();
-    let templaters = TEMPLATERS
+    let templaters = TEMPLATER_DOCS
         .into_iter()
         .map(Templater::from)
         .collect::<Vec<_>>();
@@ -139,8 +139,8 @@ impl From<DialectKind> for Dialect {
 }
 
 #[cfg(feature = "codegen-docs")]
-impl From<&'static dyn sqruff_lib::templaters::Templater> for Templater {
-    fn from(value: &'static dyn sqruff_lib::templaters::Templater) -> Self {
+impl From<&'static dyn TemplaterDocumentation> for Templater {
+    fn from(value: &'static dyn TemplaterDocumentation) -> Self {
         Templater {
             name: value.name(),
             description: value.description(),

--- a/crates/lib/src/templaters.rs
+++ b/crates/lib/src/templaters.rs
@@ -5,20 +5,15 @@ use sqruff_lib_core::templaters::TemplatedFile;
 
 use crate::Formatter;
 use crate::core::config::FluffConfig;
+use crate::templaters::dbt::DBTTemplater;
+use crate::templaters::jinja::JinjaTemplater;
 use crate::templaters::placeholder::PlaceholderTemplater;
+use crate::templaters::python::PythonTemplater;
 use crate::templaters::raw::RawTemplater;
 
-#[cfg(feature = "python")]
-use crate::templaters::jinja::JinjaTemplater;
-#[cfg(feature = "python")]
-use crate::templaters::python::PythonTemplater;
-
-#[cfg(feature = "python")]
 pub mod dbt;
-#[cfg(feature = "python")]
 pub mod jinja;
 pub mod placeholder;
-#[cfg(feature = "python")]
 pub mod python;
 #[cfg(feature = "python")]
 pub mod python_shared;
@@ -29,12 +24,19 @@ pub use types::{PlaceholderStyle, TemplaterKind};
 
 pub static RAW_TEMPLATER: RawTemplater = RawTemplater;
 pub static PLACEHOLDER_TEMPLATER: PlaceholderTemplater = PlaceholderTemplater;
-#[cfg(feature = "python")]
 pub static PYTHON_TEMPLATER: PythonTemplater = PythonTemplater;
-#[cfg(feature = "python")]
 pub static JINJA_TEMPLATER: JinjaTemplater = JinjaTemplater;
-#[cfg(feature = "python")]
-pub static DBT_TEMPLATER: dbt::DBTTemplater = dbt::DBTTemplater;
+pub static DBT_TEMPLATER: DBTTemplater = DBTTemplater;
+
+/// Documentation for every templater, including templaters whose runtime
+/// implementation requires the optional Python feature.
+pub static TEMPLATER_DOCS: [&'static dyn TemplaterDocumentation; 5] = [
+    &RAW_TEMPLATER,
+    &PLACEHOLDER_TEMPLATER,
+    &PYTHON_TEMPLATER,
+    &JINJA_TEMPLATER,
+    &DBT_TEMPLATER,
+];
 
 // templaters returns all the templaters that are available in the library
 #[cfg(feature = "python")]
@@ -64,13 +66,17 @@ pub enum ProcessingMode {
     Batch,
 }
 
-pub trait Templater: Send + Sync {
+/// Documentation that is available without compiling a templater's runtime
+/// dependencies.
+pub trait TemplaterDocumentation: Send + Sync {
     /// The name of the templater.
     fn name(&self) -> &'static str;
 
     /// Description of the templater.
     fn description(&self) -> &'static str;
+}
 
+pub trait Templater: TemplaterDocumentation {
     /// Returns the processing mode for this templater.
     fn processing_mode(&self) -> ProcessingMode;
 
@@ -101,5 +107,20 @@ pub trait Templater: Send + Sync {
             .into_iter()
             .map(|result| result.map(|templated_file| vec![templated_file]))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TEMPLATER_DOCS;
+
+    #[test]
+    fn documentation_lists_every_templater() {
+        let names = TEMPLATER_DOCS
+            .iter()
+            .map(|templater| templater.name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["raw", "placeholder", "python", "jinja", "dbt"]);
     }
 }

--- a/crates/lib/src/templaters/dbt.rs
+++ b/crates/lib/src/templaters/dbt.rs
@@ -1,18 +1,30 @@
+#[cfg(feature = "python")]
 use super::Templater;
+use super::TemplaterDocumentation;
+#[cfg(feature = "python")]
 use super::python::PythonTemplatedFile;
+#[cfg(feature = "python")]
 use crate::core::config::FluffConfig;
+#[cfg(feature = "python")]
 use crate::templaters::python_shared::PythonFluffConfig;
+#[cfg(feature = "python")]
 use crate::templaters::{Formatter, ProcessingMode, TemplaterKind};
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
 use pyo3::types::PyList;
+#[cfg(feature = "python")]
 use pyo3::{Py, PyAny, Python};
+#[cfg(feature = "python")]
 use sqruff_lib_core::errors::SQLFluffUserError;
+#[cfg(feature = "python")]
 use sqruff_lib_core::templaters::TemplatedFile;
+#[cfg(feature = "python")]
 use std::sync::Arc;
 
 pub struct DBTTemplater;
 
-impl Templater for DBTTemplater {
+impl TemplaterDocumentation for DBTTemplater {
     fn name(&self) -> &'static str {
         "dbt"
     }
@@ -117,7 +129,10 @@ WHERE created_at > '2024-01-01'
 
 The linter then operates on this compiled SQL."#
     }
+}
 
+#[cfg(feature = "python")]
+impl Templater for DBTTemplater {
     fn processing_mode(&self) -> ProcessingMode {
         ProcessingMode::Batch
     }

--- a/crates/lib/src/templaters/jinja.rs
+++ b/crates/lib/src/templaters/jinja.rs
@@ -1,16 +1,28 @@
+#[cfg(feature = "python")]
 use super::Templater;
+use super::TemplaterDocumentation;
+#[cfg(feature = "python")]
 use super::python::PythonTemplatedFile;
+#[cfg(feature = "python")]
 use crate::core::config::FluffConfig;
+#[cfg(feature = "python")]
 use crate::templaters::python_shared::PythonFluffConfig;
+#[cfg(feature = "python")]
 use crate::templaters::{Formatter, ProcessingMode, TemplaterKind};
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
 use pyo3::{Py, PyAny, Python};
+#[cfg(feature = "python")]
 use sqruff_lib_core::errors::SQLFluffUserError;
+#[cfg(feature = "python")]
 use sqruff_lib_core::templaters::TemplatedFile;
+#[cfg(feature = "python")]
 use std::sync::Arc;
 
 pub struct JinjaTemplater;
 
+#[cfg(feature = "python")]
 impl JinjaTemplater {
     fn process_single(
         &self,
@@ -72,7 +84,7 @@ impl JinjaTemplater {
     }
 }
 
-impl Templater for JinjaTemplater {
+impl TemplaterDocumentation for JinjaTemplater {
     fn name(&self) -> &'static str {
         "jinja"
     }
@@ -208,7 +220,10 @@ Now, `ds` can be used in SQL:
 SELECT "{{ "2000-01-01" | ds }}";
 ```"#
     }
+}
 
+#[cfg(feature = "python")]
+impl Templater for JinjaTemplater {
     fn processing_mode(&self) -> ProcessingMode {
         ProcessingMode::Sequential
     }
@@ -238,7 +253,7 @@ SELECT "{{ "2000-01-01" | ds }}";
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "python"))]
 mod tests {
     use crate::core::config::FluffConfig;
     use crate::core::linter::core::Linter;

--- a/crates/lib/src/templaters/placeholder.rs
+++ b/crates/lib/src/templaters/placeholder.rs
@@ -9,7 +9,7 @@ use sqruff_lib_core::templaters::{
 
 use crate::Formatter;
 use crate::core::config::FluffConfig;
-use crate::templaters::{PlaceholderStyle, ProcessingMode, Templater};
+use crate::templaters::{PlaceholderStyle, ProcessingMode, Templater, TemplaterDocumentation};
 
 #[derive(Default)]
 pub struct PlaceholderTemplater;
@@ -185,7 +185,7 @@ impl PlaceholderTemplater {
     }
 }
 
-impl Templater for PlaceholderTemplater {
+impl TemplaterDocumentation for PlaceholderTemplater {
     fn name(&self) -> &'static str {
         "placeholder"
     }
@@ -283,7 +283,9 @@ the named parameter param_name will be used as the key to replace, if missing, t
 
 Also consider making a pull request to the project to have your style added, it may be useful to other people and simplify your configuration."#
     }
+}
 
+impl Templater for PlaceholderTemplater {
     fn processing_mode(&self) -> ProcessingMode {
         ProcessingMode::Parallel
     }

--- a/crates/lib/src/templaters/python.rs
+++ b/crates/lib/src/templaters/python.rs
@@ -1,23 +1,71 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
 use pyo3::types::PySlice;
+#[cfg(feature = "python")]
 use pyo3::{Borrowed, Py, PyAny, Python};
+#[cfg(feature = "python")]
 use sqruff_lib_core::errors::SQLFluffUserError;
+#[cfg(feature = "python")]
 use sqruff_lib_core::templaters::{
     RawFileSlice, TemplateSliceKind, TemplatedFile, TemplatedFileSlice, char_idx_to_byte_idx,
     char_to_byte_indices,
 };
 
+#[cfg(feature = "python")]
 use super::Templater;
+use super::TemplaterDocumentation;
+#[cfg(feature = "python")]
 use crate::Formatter;
+#[cfg(feature = "python")]
 use crate::core::config::FluffConfig;
+#[cfg(feature = "python")]
 use crate::templaters::ProcessingMode;
+#[cfg(feature = "python")]
 use crate::templaters::TemplaterKind;
+#[cfg(feature = "python")]
 use crate::templaters::python_shared::PythonFluffConfig;
+#[cfg(feature = "python")]
 use std::sync::Arc;
 
 #[derive(Default)]
 pub struct PythonTemplater;
 
+impl TemplaterDocumentation for PythonTemplater {
+    fn name(&self) -> &'static str {
+        "python"
+    }
+
+    fn description(&self) -> &'static str {
+        r"**Note:** This templater currently does not work by default in the CLI and needs custom set up to work.
+
+The Python templater uses native Python f-strings. An example would be as follows:
+
+```sql
+SELECT * FROM {blah}
+```
+
+With the following config:
+
+```
+[sqruff]
+templater = python
+
+[sqruff:templater:python:context]
+blah = foo
+```
+
+Before parsing the sql will be transformed to:
+
+```sql
+SELECT * FROM foo
+```
+
+At the moment, dot notation is not supported in the templater."
+    }
+}
+
+#[cfg(feature = "python")]
 impl PythonTemplater {
     fn process_single(
         &self,
@@ -51,39 +99,8 @@ impl PythonTemplater {
     }
 }
 
+#[cfg(feature = "python")]
 impl Templater for PythonTemplater {
-    fn name(&self) -> &'static str {
-        "python"
-    }
-
-    fn description(&self) -> &'static str {
-        r"**Note:** This templater currently does not work by default in the CLI and needs custom set up to work.
-
-The Python templater uses native Python f-strings. An example would be as follows:
-
-```sql
-SELECT * FROM {blah}
-```
-
-With the following config:
-
-```
-[sqruff]
-templater = python
-
-[sqruff:templater:python:context]
-blah = foo
-```
-
-Before parsing the sql will be transformed to:
-
-```sql
-SELECT * FROM foo
-```
-
-At the moment, dot notation is not supported in the templater."
-    }
-
     fn processing_mode(&self) -> ProcessingMode {
         ProcessingMode::Sequential
     }
@@ -101,6 +118,7 @@ At the moment, dot notation is not supported in the templater."
     }
 }
 
+#[cfg(feature = "python")]
 #[derive(Debug)]
 struct PythonTemplatedFileSlice {
     slice_type: String,
@@ -108,6 +126,7 @@ struct PythonTemplatedFileSlice {
     templated_slice: std::ops::Range<usize>,
 }
 
+#[cfg(feature = "python")]
 impl<'a, 'py> FromPyObject<'a, 'py> for PythonTemplatedFileSlice {
     type Error = PyErr;
 
@@ -148,6 +167,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PythonTemplatedFileSlice {
     }
 }
 
+#[cfg(feature = "python")]
 #[derive(Debug)]
 struct PythonRawFileSlice {
     raw: String,
@@ -156,6 +176,7 @@ struct PythonRawFileSlice {
     block_idx: usize,
 }
 
+#[cfg(feature = "python")]
 impl<'a, 'py> FromPyObject<'a, 'py> for PythonRawFileSlice {
     type Error = PyErr;
 
@@ -174,6 +195,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PythonRawFileSlice {
     }
 }
 
+#[cfg(feature = "python")]
 #[derive(FromPyObject, Debug)]
 pub struct PythonTemplatedFile {
     source_str: String,
@@ -183,6 +205,7 @@ pub struct PythonTemplatedFile {
     raw_sliced: Option<Vec<PythonRawFileSlice>>,
 }
 
+#[cfg(feature = "python")]
 impl PythonTemplatedFile {
     pub fn to_templated_file(&self) -> PyResult<TemplatedFile> {
         // Python uses character-based indices, but Rust uses byte-based indices.
@@ -258,7 +281,7 @@ impl PythonTemplatedFile {
 }
 
 // Working on tests
-#[cfg(test)]
+#[cfg(all(test, feature = "python"))]
 mod tests {
     use super::*;
 

--- a/crates/lib/src/templaters/raw.rs
+++ b/crates/lib/src/templaters/raw.rs
@@ -5,7 +5,7 @@ use sqruff_lib_core::templaters::TemplatedFile;
 
 use crate::Formatter;
 use crate::core::config::FluffConfig;
-use crate::templaters::{ProcessingMode, Templater};
+use crate::templaters::{ProcessingMode, Templater, TemplaterDocumentation};
 
 #[derive(Default)]
 pub struct RawTemplater;
@@ -21,7 +21,7 @@ impl RawTemplater {
     }
 }
 
-impl Templater for RawTemplater {
+impl TemplaterDocumentation for RawTemplater {
     fn name(&self) -> &'static str {
         "raw"
     }
@@ -29,7 +29,9 @@ impl Templater for RawTemplater {
     fn description(&self) -> &'static str {
         r"The raw templater simply returns the input string as the output string. It passes through the input string unchanged and is useful if you need no templating. It is the default templater."
     }
+}
 
+impl Templater for RawTemplater {
     fn processing_mode(&self) -> ProcessingMode {
         ProcessingMode::Parallel
     }


### PR DESCRIPTION
## Summary

- split lightweight templater documentation from executable templater behavior with a new `TemplaterDocumentation` trait
- make `Templater` extend that trait while keeping an all-templater `TEMPLATER_DOCS` list available without the `python` feature
- move Python, Jinja, and dbt descriptions into documentation-only entries shared by their Python-enabled runtime implementations
- stop `codegen-docs` from enabling the `python` feature and remove Python runtime inputs from the Bazel docs check/fix actions

This takes the description-extraction idea from #3727 but completes it as a trait boundary: docs generation sees all five templaters as documentation trait objects and never needs to compile their Python-backed processing implementations.

Generated documentation is unchanged.

## Benchmark

Same checkout and command on `main` and this branch, with Bazel test-result caching disabled:

```text
bazelisk test --lockfile_mode=error //:codegen_docs_check \
  --nocache_test_results --test_output=errors --noshow_progress

main:      105.9s test / 118.703s total
candidate:  95.1s test / 105.654s total

change:    -10.8s test (-10.2%) / -13.049s total (-11.0%)
```

The candidate also removes the Bazel-managed Python runtime from the action graph and does not include PyO3 in the normal/build dependency graph for `--no-default-features --features codegen-docs`.

## Validation

- `cargo check -p sqruff --no-default-features --features codegen-docs`
- `cargo check -p sqruff --all-features`
- focused non-Python unit test confirms all five templaters are present in `TEMPLATER_DOCS`
- `bazelisk test --lockfile_mode=error //:codegen_docs_check //:cargo_compile_checks --nocache_test_results --test_output=errors --noshow_progress`
- `cargo fmt --all -- --check`
- `git diff --check`

`MODULE.bazel.lock` changes only by the expected `crates/cli-lib/Cargo.toml` input hash.
