### PR TITLE
ci: move dialect tests to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -461,6 +461,7 @@ cargo_test(
 # Crates that don't need the Python/maturin setup run natively via rust_test:
 #   //crates/cli:cli_tests
 #   //crates/lib-dialects:dialect_tests
+#   //crates/lib-dialects:sqruff-lib-dialects-test
 #   //crates/lib-core:sqruff-lib-core-test
 #   //crates/sqlinference:sqruff-sqlinference-test
 #   //crates/lineage:lineage-test
@@ -474,6 +475,7 @@ test_suite(
         ":cargo_workspace_tests",
         "//crates/cli:cli_tests",
         "//crates/lib-dialects:dialect_tests",
+        "//crates/lib-dialects:sqruff-lib-dialects-test",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -450,7 +450,7 @@ cargo_test(
         "//crates/cli-python:python_srcs",
         "//crates/cli-python:test_fixtures",
         "//crates/lib:test_fixtures",
-        "//crates/lib-dialects:test_fixtures",
+        "//crates/lib-dialects:test/fixtures/dialects/ansi/sqlfluff/select_in_multiline_comment.sql",
     ],
     vendor = ":cargo_deps",
     python_venv = ":python_deps",
@@ -460,10 +460,11 @@ cargo_test(
 
 # Crates that don't need the Python/maturin setup run natively via rust_test:
 #   //crates/cli:cli_tests
+#   //crates/lib-dialects:dialect_tests
 #   //crates/lib-core:sqruff-lib-core-test
 #   //crates/sqlinference:sqruff-sqlinference-test
 #   //crates/lineage:lineage-test
-cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-sqlinference --exclude lineage --locked --offline
+cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-lib-dialects --exclude sqruff-sqlinference --exclude lineage --locked --offline
 """,
 )
 
@@ -472,6 +473,7 @@ test_suite(
     tests = [
         ":cargo_workspace_tests",
         "//crates/cli:cli_tests",
+        "//crates/lib-dialects:dialect_tests",
     ],
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2642,7 +2642,7 @@
           "FILE:@@//crates/cli-python/Cargo.toml 7a4307b8bf718c65f746fe859557c2f512e07dee134d9f66fb686e541cbf0d03",
           "FILE:@@//crates/lib/Cargo.toml b37090b55ba169d84535af30a8746e2572bda1d5eec572e833ef11208285bc84",
           "FILE:@@//crates/lib-core/Cargo.toml 6d5efc6ffa84b5a69c9fd863be45cb59d7845fc142ae5ce67ea70c5e46e31a1e",
-          "FILE:@@//crates/lib-dialects/Cargo.toml 115e8dae13062b527ef53aba6d5577dc31d9ca7e3f3ce69fd54b2b0ce78ea690",
+          "FILE:@@//crates/lib-dialects/Cargo.toml e8137157c786eb056134ccbb1a12afaa8253bf7700deff2947afa74fd3554945",
           "FILE:@@//crates/lib-wasm/Cargo.toml b30295c41e74e6f1cb5b93e9eb1d4c542578c0c53dd3afededd0edc93a804b8f",
           "FILE:@@//crates/lineage/Cargo.toml d26ee434e736f8dd310937ca3dad5a5090d207ecf3e553dd627b4bdc576d82bb",
           "FILE:@@//crates/lsp/Cargo.toml 548d1f199a3efb4d69da8a4f0b1fb9fdc4a8b0be0a2a7b87ee2857a353e67081",

--- a/crates/lib-dialects/BUILD.bazel
+++ b/crates/lib-dialects/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite")
 
 exports_files([
     "Cargo.toml",
@@ -41,6 +41,14 @@ rust_library(
     deps = all_crate_deps(normal = True) + [
         "//crates/lib-core:sqruff-lib-core",
     ],
+)
+
+rust_test(
+    name = "sqruff-lib-dialects-test",
+    crate = ":sqruff-lib-dialects",
+    crate_features = ALL_FEATURES,
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+    deps = all_crate_deps(normal_dev = True),
 )
 
 rust_test_suite(

--- a/crates/lib-dialects/BUILD.bazel
+++ b/crates/lib-dialects/BUILD.bazel
@@ -1,7 +1,10 @@
-load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
-exports_files(["Cargo.toml"])
+exports_files([
+    "Cargo.toml",
+    "test/fixtures/dialects/ansi/sqlfluff/select_in_multiline_comment.sql",
+])
 
 # Keep in sync with the features enabled by default in Cargo.toml.
 ALL_FEATURES = [
@@ -38,6 +41,29 @@ rust_library(
     deps = all_crate_deps(normal = True) + [
         "//crates/lib-core:sqruff-lib-core",
     ],
+)
+
+rust_test_suite(
+    name = "dialect_tests",
+    srcs = ["tests/dialects.rs"],
+    crate_features = ALL_FEATURES,
+    data = [
+        ":test_fixtures",
+        "Cargo.toml",
+    ],
+    deps = all_crate_deps(normal = True) + crate_deps([
+        "configparser",
+        "expect-test",
+        "glob",
+        "rayon",
+    ]) + [
+        ":sqruff-lib-dialects",
+        "//crates/lib-core:sqruff-lib-core",
+    ],
+    env = {
+        "SQRUFF_TEST_MANIFEST": "$(rootpath :Cargo.toml)",
+    },
+    size = "small",
 )
 
 filegroup(

--- a/crates/lib-dialects/Cargo.toml
+++ b/crates/lib-dialects/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [[test]]
 name = "dialects"
-harness = false
+harness = true
 
 [features]
 default = [

--- a/crates/lib-dialects/tests/dialects.rs
+++ b/crates/lib-dialects/tests/dialects.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use configparser::ini::Ini;
@@ -16,6 +17,25 @@ use sqruff_lib_core::parser::segments::{ErasedSegment, Tables};
 use sqruff_lib_core::value::Value;
 use sqruff_lib_dialects::kind_to_dialect;
 use strum::IntoEnumIterator;
+
+fn absolute_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().unwrap().join(path)
+    }
+}
+
+fn manifest_dir() -> PathBuf {
+    if let Some(manifest) = std::env::var_os("SQRUFF_TEST_MANIFEST") {
+        return absolute_path(PathBuf::from(manifest))
+            .parent()
+            .unwrap()
+            .to_path_buf();
+    }
+
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
 
 fn check_no_unparsable_segments(tree: &ErasedSegment) -> Vec<String> {
     tree.recursive_crawl_all(false)
@@ -172,8 +192,10 @@ fn known_missing_references(dialect: DialectKind) -> &'static [&'static str] {
     }
 }
 
-fn validate_dialect_reference_baseline() {
-    for dialect_kind in DialectKind::iter() {
+fn validate_dialect_reference_baseline(arg_dialect: Option<DialectKind>) {
+    for dialect_kind in
+        DialectKind::iter().filter(|dialect| arg_dialect.is_none_or(|arg| arg == *dialect))
+    {
         let Some(dialect) = kind_to_dialect(&dialect_kind, None) else {
             continue;
         };
@@ -198,16 +220,15 @@ fn validate_dialect_reference_baseline() {
     }
 }
 
-fn main() {
-    validate_dialect_reference_baseline();
+#[test]
+fn dialects() {
+    // Set SQRUFF_TEST_DIALECT to run the fixtures for a single dialect.
+    let arg_dialect = std::env::var("SQRUFF_TEST_DIALECT").ok().map(|dialect| {
+        DialectKind::from_str(&dialect)
+            .unwrap_or_else(|_| panic!("unknown dialect in SQRUFF_TEST_DIALECT: {dialect}"))
+    });
 
-    let args = std::env::args().skip(1).collect::<Vec<String>>();
-
-    let mut arg_dialect = None;
-
-    if args.len() == 1 {
-        arg_dialect = Some(DialectKind::from_str(&args[0]).unwrap());
-    }
+    validate_dialect_reference_baseline(arg_dialect);
 
     let dialects = DialectKind::iter()
         .filter(|dialect| arg_dialect.is_none() || &arg_dialect.unwrap() == dialect)
@@ -216,7 +237,7 @@ fn main() {
     println!("{dialects:?}");
 
     // list folders in the dialects directory
-    let dialects_dir = std::path::Path::new("test/fixtures/dialects");
+    let dialects_dir = manifest_dir().join("test/fixtures/dialects");
     let dialects_dirs = dialects_dir
         .read_dir()
         .unwrap()
@@ -227,7 +248,7 @@ fn main() {
             }
             Some(entry.unwrap().path())
         })
-        .collect::<HashSet<std::path::PathBuf>>();
+        .collect::<HashSet<PathBuf>>();
     println!("{dialects_dirs:?}");
 
     // check if all dialects have a corresponding folder
@@ -248,8 +269,11 @@ fn main() {
             continue;
         }
 
-        let path = format!("test/fixtures/dialects/{dialect_name}/*/*.sql");
-        let files = glob::glob(&path).unwrap().flatten().collect_vec();
+        let path = dialects_dir.join(dialect_name).join("*").join("*.sql");
+        let files = glob::glob(path.to_str().unwrap())
+            .unwrap()
+            .flatten()
+            .collect_vec();
         let dialects_by_fixture_dir = files
             .iter()
             .map(|file| file.parent().unwrap())


### PR DESCRIPTION
Depends on #3802.

## Summary

- run the dialect fixture integration test through a native Bazel rust_test_suite
- use the standard Rust test harness while retaining targeted runs through SQRUFF_TEST_DIALECT
- exclude sqruff-lib-dialects from the monolithic Cargo workspace test
- keep the native dialect suite in the aggregate //:cargo_test target
- narrow the remaining Cargo workspace fixture dependency to the one SQL file consumed by sqruff-lib

## Testing

- bazel test //crates/lib-dialects:dialect_tests --cache_test_results=no --test_arg=--nocapture --test_output=all
  - verified all 23 dialect directories and all 1,544 SQL fixtures
- bazel test //crates/lib-dialects:dialect_tests --test_env=SQRUFF_TEST_DIALECT=clickhouse --cache_test_results=no --test_arg=--nocapture --test_output=all
  - verified exactly 52 ClickHouse fixtures
- bazel test //:cargo_test --test_output=errors
  - all 13 test targets passed
- bazel test //:cargo_workspace_tests //:keep_sorted_check --test_output=errors
- SQRUFF_TEST_DIALECT=clickhouse cargo test -p sqruff-lib-dialects --test dialects
- cargo fmt --all -- --check
- git diff --check