### PR TITLE
ci: speed up remaining cargo workspace tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -455,6 +455,12 @@ cargo_test(
     vendor = ":cargo_deps",
     python_venv = ":python_deps",
     script = """
+# Cargo builds into a disposable target directory, so incremental artifacts and
+# debug information only add work and are discarded after this test finishes.
+export CARGO_INCREMENTAL=0
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_PROFILE_TEST_DEBUG=0
+
 # Build Python extension (maturin uses the vendored cargo + pre-cached venv)
 (cd crates/cli-python && maturin develop --locked --offline)
 
@@ -463,9 +469,12 @@ cargo_test(
 #   //crates/lib-dialects:dialect_tests
 #   //crates/lib-dialects:sqruff-lib-dialects-test
 #   //crates/lib-core:sqruff-lib-core-test
+#   //crates/lsp:sqruff-lsp-test
 #   //crates/sqlinference:sqruff-sqlinference-test
 #   //crates/lineage:lineage-test
-cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-lib-dialects --exclude sqruff-sqlinference --exclude lineage --locked --offline
+# sqruff-wasm has no Cargo tests; its WASM output is exercised by the playground
+# browser tests instead.
+cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-lib-dialects --exclude sqruff-lsp --exclude sqruff-sqlinference --exclude sqruff-wasm --exclude lineage --locked --offline
 """,
 )
 
@@ -476,6 +485,7 @@ test_suite(
         "//crates/cli:cli_tests",
         "//crates/lib-dialects:dialect_tests",
         "//crates/lib-dialects:sqruff-lib-dialects-test",
+        "//crates/lsp:sqruff-lsp-test",
     ],
 )
 

--- a/crates/lsp/BUILD.bazel
+++ b/crates/lsp/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library", "rust_test")
 load("@rules_rust_wasm_bindgen//:defs.bzl", "rust_wasm_bindgen")
 
 exports_files(["Cargo.toml"])
@@ -13,6 +13,13 @@ rust_library(
         "//crates/lib-core:sqruff-lib-core",
         "//crates/lib:sqruff-lib",
     ],
+)
+
+rust_test(
+    name = "sqruff-lsp-test",
+    crate = ":sqruff-lsp",
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+    deps = all_crate_deps(normal_dev = True),
 )
 
 # Crate deps for WASM build - explicit list to avoid pyo3 which doesn't support WASM


### PR DESCRIPTION
## Summary

- run the nine sqruff-lsp unit tests as a native Bazel rust_test and exclude their Cargo test target
- exclude sqruff-wasm from Cargo tests while retaining its Playwright browser coverage
- disable Cargo incremental compilation and dev/test debug info in the disposable workspace-test build

## Performance

Controlled uncached cargo_workspace_tests timings on macOS:

- baseline: 95.4s
- profile settings only: 85.7s
- final change with LSP and WASM exclusions: 83.5s

This reduces the test runtime by 11.9s, or 12.5%.

## Verification

- bazel test //crates/lsp:sqruff-lsp-test //:keep_sorted_check --test_output=errors
- bazel test //:cargo_workspace_tests //crates/lsp:sqruff-lsp-test --cache_test_results=no --test_output=errors
- bazel test //playground:playwright_test --cache_test_results=no --test_output=errors
- bazel test //:cargo_test --test_output=errors
- git diff --check