### PR TITLE
ci: parallelize Python version tests

### DIFF
--- a/.hacking/scripts/pytest_uv.sh
+++ b/.hacking/scripts/pytest_uv.sh
@@ -4,11 +4,24 @@ set -eo pipefail
 
 VENV_DIR="$RUNFILES_DIR/$PYTHON_VENV"
 
-# Create a temp directory and copy everything there so paths are consistent
-# This is needed because dbt parses the project and stores paths in its manifest,
-# and those paths need to match when we later search for files.
-WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+# Keep every writable location inside Bazel's per-test temporary directory so
+# Python versions can run concurrently without sharing state through $HOME,
+# caches, bytecode, temporary files, or coverage data.
+STATE_DIR="$TEST_TMPDIR/state"
+WORKDIR="$TEST_TMPDIR/work"
+mkdir -p \
+    "$STATE_DIR/home" \
+    "$STATE_DIR/xdg-cache" \
+    "$STATE_DIR/pycache" \
+    "$STATE_DIR/tmp" \
+    "$WORKDIR"
+
+export HOME="$STATE_DIR/home"
+export XDG_CACHE_HOME="$STATE_DIR/xdg-cache"
+export PYTHONPYCACHEPREFIX="$STATE_DIR/pycache"
+export TMPDIR="$STATE_DIR/tmp"
+export COVERAGE_FILE="$STATE_DIR/.coverage"
+export PYTHONNOUSERSITE=1
 
 # Copy project files to temp directory (use -L to follow symlinks from runfiles)
 cp -rL "$RUNFILES_DIR/_main/crates" "$WORKDIR/"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -601,12 +601,11 @@ sh_test(
         data = [
             ":pytest_py{}_venv".format(version.replace(".", "")),
             "//crates/cli-python:python_srcs",
-            "//crates/cli-python:test_fixtures",
+            "//crates/cli-python:dbt_test_fixtures",
         ],
         env = {
             "PYTHON_VENV": "$(rlocationpath :pytest_py{}_venv)".format(version.replace(".", "")),
         },
-        tags = ["exclusive"],
     )
     for version in [
         "3.10",

--- a/crates/cli-python/BUILD.bazel
+++ b/crates/cli-python/BUILD.bazel
@@ -20,6 +20,14 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+# The pure-Python tests only consume the sample dbt project. Keep their Bazel
+# inputs separate from the Rust integration fixtures to avoid needless reruns.
+filegroup(
+    name = "dbt_test_fixtures",
+    srcs = glob(["tests/dbt_sample/**/*"]),
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "machete_srcs",
     srcs = glob(


### PR DESCRIPTION
## What

- isolate `HOME`, XDG cache, bytecode, temporary files, and coverage output inside each Bazel test temporary directory
- remove the `exclusive` tag from the Python 3.10-3.13 pytest targets
- narrow the pure-Python fixture input from every CLI integration fixture to the DBT sample it actually uses

## Why

The matrix was serialized after historical CI conflicts. Explicitly isolating every writable location removes that shared state, allowing the four versions to run concurrently while retaining separate interpreter-specific environments.

The narrower fixture filegroup also avoids invalidating all four pytest targets when unrelated Rust integration fixtures change.

## Performance

- serialized baseline: 16.5 seconds
- parallel matrix: 6.9 seconds
- reduction: 9.6 seconds / 58%

## Validation

- all four versions each discovered and passed 29 tests
- 5 runs per version, 20 executions total, passed with 4 concurrent jobs
- `//:shellcheck`
- `//:keep_sorted_check`

Stacked on #3808.