### PR TITLE
chore(sqlfluff): record existing SQLite trigger port (6107)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-b1cf6c3964abc6bc44cccc82631c42e3dfaef1d9
+ae9dc4666b90fcc42b417c200bf0c3ebdb70483b


### PR DESCRIPTION
> Stacked on sqruff #3753. Merge #3753 first.
> Base PR: https://github.com/quarylabs/sqruff/pull/3753

## Summary

- advance the SQLFluff cursor for optionally bracketed SQLite trigger `WHEN` expressions
- record that the equivalent Rust grammar and exact upstream fixture already landed in sqruff #3104 (`740a6df9`)
- retain the existing generated parse fixture without duplication

## Upstream

- SQLFluff PR: https://github.com/sqlfluff/sqlfluff/pull/6107
- SQLFluff commit: https://github.com/sqlfluff/sqlfluff/commit/ae9dc4666b90fcc42b417c200bf0c3ebdb70483b

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p sqruff-lib-dialects --test dialects -- sqlite`
- `cargo build`
- `cargo test`
- `bazelisk test //... --jobs=2 --test_timeout=1200 --flaky_test_attempts=3 --test_output=errors`
- `bazelisk test //:verify_sqlfluff_sha --test_output=errors`
