### PR TITLE
fix(tsql): parse merge targets without aliases (6170)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-df8b47ab696dfb5f37fd09bc9d55b261cc3b1ee4
+67fbabe2d7ff2f6f9f33cefa9ec6d412086b3ed6

--- a/crates/lib-dialects/src/tsql.rs
+++ b/crates/lib-dialects/src/tsql.rs
@@ -2313,6 +2313,50 @@ pub fn raw_dialect() -> Dialect {
         ),
     ]);
 
+    // T-SQL MERGE supports table hints on the target. Excluding USING from the
+    // optional alias prevents a target without an alias from consuming it.
+    dialect.add([(
+        "MergeStatementSegment".into(),
+        NodeMatcher::new(SyntaxKind::MergeStatement, |_| {
+            Sequence::new(vec![
+                Ref::new("MergeIntoLiteralGrammar").to_matchable(),
+                MetaSegment::indent().to_matchable(),
+                Ref::new("TableReferenceSegment").to_matchable(),
+                Ref::new("TableHintSegment").optional().to_matchable(),
+                Ref::new("AliasExpressionSegment")
+                    .exclude(Ref::keyword("USING"))
+                    .optional()
+                    .to_matchable(),
+                MetaSegment::dedent().to_matchable(),
+                Ref::keyword("USING").to_matchable(),
+                MetaSegment::indent().to_matchable(),
+                one_of(vec![
+                    Ref::new("TableReferenceSegment").to_matchable(),
+                    Ref::new("AliasedTableReferenceGrammar").to_matchable(),
+                    Sequence::new(vec![
+                        Bracketed::new(vec![Ref::new("SelectableGrammar").to_matchable()])
+                            .to_matchable(),
+                        Ref::new("AliasExpressionSegment").optional().to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+                MetaSegment::dedent().to_matchable(),
+                Conditional::new(MetaSegment::indent())
+                    .indented_using_on()
+                    .to_matchable(),
+                Ref::new("JoinOnConditionSegment").to_matchable(),
+                Conditional::new(MetaSegment::dedent())
+                    .indented_using_on()
+                    .to_matchable(),
+                Ref::new("MergeMatchSegment").to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
     // Define PostTableExpressionGrammar to include T-SQL table hints
     dialect.add([(
         "PostTableExpressionGrammar".into(),

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/sqlfluff/merge.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/sqlfluff/merge.sql
@@ -1,0 +1,5 @@
+MERGE INTO dbo.target
+USING  (	SELECT 1 AS i	) AS source
+ON source.i = target.i
+WHEN MATCHED
+THEN  UPDATE SET target.i = source.i;

--- a/crates/lib-dialects/test/fixtures/dialects/tsql/sqlfluff/merge.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/tsql/sqlfluff/merge.yml
@@ -1,0 +1,61 @@
+file:
+- statement:
+  - merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: target
+    - keyword: USING
+    - bracketed:
+      - start_bracket: (
+      - select_statement:
+        - select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+            - numeric_literal: '1'
+            - alias_expression:
+              - alias_operator:
+                - keyword: AS
+              - naked_identifier: i
+      - end_bracket: )
+    - alias_expression:
+      - alias_operator:
+        - keyword: AS
+      - naked_identifier: source
+    - join_on_condition:
+      - keyword: ON
+      - expression:
+        - column_reference:
+          - naked_identifier: source
+          - dot: .
+          - naked_identifier: i
+        - comparison_operator:
+          - raw_comparison_operator: =
+        - column_reference:
+          - naked_identifier: target
+          - dot: .
+          - naked_identifier: i
+    - merge_match:
+      - merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+          - keyword: UPDATE
+          - set_clause_list:
+            - keyword: SET
+            - set_clause:
+              - column_reference:
+                - naked_identifier: target
+                - dot: .
+                - naked_identifier: i
+              - comparison_operator:
+                - raw_comparison_operator: =
+              - column_reference:
+                - naked_identifier: source
+                - dot: .
+                - naked_identifier: i
+- statement_terminator: ;


### PR DESCRIPTION
> Stacked on sqruff #3792. Merge #3792 first.
> Base PR: https://github.com/quarylabs/sqruff/pull/3792

## Summary

- add a T-SQL-specific `MERGE` target grammar while retaining table-hint support
- prevent `USING` from being consumed as the optional target alias
- add a regression parse fixture for `MERGE` without a target alias

Ported from SQLFluff 67fbabe2d7ff2f6f9f33cefa9ec6d412086b3ed6
https://github.com/sqlfluff/sqlfluff/pull/6170
https://github.com/sqlfluff/sqlfluff/commit/67fbabe2d7ff2f6f9f33cefa9ec6d412086b3ed6

## Verification

- `cargo fmt --all -- --check`
- `UPDATE_EXPECT=1 PYO3_PYTHON=/home/ben/.local/share/uv/python/cpython-3.13.15-linux-x86_64-gnu/bin/python3.13 cargo test -p sqruff-lib-dialects --test dialects -- tsql`
- `PYO3_PYTHON=/home/ben/.local/share/uv/python/cpython-3.13.15-linux-x86_64-gnu/bin/python3.13 cargo test -p sqruff-lib-dialects --test dialects -- tsql`
- `PYO3_PYTHON=/home/ben/.local/share/uv/python/cpython-3.13.15-linux-x86_64-gnu/bin/python3.13 cargo build`
- `PYO3_PYTHON=/home/ben/.local/share/uv/python/cpython-3.13.15-linux-x86_64-gnu/bin/python3.13 cargo test`
- `bazelisk test //... --jobs=2 --test_timeout=1200 --flaky_test_attempts=3 --test_output=errors`
- `bazelisk test //:verify_sqlfluff_sha --test_output=errors`
- `git diff --check`
