### PR TITLE
perf: reuse docs build and speed up Cargo checks

### DIFF
--- a/.hacking/scripts/zensical_build.sh
+++ b/.hacking/scripts/zensical_build.sh
@@ -1,35 +1,7 @@
 #!/bin/bash
-# Build documentation using zensical.
-set -eo pipefail
+# Check the cached documentation artifact used by the website.
+set -euo pipefail
 
-UV_BIN="$RUNFILES_DIR/$UV"
-
-# Create a temp directory for uv cache and build
-WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
-
-# Copy project files to temp directory (use -L to follow symlinks from runfiles)
-cp -L "$RUNFILES_DIR/_main/pyproject.toml" "$WORKDIR/"
-cp -L "$RUNFILES_DIR/_main/uv.lock" "$WORKDIR/"
-cp -L "$RUNFILES_DIR/_main/zensical.toml" "$WORKDIR/"
-cp -rL "$RUNFILES_DIR/_main/docs" "$WORKDIR/"
-
-cd "$WORKDIR"
-
-# Set uv directories to temp locations to avoid read-only filesystem errors in sandbox
-export UV_CACHE_DIR="$WORKDIR/.uv-cache"
-export UV_PYTHON_INSTALL_DIR="$WORKDIR/.uv-python"
-
-# Sync dependencies
-echo "Syncing dependencies..."
-"$UV_BIN" sync --extra docs --no-install-project
-
-# Build docs using zensical
-echo "Building documentation..."
-"$UV_BIN" run --no-sync zensical build
-
-echo "Documentation built successfully!"
-echo "Output: $WORKDIR/site"
-
-# List the output
-ls -la "$WORKDIR/site" || echo "No site directory created"
+SITE="$RUNFILES_DIR/$DOCS_SITE"
+test -s "$SITE/index.html"
+echo "Documentation built successfully: $SITE"

--- a/.hacking/scripts/zensical_genrule.sh
+++ b/.hacking/scripts/zensical_genrule.sh
@@ -1,63 +1,27 @@
 #!/bin/bash
-# Build documentation using zensical and output to specified directory.
-# Usage: zensical_genrule.sh <output_dir>
-set -eo pipefail
+# Build documentation with the cached Python environment.
+# Usage: zensical_genrule.sh <output_dir> <python_dir>
+set -euo pipefail
 
