### PR TITLE
build(bazel): enable MariaDB dialect feature

### DIFF
--- a/crates/lib-dialects/BUILD.bazel
+++ b/crates/lib-dialects/BUILD.bazel
@@ -17,6 +17,7 @@ ALL_FEATURES = [
     "exasol",
     "greenplum",
     "hive",
+    "mariadb",
     "materialize",
     "mysql",
     "oracle",


### PR DESCRIPTION
## Summary
- add the MariaDB feature to the Bazel dialect ALL_FEATURES list
- keep Bazel feature coverage aligned with Cargo default features
- ensure MariaDB code and fixtures are compiled and tested by Bazel

## Testing
- bazelisk test //... (49/49 test targets passed)