### PR TITLE
feat(databricks): expand create table support (6216)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-372f7ffc2feab03ef0ee38016eda976db8fa42c1
+efcf0691bfe6cdee35535c52c0a975f0feb436ef

--- a/crates/lib-dialects/src/databricks.rs
+++ b/crates/lib-dialects/src/databricks.rs
@@ -1021,6 +1021,140 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                 )
                 .into(),
         ),
+        (
+            "LocationWithCredentialGrammar".into(),
+            Sequence::new(vec![
+                Ref::keyword("LOCATION").to_matchable(),
+                Ref::new("QuotedLiteralSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("WITH").to_matchable(),
+                    Bracketed::new(vec![
+                        Ref::keyword("CREDENTIAL").to_matchable(),
+                        Ref::new("PrincipalIdentifierSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .config(|config| config.optional())
+                .to_matchable(),
+            ])
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "CreateTableUsingStatementSegment".into(),
+            NodeMatcher::new(SyntaxKind::CreateTableUsingStatement, |_| {
+                Sequence::new(vec![
+                    one_of(vec![
+                        Sequence::new(vec![
+                            Sequence::new(vec![
+                                Ref::keyword("CREATE").to_matchable(),
+                                Ref::keyword("OR").optional().to_matchable(),
+                            ])
+                            .to_matchable(),
+                            Ref::keyword("REPLACE").to_matchable(),
+                            Ref::keyword("TABLE").to_matchable(),
+                        ])
+                        .to_matchable(),
+                        Sequence::new(vec![
+                            Ref::keyword("CREATE").to_matchable(),
+                            Ref::keyword("EXTERNAL").optional().to_matchable(),
+                            Ref::keyword("TABLE").to_matchable(),
+                            Ref::new("IfNotExistsGrammar").optional().to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                    Ref::new("TableReferenceSegment").to_matchable(),
+                    Ref::new("TableSpecificationSegment")
+                        .optional()
+                        .to_matchable(),
+                    Sequence::new(vec![
+                        Ref::keyword("USING").to_matchable(),
+                        Ref::new("DataSourceFormatSegment").to_matchable(),
+                    ])
+                    .config(|config| config.optional())
+                    .to_matchable(),
+                    AnyNumberOf::new(vec![Ref::new("TableClausesSegment").to_matchable()])
+                        .to_matchable(),
+                    Sequence::new(vec![
+                        Ref::keyword("AS").to_matchable(),
+                        one_of(vec![
+                            Ref::new("SelectStatementSegment").to_matchable(),
+                            Ref::new("ValuesClauseSegment").to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .config(|config| config.optional())
+                    .to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "TableSpecificationSegment".into(),
+            NodeMatcher::new(SyntaxKind::TableSpecificationSegment, |_| {
+                Bracketed::new(vec![
+                    Delimited::new(vec![
+                        Sequence::new(vec![
+                            Ref::new("ColumnReferenceSegment").to_matchable(),
+                            Ref::new("DatatypeSegment").to_matchable(),
+                            AnyNumberOf::new(vec![
+                                Ref::new("ColumnPropertiesSegment").to_matchable(),
+                            ])
+                            .to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "ColumnPropertiesSegment".into(),
+            NodeMatcher::new(SyntaxKind::ColumnPropertiesSegment, |_| {
+                one_of(vec![
+                    Ref::new("NotNullGrammar").to_matchable(),
+                    Ref::new("GeneratedColumnDefinitionSegment").to_matchable(),
+                    Sequence::new(vec![
+                        Ref::keyword("DEFAULT").to_matchable(),
+                        Ref::new("ColumnConstraintDefaultGrammar").to_matchable(),
+                    ])
+                    .to_matchable(),
+                    Ref::new("CommentGrammar").to_matchable(),
+                    Ref::new("ColumnConstraintSegment").to_matchable(),
+                    Ref::new("MaskStatementSegment").to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
+        (
+            "TableClausesSegment".into(),
+            NodeMatcher::new(SyntaxKind::TableClausesSegment, |_| {
+                one_of(vec![
+                    Ref::new("PartitionClauseSegment").to_matchable(),
+                    Ref::new("ClusterByClauseSegment").to_matchable(),
+                    Ref::new("LocationWithCredentialGrammar").to_matchable(),
+                    Ref::new("OptionsGrammar").to_matchable(),
+                    Ref::new("CommentGrammar").to_matchable(),
+                    Ref::new("TablePropertiesGrammar").to_matchable(),
+                    Sequence::new(vec![
+                        Ref::keyword("WITH").to_matchable(),
+                        Ref::new("RowFilterClauseGrammar").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable()
+            })
+            .to_matchable()
+            .into(),
+        ),
         // https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-dml-insert-into#insert-using-the-by-name-clause
         (
             "InsertBracketedColumnReferenceListGrammar".into(),
@@ -1036,6 +1170,58 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
             .into(),
         ),
     ]);
+
+    databricks.replace_grammar(
+        "NotNullGrammar",
+        Sequence::new(vec![
+            Ref::keyword("NOT").to_matchable(),
+            Ref::keyword("NULL").to_matchable(),
+        ])
+        .to_matchable(),
+    );
+
+    databricks.replace_grammar(
+        "ColumnConstraintSegment",
+        Sequence::new(vec![
+            Ref::new("NotNullGrammar").optional().to_matchable(),
+            Sequence::new(vec![
+                Sequence::new(vec![
+                    Ref::keyword("CONSTRAINT").to_matchable(),
+                    Ref::new("ObjectReferenceSegment").to_matchable(),
+                ])
+                .config(|config| config.optional())
+                .to_matchable(),
+                one_of(vec![
+                    Sequence::new(vec![
+                        Ref::new("PrimaryKeyGrammar").to_matchable(),
+                        Ref::new("ConstraintOptionGrammar")
+                            .optional()
+                            .to_matchable(),
+                    ])
+                    .to_matchable(),
+                    Sequence::new(vec![
+                        Ref::new("ForeignKeyGrammar").optional().to_matchable(),
+                        Ref::keyword("REFERENCES").to_matchable(),
+                        Ref::new("TableReferenceSegment").to_matchable(),
+                        Ref::new("BracketedColumnReferenceListGrammar")
+                            .optional()
+                            .to_matchable(),
+                        one_of(vec![
+                            Ref::new("ForeignKeyOptionGrammar").to_matchable(),
+                            Ref::new("ConstraintOptionGrammar").to_matchable(),
+                        ])
+                        .config(|config| config.optional())
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .config(|config| config.optional())
+            .to_matchable(),
+        ])
+        .to_matchable(),
+    );
 
     // https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-using.html
     databricks.replace_grammar(
@@ -1055,6 +1241,7 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                         one_of(vec![
                             Ref::new("FunctionSegment").to_matchable(),
                             Ref::new("BareFunctionSegment").to_matchable(),
+                            Ref::new("ExpressionSegment").to_matchable(),
                         ])
                         .to_matchable(),
                     ])
@@ -1094,12 +1281,6 @@ pub fn dialect(config: Option<&Value>) -> Dialect {
                     .to_matchable(),
                 ])
                 .to_matchable(),
-            ])
-            .to_matchable(),
-            AnyNumberOf::new(vec![
-                Ref::new("ColumnConstraintSegment")
-                    .optional()
-                    .to_matchable(),
             ])
             .to_matchable(),
         ])

--- a/crates/lib-dialects/src/sparksql.rs
+++ b/crates/lib-dialects/src/sparksql.rs
@@ -1122,7 +1122,7 @@ pub fn raw_dialect() -> Dialect {
                         Delimited::new(vec![
                             Sequence::new(vec![
                                 one_of(vec![
-                                    Ref::new("ColumnDefinitionSegment").to_matchable(),
+                                    Ref::new("ColumnFieldDefinitionSegment").to_matchable(),
                                     Ref::new("GeneratedColumnDefinitionSegment").to_matchable(),
                                     Ref::new("TableConstraintSegment").to_matchable(),
                                 ])

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/create_table.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/create_table.sql
@@ -18,3 +18,44 @@ OPTIMIZE tablename;
 OPTIMIZE tablename
 WHERE date >= current_timestamp() - INTERVAL 1 day
 ZORDER BY (eventType, eventTime);
+
+
+-- Creates a Delta table
+CREATE TABLE student (id INT, name STRING, age INT);
+
+-- Use data from another table
+CREATE TABLE student_copy AS SELECT * FROM student;
+
+-- Creates a CSV table from an external directory
+CREATE TABLE student USING CSV LOCATION '/path/to/csv_files';
+
+-- Specify table comment and properties
+CREATE TABLE student (id INT, name STRING, age INT)
+    COMMENT 'this is a comment'
+    TBLPROPERTIES ('foo'='bar');
+
+-- Specify table comment and properties with different clauses order
+CREATE TABLE student (id INT, name STRING, age INT)
+    TBLPROPERTIES ('foo'='bar')
+    COMMENT 'this is a comment';
+
+-- Create partitioned table
+CREATE TABLE student (id INT, name STRING, age INT)
+    PARTITIONED BY (age);
+
+-- Create a table with a generated column
+CREATE TABLE rectangles(a INT, b INT,
+                          area INT GENERATED ALWAYS AS (a * b));
+
+-- Create a table with a primary key
+CREATE TABLE rectangles(a INT, b INT PRIMARY KEY);
+
+-- Create a table with a not null primary key
+CREATE TABLE rectangles(a INT NOT NULL, b INT NOT NULL PRIMARY KEY);
+
+-- Create a table with a foreign key relation
+CREATE OR REPLACE TABLE TABLE1 (
+  DATE_VALUE DATE NOT NULL
+    CONSTRAINT DATE_CONSTRAINT
+    FOREIGN KEY REFERENCES TABLE2
+);

--- a/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/databricks/sqlfluff/create_table.yml
@@ -9,13 +9,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id_column
+        - column_reference:
+          - naked_identifier: id_column
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: othercolumn
+        - column_reference:
+          - naked_identifier: othercolumn
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -173,4 +175,327 @@ file:
     - column_reference:
       - naked_identifier: eventTime
     - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: student
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: id
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: name
+        - data_type:
+          - primitive_type:
+            - keyword: STRING
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: age
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: student_copy
+    - keyword: AS
+    - select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+          - wildcard_expression:
+            - wildcard_identifier:
+              - star: '*'
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+          - from_expression_element:
+            - table_expression:
+              - table_reference:
+                - object_reference:
+                  - naked_identifier: student
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: student
+    - using_clause:
+      - keyword: USING
+      - data_source_format:
+        - keyword: CSV
+    - keyword: LOCATION
+    - quoted_literal: '''/path/to/csv_files'''
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: student
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: id
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: name
+        - data_type:
+          - primitive_type:
+            - keyword: STRING
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: age
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - end_bracket: )
+    - keyword: COMMENT
+    - quoted_literal: '''this is a comment'''
+    - keyword: TBLPROPERTIES
+    - bracketed:
+      - start_bracket: (
+      - property_name_identifier:
+        - quoted_identifier: '''foo'''
+      - comparison_operator:
+        - raw_comparison_operator: =
+      - quoted_literal: '''bar'''
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: student
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: id
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: name
+        - data_type:
+          - primitive_type:
+            - keyword: STRING
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: age
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - end_bracket: )
+    - keyword: TBLPROPERTIES
+    - bracketed:
+      - start_bracket: (
+      - property_name_identifier:
+        - quoted_identifier: '''foo'''
+      - comparison_operator:
+        - raw_comparison_operator: =
+      - quoted_literal: '''bar'''
+      - end_bracket: )
+    - keyword: COMMENT
+    - quoted_literal: '''this is a comment'''
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: student
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: id
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: name
+        - data_type:
+          - primitive_type:
+            - keyword: STRING
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: age
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - end_bracket: )
+    - keyword: PARTITIONED
+    - keyword: BY
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+        - naked_identifier: age
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: rectangles
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: a
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: b
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - generated_column_definition:
+        - naked_identifier: area
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+        - keyword: GENERATED
+        - keyword: ALWAYS
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - expression:
+            - column_reference:
+              - naked_identifier: a
+            - binary_operator: '*'
+            - column_reference:
+              - naked_identifier: b
+          - end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: rectangles
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: a
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: b
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+        - column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: rectangles
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: a
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+      - comma: ','
+      - column_definition:
+        - column_reference:
+          - naked_identifier: b
+        - data_type:
+          - primitive_type:
+            - keyword: INT
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+          - keyword: PRIMARY
+          - keyword: KEY
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+      - object_reference:
+        - naked_identifier: TABLE1
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - column_reference:
+          - naked_identifier: DATE_VALUE
+        - data_type:
+          - primitive_type:
+            - keyword: DATE
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+          - keyword: CONSTRAINT
+          - object_reference:
+            - naked_identifier: DATE_CONSTRAINT
+          - keyword: FOREIGN
+          - keyword: KEY
+          - keyword: REFERENCES
+          - table_reference:
+            - object_reference:
+              - naked_identifier: TABLE2
+      - end_bracket: )
 - statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_complex_datatypes.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_complex_datatypes.yml
@@ -8,7 +8,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: a
+        - column_reference:
+          - naked_identifier: a
         - data_type:
           - struct_type:
             - keyword: STRUCT
@@ -28,7 +29,8 @@ file:
               - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: d
+        - column_reference:
+          - naked_identifier: d
         - data_type:
           - keyword: MAP
           - start_angle_bracket: <
@@ -42,7 +44,8 @@ file:
           - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: e
+        - column_reference:
+          - naked_identifier: e
         - data_type:
           - array_type:
             - keyword: ARRAY
@@ -62,7 +65,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: a
+        - column_reference:
+          - naked_identifier: a
         - data_type:
           - struct_type:
             - keyword: STRUCT
@@ -88,7 +92,8 @@ file:
             - quoted_literal: '''col_comment'''
       - comma: ','
       - column_definition:
-        - naked_identifier: d
+        - column_reference:
+          - naked_identifier: d
         - data_type:
           - keyword: MAP
           - start_angle_bracket: <
@@ -106,7 +111,8 @@ file:
             - quoted_literal: '''col_comment'''
       - comma: ','
       - column_definition:
-        - naked_identifier: e
+        - column_reference:
+          - naked_identifier: e
         - data_type:
           - array_type:
             - keyword: ARRAY
@@ -130,7 +136,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: a
+        - column_reference:
+          - naked_identifier: a
         - data_type:
           - struct_type:
             - keyword: STRUCT
@@ -158,7 +165,8 @@ file:
               - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: d
+        - column_reference:
+          - naked_identifier: d
         - data_type:
           - keyword: MAP
           - start_angle_bracket: <
@@ -194,7 +202,8 @@ file:
           - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: g
+        - column_reference:
+          - naked_identifier: g
         - data_type:
           - array_type:
             - keyword: ARRAY
@@ -236,7 +245,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: a
+        - column_reference:
+          - naked_identifier: a
         - data_type:
           - struct_type:
             - keyword: STRUCT
@@ -256,7 +266,8 @@ file:
               - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - quoted_identifier: '`d`'
+        - column_reference:
+          - quoted_identifier: '`d`'
         - data_type:
           - keyword: MAP
           - start_angle_bracket: <
@@ -270,7 +281,8 @@ file:
           - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: e
+        - column_reference:
+          - naked_identifier: e
         - data_type:
           - array_type:
             - keyword: ARRAY
@@ -290,13 +302,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: field_a
+        - column_reference:
+          - naked_identifier: field_a
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: field_b
+        - column_reference:
+          - naked_identifier: field_b
         - data_type:
           - primitive_type:
             - keyword: VARIANT

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_datasource.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_datasource.yml
@@ -11,7 +11,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: test
+        - column_reference:
+          - naked_identifier: test
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -121,19 +122,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -181,19 +185,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -208,19 +215,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -250,19 +260,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -302,19 +315,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -340,19 +356,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -388,13 +407,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: test_value
+        - column_reference:
+          - naked_identifier: test_value
         - data_type:
           - primitive_type:
             - keyword: string
       - comma: ','
       - column_definition:
-        - naked_identifier: activity_date_partition
+        - column_reference:
+          - naked_identifier: activity_date_partition
         - data_type:
           - primitive_type:
             - keyword: date

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_hiveformat.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_hiveformat.yml
@@ -12,7 +12,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: col_name1
+        - column_reference:
+          - naked_identifier: col_name1
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -118,19 +119,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -173,19 +177,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -214,19 +221,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -255,13 +265,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -289,13 +301,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -323,13 +337,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -356,13 +372,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: friends
+        - column_reference:
+          - naked_identifier: friends
         - data_type:
           - array_type:
             - keyword: ARRAY
@@ -373,7 +391,8 @@ file:
             - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: children
+        - column_reference:
+          - naked_identifier: children
         - data_type:
           - keyword: MAP
           - start_angle_bracket: <
@@ -387,7 +406,8 @@ file:
           - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
-        - naked_identifier: address
+        - column_reference:
+          - naked_identifier: address
         - data_type:
           - struct_type:
             - keyword: STRUCT
@@ -490,13 +510,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: family_name
+        - column_reference:
+          - naked_identifier: family_name
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -524,13 +546,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -558,13 +582,15 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: test_name
+        - column_reference:
+          - naked_identifier: test_name
         - data_type:
           - primitive_type:
             - keyword: STRING

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_primitive_datatypes.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/create_table_primitive_datatypes.yml
@@ -8,19 +8,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: a
+        - column_reference:
+          - naked_identifier: a
         - data_type:
           - primitive_type:
             - keyword: LONG
       - comma: ','
       - column_definition:
-        - naked_identifier: b
+        - column_reference:
+          - naked_identifier: b
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: c
+        - column_reference:
+          - naked_identifier: c
         - data_type:
           - primitive_type:
             - keyword: SMALLINT

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/databricks_dlt_create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/databricks_dlt_create_table.yml
@@ -220,7 +220,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: a
+        - column_reference:
+          - naked_identifier: a
         - data_type:
           - primitive_type:
             - keyword: STRING
@@ -230,7 +231,8 @@ file:
             - quoted_literal: '''a'''
       - comma: ','
       - column_definition:
-        - naked_identifier: b
+        - column_reference:
+          - naked_identifier: b
         - data_type:
           - primitive_type:
             - keyword: INT

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/delta_change_data_feed.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/delta_change_data_feed.yml
@@ -8,19 +8,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: student_name
+        - column_reference:
+          - naked_identifier: student_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: age
+        - column_reference:
+          - naked_identifier: age
         - data_type:
           - primitive_type:
             - keyword: INT

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/delta_create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/delta_create_table.yml
@@ -13,49 +13,57 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: first_name
+        - column_reference:
+          - naked_identifier: first_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: middle_name
+        - column_reference:
+          - naked_identifier: middle_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: last_name
+        - column_reference:
+          - naked_identifier: last_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: gender
+        - column_reference:
+          - naked_identifier: gender
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: birth_date
+        - column_reference:
+          - naked_identifier: birth_date
         - data_type:
           - primitive_type:
             - keyword: TIMESTAMP
       - comma: ','
       - column_definition:
-        - naked_identifier: ssn
+        - column_reference:
+          - naked_identifier: ssn
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: salary
+        - column_reference:
+          - naked_identifier: salary
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -78,49 +86,57 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: first_name
+        - column_reference:
+          - naked_identifier: first_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: middle_name
+        - column_reference:
+          - naked_identifier: middle_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: last_name
+        - column_reference:
+          - naked_identifier: last_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: gender
+        - column_reference:
+          - naked_identifier: gender
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: birth_date
+        - column_reference:
+          - naked_identifier: birth_date
         - data_type:
           - primitive_type:
             - keyword: TIMESTAMP
       - comma: ','
       - column_definition:
-        - naked_identifier: ssn
+        - column_reference:
+          - naked_identifier: ssn
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: salary
+        - column_reference:
+          - naked_identifier: salary
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -143,49 +159,57 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: first_name
+        - column_reference:
+          - naked_identifier: first_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: middle_name
+        - column_reference:
+          - naked_identifier: middle_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: last_name
+        - column_reference:
+          - naked_identifier: last_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: gender
+        - column_reference:
+          - naked_identifier: gender
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: birth_date
+        - column_reference:
+          - naked_identifier: birth_date
         - data_type:
           - primitive_type:
             - keyword: TIMESTAMP
       - comma: ','
       - column_definition:
-        - naked_identifier: ssn
+        - column_reference:
+          - naked_identifier: ssn
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: salary
+        - column_reference:
+          - naked_identifier: salary
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -206,49 +230,57 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: first_name
+        - column_reference:
+          - naked_identifier: first_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: middle_name
+        - column_reference:
+          - naked_identifier: middle_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: last_name
+        - column_reference:
+          - naked_identifier: last_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: gender
+        - column_reference:
+          - naked_identifier: gender
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: birth_date
+        - column_reference:
+          - naked_identifier: birth_date
         - data_type:
           - primitive_type:
             - keyword: TIMESTAMP
       - comma: ','
       - column_definition:
-        - naked_identifier: ssn
+        - column_reference:
+          - naked_identifier: ssn
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: salary
+        - column_reference:
+          - naked_identifier: salary
         - data_type:
           - primitive_type:
             - keyword: INT
@@ -291,37 +323,43 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: INT
       - comma: ','
       - column_definition:
-        - naked_identifier: first_name
+        - column_reference:
+          - naked_identifier: first_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: middle_name
+        - column_reference:
+          - naked_identifier: middle_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: last_name
+        - column_reference:
+          - naked_identifier: last_name
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: gender
+        - column_reference:
+          - naked_identifier: gender
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: birth_date
+        - column_reference:
+          - naked_identifier: birth_date
         - data_type:
           - primitive_type:
             - keyword: TIMESTAMP
@@ -353,13 +391,15 @@ file:
           - end_bracket: )
       - comma: ','
       - column_definition:
-        - naked_identifier: ssn
+        - column_reference:
+          - naked_identifier: ssn
         - data_type:
           - primitive_type:
             - keyword: STRING
       - comma: ','
       - column_definition:
-        - naked_identifier: salary
+        - column_reference:
+          - naked_identifier: salary
         - data_type:
           - primitive_type:
             - keyword: INT

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/explain.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/explain.yml
@@ -172,19 +172,22 @@ file:
         - bracketed:
           - start_bracket: (
           - column_definition:
-            - naked_identifier: id
+            - column_reference:
+              - naked_identifier: id
             - data_type:
               - primitive_type:
                 - keyword: INT
           - comma: ','
           - column_definition:
-            - naked_identifier: student_name
+            - column_reference:
+              - naked_identifier: student_name
             - data_type:
               - primitive_type:
                 - keyword: STRING
           - comma: ','
           - column_definition:
-            - naked_identifier: age
+            - column_reference:
+              - naked_identifier: age
             - data_type:
               - primitive_type:
                 - keyword: INT
@@ -206,19 +209,22 @@ file:
         - bracketed:
           - start_bracket: (
           - column_definition:
-            - naked_identifier: id
+            - column_reference:
+              - naked_identifier: id
             - data_type:
               - primitive_type:
                 - keyword: INT
           - comma: ','
           - column_definition:
-            - naked_identifier: student_name
+            - column_reference:
+              - naked_identifier: student_name
             - data_type:
               - primitive_type:
                 - keyword: STRING
           - comma: ','
           - column_definition:
-            - naked_identifier: age
+            - column_reference:
+              - naked_identifier: age
             - data_type:
               - primitive_type:
                 - keyword: INT

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/iceberg_create_table.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/iceberg_create_table.yml
@@ -12,7 +12,8 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: bigint
@@ -22,7 +23,8 @@ file:
             - quoted_literal: '''unique id'''
       - comma: ','
       - column_definition:
-        - naked_identifier: data
+        - column_reference:
+          - naked_identifier: data
         - data_type:
           - primitive_type:
             - keyword: string
@@ -45,19 +47,22 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: bigint
       - comma: ','
       - column_definition:
-        - naked_identifier: data
+        - column_reference:
+          - naked_identifier: data
         - data_type:
           - primitive_type:
             - keyword: string
       - comma: ','
       - column_definition:
-        - naked_identifier: category
+        - column_reference:
+          - naked_identifier: category
         - data_type:
           - primitive_type:
             - keyword: string
@@ -87,25 +92,29 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - naked_identifier: id
+        - column_reference:
+          - naked_identifier: id
         - data_type:
           - primitive_type:
             - keyword: bigint
       - comma: ','
       - column_definition:
-        - naked_identifier: data
+        - column_reference:
+          - naked_identifier: data
         - data_type:
           - primitive_type:
             - keyword: string
       - comma: ','
       - column_definition:
-        - naked_identifier: category
+        - column_reference:
+          - naked_identifier: category
         - data_type:
           - primitive_type:
             - keyword: string
       - comma: ','
       - column_definition:
-        - naked_identifier: ts
+        - column_reference:
+          - naked_identifier: ts
         - data_type:
           - primitive_type:
             - keyword: timestamp


### PR DESCRIPTION
> Stacked on sqruff #3831. Merge #3831 first.

Base PR: https://github.com/quarylabs/sqruff/pull/3831

## Summary
- add Databricks `CREATE TABLE` specifications, clauses, and column constraints
- support generated expressions plus primary, foreign, and `NOT NULL` key constraints
- use Spark column-field definitions and port all affected Databricks/SparkSQL parse trees

Ported from SQLFluff efcf0691bfe6cdee35535c52c0a975f0feb436ef
https://github.com/sqlfluff/sqlfluff/pull/6216
https://github.com/sqlfluff/sqlfluff/commit/efcf0691bfe6cdee35535c52c0a975f0feb436ef