-OUTPUT_DIR_ARG="$1"
+EXECROOT="$PWD"
+absolute_path() {
+    case "$1" in
+        /*) echo "$1" ;;
+        *) echo "$EXECROOT/$1" ;;
+    esac
+}
+OUTPUT_DIR="$(absolute_path "$1")"
+PYTHON_DIR="$(absolute_path "$2")"
 
-# Save the original working directory (Bazel execroot)
-EXECROOT="$(pwd)"
-
-# Convert the output path to absolute if it's relative
-if [[ "$OUTPUT_DIR_ARG" == /* ]]; then
-    OUTPUT_DIR="$OUTPUT_DIR_ARG"
-else
-    OUTPUT_DIR="$EXECROOT/$OUTPUT_DIR_ARG"
-fi
-
-# Find runfiles directory - it's alongside the script with .runfiles suffix
-# When run via run_binary, RUNFILES_DIR may not be set, so we find it ourselves
-if [[ -z "$RUNFILES_DIR" ]]; then
-    # Get the directory where this script is located
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    RUNFILES_DIR="${SCRIPT_DIR}/zensical_genrule_tool.runfiles"
-fi
-
-# Find UV binary - the path from @uv//:uv is +tools+uv/uv
-UV_BIN="$RUNFILES_DIR/+tools+uv/uv"
-
-if [[ ! -e "$UV_BIN" ]]; then
-    echo "ERROR: Could not find uv binary at $UV_BIN"
-    ls -la "$RUNFILES_DIR" || true
-    exit 1
-fi
-
-# Create a temp directory for uv cache and build
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
-
-# The tool's data dependencies are in runfiles
-# Copy project files to temp directory (use -L to follow symlinks)
-cp -L "$RUNFILES_DIR/_main/pyproject.toml" "$WORKDIR/"
-cp -L "$RUNFILES_DIR/_main/uv.lock" "$WORKDIR/"
-cp -L "$RUNFILES_DIR/_main/zensical.toml" "$WORKDIR/"
-cp -rL "$RUNFILES_DIR/_main/docs" "$WORKDIR/"
-
+cp -L zensical.toml "$WORKDIR/"
+cp -rL docs "$WORKDIR/"
 cd "$WORKDIR"
 
-# Set uv directories to temp locations to avoid read-only filesystem errors in sandbox
-export UV_CACHE_DIR="$WORKDIR/.uv-cache"
-export UV_PYTHON_INSTALL_DIR="$WORKDIR/.uv-python"
-
-# Sync dependencies
-echo "Syncing dependencies..."
-"$UV_BIN" sync --extra docs --no-install-project
-
-# Build docs using zensical
-echo "Building documentation..."
-"$UV_BIN" run --no-sync zensical build
-
-# Copy output to the specified directory (using absolute path)
-cp -r "$WORKDIR/site/"* "$OUTPUT_DIR/"
-
-echo "Documentation built successfully!"
+# Invoke the module directly: installed entry-point scripts contain the
+# temporary installation prefix, while the Python runtime is relocatable.
+export PYTHONHOME="$PYTHON_DIR"
+"$PYTHON_DIR/bin/python3" -m zensical build
+mkdir -p "$OUTPUT_DIR"
+cp -r site/. "$OUTPUT_DIR/"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -399,6 +399,11 @@ cargo_test(
     tools = ["@cargo_hack//:cargo-hack"],
     vendor = ":cargo_deps",
     script = """
+# These disposable compiler checks need neither debugger information nor
+# incremental state. Cargo still reuses completed artifacts between commands.
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_INCREMENTAL=0
+
 echo "::group::Cargo check"
 cargo check --all --all-features --tests --benches --locked --offline
 echo "::endgroup::"
@@ -489,21 +494,25 @@ test_suite(
     ],
 )
 
-# Zensical docs build - verify documentation builds successfully
+# Validate the same cached site that is published by //:website.
 sh_test(
     name = "zensical_build",
-    size = "large",
+    size = "small",
     srcs = [".hacking/scripts/zensical_build.sh"],
-    data = [
-        "pyproject.toml",
-        "uv.lock",
-        "zensical.toml",
-        "@uv//:uv",
-    ] + glob(["docs/**"]),
+    data = [":docs_build"],
     env = {
-        "UV": "$(rlocationpath @uv//:uv)",
+        "DOCS_SITE": "$(rlocationpath :docs_build)",
     },
-    tags = ["exclusive"],
+)
+
+# Resolve/install dependencies only when the manifests or Python runtime change.
+uv_python_venv(
+    name = "docs_python",
+    srcs = ["pyproject.toml", "uv.lock"],
+    extra = "docs",
+    locked = True,
+    python = [":pytest_py312_python"],
+    uv = ["@uv//:uv"],
 )
 
 # Zensical docs serve - build docs and optionally serve locally
@@ -514,31 +523,19 @@ sh_binary(
     srcs = [".hacking/scripts/zensical_serve.sh"],
 )
 
-# Zensical docs genrule tool - builds docs to output directory
+# Build zensical docs once, using the separately cached Python environment.
 sh_binary(
     name = "zensical_genrule_tool",
     srcs = [".hacking/scripts/zensical_genrule.sh"],
-    data = [
-        "pyproject.toml",
-        "uv.lock",
-        "zensical.toml",
-        "@uv//:uv",
-    ] + glob(["docs/**"]),
-    env = {
-        "UV": "$(rlocationpath @uv//:uv)",
-    },
 )
 
-# Build zensical docs as output directory
 run_binary(
     name = "docs_build",
     srcs = [
-        "pyproject.toml",
-        "uv.lock",
+        ":docs_python",
         "zensical.toml",
     ] + glob(["docs/**"]),
-    outs = [],
-    args = ["$(BINDIR)/docs_site"],
+    args = ["$(BINDIR)/docs_site", "$(execpath :docs_python)"],
     out_dirs = ["docs_site"],
     tool = ":zensical_genrule_tool",
 )

--- a/cargo_build.bzl
+++ b/cargo_build.bzl
@@ -375,8 +375,8 @@ uv_python_install = rule(
 def _uv_python_venv_impl(ctx):
     """Syncs project dependencies into a venv using an already-installed Python.
 
-    Takes the output of uv_python_install and project files, produces a venv
-    directory with all test dependencies installed. Cached by Bazel.
+    Takes the output of uv_python_install and project files, produces a Python
+    directory with the selected extra installed. Cached by Bazel.
     """
     venv_dir = ctx.actions.declare_directory(ctx.label.name + "_venv")
     uv_file = ctx.files.uv[0]
@@ -384,6 +384,12 @@ def _uv_python_venv_impl(ctx):
     src_files = ctx.files.srcs
 
     src_paths = " ".join([f.path for f in src_files])
+
+    requirements = "-r pyproject.toml --extra " + ctx.attr.extra
+    export_requirements = ""
+    if ctx.attr.locked:
+        export_requirements = '"$UV_BIN" export --locked --no-dev --no-emit-project --extra %s --output-file requirements.txt' % ctx.attr.extra
+        requirements = "-r requirements.txt"
 
     script_content = """#!/bin/bash
 set -euo pipefail
@@ -411,16 +417,19 @@ cd "$WORK_DIR"
 # Find the python3 binary
 PYTHON_BIN="$WORK_DIR/python/bin/python3"
 
-# Install test dependencies
+# Install the selected dependencies
+{export_requirements}
 "$UV_BIN" pip install --python "$PYTHON_BIN" \
     --prefix "$WORK_DIR/python" \
-    -r pyproject.toml --extra test
+    {requirements}
 
 # Copy the complete environment to the Bazel output directory
 cp -r "$WORK_DIR/python/." "$VENV_OUT/"
 
 echo "Python venv created at $VENV_OUT"
 """.format(
+        export_requirements = export_requirements,
+        requirements = requirements,
         uv_path = uv_file.path,
         python_dir = python_dir.path,
         srcs = src_paths,
@@ -446,6 +455,8 @@ echo "Python venv created at $VENV_OUT"
 uv_python_venv = rule(
     implementation = _uv_python_venv_impl,
     attrs = {
+        "extra": attr.string(default = "test"),
+        "locked": attr.bool(default = False),
         "srcs": attr.label_list(
             allow_files = True,
             doc = "pyproject.toml and uv.lock for dependency resolution",


### PR DESCRIPTION
The docs test rebuilt the site and installed dependencies independently of `docs_build`. It now validates the site artifact used by `website`, with a separately cached, lockfile-backed Python environment. Docs-only edits reuse that environment, and the artifact check no longer needs exclusive scheduling.

Disable debug information and incremental compilation for `cargo_compile_checks`, whose target directory is disposable. Cargo still reuses completed artifacts between check, Clippy, and the feature checks.

Validation:
- Docs and shell checks passed. Forced warm docs validation took 0.1s; its profile confirmed no site rebuild or dependency installation.
- Artifact validation rejects a missing index and accepts a populated index.
- Full Cargo check/Clippy/46-feature sequence passed: baseline 123.5s, no debug info 109.7s, both settings disabled 102.9s. Final settings passed in 100.2s (about 19% faster locally).
- `git diff --check` passed.

Timings are local target-level measurements. Full `bazelisk test //...` was not rerun.
