### PR TITLE
perf: migrate remaining Cargo runtime tests to native Bazel targets

### DIFF
--- a/.hacking/scripts/python_rust_test.sh
+++ b/.hacking/scripts/python_rust_test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Run a native Rust test with immutable Python dependencies and private fixtures.
+set -euo pipefail
+
+RUNFILES="$RUNFILES_DIR"
+BINARY="$RUNFILES/$SQRUFF_NATIVE_TEST_BINARY"
+PYTHON="$RUNFILES/$PYTHON_RUNTIME"
+WORK="$TEST_TMPDIR/work"
+mkdir -p "$WORK" "$TEST_TMPDIR/home" "$TEST_TMPDIR/cache" "$TEST_TMPDIR/tmp"
+export HOME="$TEST_TMPDIR/home"
+export XDG_CACHE_HOME="$TEST_TMPDIR/cache"
+export TMPDIR="$TEST_TMPDIR/tmp"
+export PYTHONPYCACHEPREFIX="$TEST_TMPDIR/pycache"
+export PYTHONNOUSERSITE=1
+export SQRUFF_REQUIRE_PYTHON=1
+unset SQRUFF_SKIP_UNSUPPORTED_TEMPLATERS
+export PYTHONHOME="$PYTHON"
+SITE_PACKAGES=("$PYTHON"/lib/python*/site-packages)
+export PYTHONPATH="$WORK/python:${SITE_PACKAGES[0]}"
+export LD_LIBRARY_PATH="$PYTHON/lib:${LD_LIBRARY_PATH:-}"
+export DYLD_LIBRARY_PATH="$PYTHON/lib:${DYLD_LIBRARY_PATH:-}"
+
+# Only declared fixture trees are present in this test's runfiles. Copying
+# dereferences symlinks for directory walkers and isolates dbt/fix writes.
+for crate in "$RUNFILES/_main/crates/"*; do
+    for kind in test tests; do
+        if [[ -d "$crate/$kind" ]]; then
+            mkdir -p "$WORK/crates/$(basename "$crate")"
+            cp -rL "$crate/$kind" "$WORK/crates/$(basename "$crate")/"
+        fi
+    done
+done
+cp -rL "$RUNFILES/_main/crates/cli-python/python" "$WORK/python"
+if [[ -n "${SQRUFF_EXTENSION:-}" ]]; then
+    cp -L "$RUNFILES/$SQRUFF_EXTENSION" "$WORK/python/sqruff/_lib_name.so"
+fi
+
+# Preserve the actual Python entry point instead of substituting the native CLI.
+mkdir -p "$WORK/bin" "$WORK/$TEST_CRATE"
+cat > "$WORK/bin/sqruff" <<'LAUNCHER'
+#!/bin/bash
+set -euo pipefail
+exec "$PYTHONHOME/bin/python3" -c 'from sqruff.main import main; main()' "$@"
+LAUNCHER
+chmod +x "$WORK/bin/sqruff"
+export SQRUFF_TEST_MANIFEST_DIR="$WORK/$TEST_CRATE"
+export SQRUFF_PYTHON_BIN="$WORK/bin/sqruff"
+
+# Fail on missing Python support before a fixture harness can silently skip it.
+"$PYTHON/bin/python3" -c 'import sqruff.templaters.jinja_templater, sqruff.templaters.dbt_templater'
+if [[ -n "${SQRUFF_EXTENSION:-}" ]]; then
+    "$PYTHON/bin/python3" -c 'from sqruff._lib_name import run_cli; assert callable(run_cli)'
+fi
+cd "$WORK/$TEST_CRATE"
+exec "$BINARY" "$@"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,8 +7,8 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_shellcheck//:def.bzl", "shellcheck_test")
-load(":cargo_build.bzl", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv", "python_venv_provider", "uv_python_install", "uv_python_venv")
 load(":clippy.bzl", "clippy_feature_flag", "clippy_targets", "workspace_clippy")
+load(":cargo_build.bzl", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv_provider", "uv_python_install", "uv_python_venv")
 load(":linters.bzl", "keep_sorted_test")
 load(":rustfmt.bzl", "rustfmt_sources_test")
 
@@ -309,23 +309,6 @@ cargo_vendor_provider(
     vendor = ":cargo_vendor",
 )
 
-# Pre-cache Python venv with all dev dependencies (cached until pyproject.toml changes)
-# Uses the Bazel-managed Python 3.12 interpreter and uv for fast pip installs
-python_venv(
-    name = "python_venv",
-    srcs = [
-        "pyproject.toml",
-    ],
-    python = ["@python_3_12//:files"],
-    uv = ["@uv//:uv"],
-)
-
-# Provider wrapper for Python venv
-python_venv_provider(
-    name = "python_deps",
-    venv = ":python_venv",
-)
-
 # Compiler-only Cargo actions need Python and libpython for PyO3, but not the
 # hundreds of MB of test dependencies layered onto the standalone runtime.
 python_venv_provider(
@@ -499,58 +482,22 @@ alias(
     actual = ":rustfmt_check",
 )
 
-# Cargo test - run workspace tests that have not migrated to native Bazel rules.
-# Uses the registered rules_rust toolchain and pre-cached Python venv
-# for fully sandboxed execution
-# Python venv provides maturin, pytest, jinja2, dbt, etc.
-cargo_test(
-    name = "cargo_workspace_tests",
-    size = "enormous",
-    srcs = [
-        ":cargo_srcs",
-        "pyproject.toml",
-        "uv.lock",
-        "//crates/cli-python:machete_srcs",
-        "//crates/cli-python:pyproject.toml",
-        "//crates/cli-python:python_srcs",
-        "//crates/cli-python:test_fixtures",
-        "//crates/lib:test_fixtures",
-        "//crates/lib-dialects:test/fixtures/dialects/ansi/sqlfluff/select_in_multiline_comment.sql",
-    ],
-    vendor = ":cargo_deps",
-    python_venv = ":python_deps",
-    script = """
-# Cargo builds into a disposable target directory, so incremental artifacts and
-# debug information only add work and are discarded after this test finishes.
-export CARGO_INCREMENTAL=0
-export CARGO_PROFILE_DEV_DEBUG=0
-export CARGO_PROFILE_TEST_DEBUG=0
-
-# Build Python extension (maturin uses the vendored cargo + pre-cached venv)
-(cd crates/cli-python && maturin develop --locked --offline)
-
-# Crates that don't need the Python/maturin setup run natively via rust_test:
-#   //crates/cli:cli_tests
-#   //crates/lib-dialects:dialect_tests
-#   //crates/lib-dialects:sqruff-lib-dialects-test
-#   //crates/lib-core:sqruff-lib-core-test
-#   //crates/lsp:sqruff-lsp-test
-#   //crates/sqlinference:sqruff-sqlinference-test
-#   //crates/lineage:lineage-test
-# sqruff-wasm has no Cargo tests; its WASM output is exercised by the playground
-# browser tests instead.
-cargo test --all --all-features --exclude sqruff --exclude sqruff-lib-core --exclude sqruff-lib-dialects --exclude sqruff-lsp --exclude sqruff-sqlinference --exclude sqruff-wasm --exclude lineage --locked --offline
-""",
-)
-
+# Compatibility entry point: all workspace runtime tests now build natively.
 test_suite(
     name = "cargo_test",
     tests = [
-        ":cargo_workspace_tests",
         "//crates/cli:cli_tests",
+        "//crates/cli-lib:sqruff-cli-lib-test",
+        "//crates/cli-python:integration_tests",
+        "//crates/lib:sqruff-lib-test",
+        "//crates/lib:rules_test",
+        "//crates/lib:templaters_test",
+        "//crates/lib-core:sqruff-lib-core-test",
         "//crates/lib-dialects:dialect_tests",
         "//crates/lib-dialects:sqruff-lib-dialects-test",
+        "//crates/lineage:lineage-test",
         "//crates/lsp:sqruff-lsp-test",
+        "//crates/sqlinference:sqruff-sqlinference-test",
     ],
 )
 
@@ -638,8 +585,7 @@ PYTEST_PYTHON_VERSIONS = [
 PYTEST_VENVS = {
     "3.10": ":pytest_py310_venv",
     "3.11": ":pytest_py311_venv",
-    # Cargo and pytest can safely share the same Python 3.12 environment.
-    "3.12": ":python_venv",
+    "3.12": ":pytest_py312_venv",
     "3.13": ":pytest_py313_venv",
 }
 
@@ -663,7 +609,6 @@ PYTEST_VENVS = {
         uv = ["@uv//:uv"],
     )
     for version in PYTEST_PYTHON_VERSIONS
-    if version != "3.12"
 ]
 
 [
@@ -682,3 +627,11 @@ PYTEST_VENVS = {
     )
     for version in PYTEST_PYTHON_VERSIONS
 ]
+
+exports_files([".hacking/scripts/python_rust_test.sh"])
+
+filegroup(
+    name = "native_test_python",
+    srcs = [":pytest_py312_venv"],
+    visibility = ["//visibility:public"],
+)

--- a/crates/cli-lib/BUILD.bazel
+++ b/crates/cli-lib/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//:clippy.bzl", "cargo_lints", "clippy_config")
+load("//:python_tests.bzl", "python_rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
@@ -73,3 +74,27 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+rust_library(
+    name = "sqruff-cli-lib-python",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "sqruff_cli_lib",
+    crate_features = ["python", "parser"],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True) + [
+        "//crates/lib:sqruff-lib-python",
+        "//crates/lib-core:sqruff-lib-core",
+        "//crates/lib-dialects:sqruff-lib-dialects",
+        "//crates/lsp:sqruff-lsp",
+    ],
+)
+
+python_rust_test(
+    name = "sqruff-cli-lib-test",
+    crate = ":sqruff-cli-lib-python",
+    crate_features = ["python", "parser", "codegen-docs"],
+    compile_data = glob(["src/docs/*.md"]),
+    deps = all_crate_deps(normal_dev = True) + [
+        "@rules_python//python/cc:current_py_cc_libs",
+    ],
+)

--- a/crates/cli-python/BUILD.bazel
+++ b/crates/cli-python/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//:clippy.bzl", "cargo_lints")
+load("//:python_tests.bzl", "python_rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
+
 exports_files([
     "Cargo.toml",
     "pyproject.toml",
@@ -41,6 +43,59 @@ filegroup(
         ],
         allow_empty = True,
     ) + ["Cargo.toml"],
+    visibility = ["//visibility:public"],
+)
+
+# Runtime extension for native tests, built with the workspace's PyO3 version.
+# Wheel/ABI packaging remains validated by the maturin CI matrix.
+rust_shared_library(
+    name = "sqruff-extension",
+    crate_name = "sqruff_cli_python",
+    srcs = ["src/lib.rs"],
+    deps = all_crate_deps(normal = True) + [
+        "//crates/cli-lib:sqruff-cli-lib-python",
+        "@rules_python//python/cc:current_py_cc_libs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Test inputs are isolated so a dbt fixture edit does not rerun every CLI test.
+_INTEGRATION_FIXTURES = {
+    "config_not_found": ["config_not_found"],
+    "configure_rule": ["configure_rule"],
+    "fix_parse_errors": [],
+    "fix_return_code": ["fix_return_code"],
+    "library_path": ["library_path"],
+    "ui": ["lint", "stdin"],
+    "ui_github": ["github"],
+    "ui_json": ["json"],
+    "ui_with_dbt": ["dbt", "dbt_sample"],
+    "ui_with_jinja": ["jinja"],
+    "ui_with_python": ["python"],
+}
+
+[
+    python_rust_test(
+        name = "integration_" + test,
+        srcs = ["tests/" + test + ".rs"] + glob(["tests/common/**/*.rs"]),
+        crate_root = "tests/" + test + ".rs",
+        use_libtest_harness = False,
+        deps = all_crate_deps(normal_dev = True),
+        fixtures = glob(["tests/" + directory + "/**" for directory in _INTEGRATION_FIXTURES[test]]) if _INTEGRATION_FIXTURES[test] else [],
+        extension = True,
+    )
+    for test in [src.removeprefix("tests/").removesuffix(".rs") for src in glob(["tests/*.rs"])]
+]
+
+test_suite(
+    name = "integration_tests",
+    tests = [":integration_" + test for test in _INTEGRATION_FIXTURES],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "python_runtime_srcs",
+    srcs = glob(["python/**/*.py"], exclude = ["python/**/*_test.py", "python/**/*_benchmark.py"]),
     visibility = ["//visibility:public"],
 )
 

--- a/crates/cli-python/tests/common/mod.rs
+++ b/crates/cli-python/tests/common/mod.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+pub(crate) fn manifest_dir() -> &'static Path {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    PATH.get_or_init(|| {
+        std::env::var_os("SQRUFF_TEST_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+    })
+}
+
+pub(crate) fn sqruff_path() -> PathBuf {
+    let path = std::env::var_os("SQRUFF_PYTHON_BIN")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest_dir().join("../../.venv/bin/sqruff"));
+    assert!(
+        path.is_file(),
+        "Python sqruff launcher missing; run maturin develop for Cargo tests"
+    );
+    path
+}

--- a/crates/cli-python/tests/config_not_found.rs
+++ b/crates/cli-python/tests/config_not_found.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::path::PathBuf;
 
 use assert_cmd::Command;
@@ -8,28 +10,13 @@ fn main() {
 }
 
 fn config_not_found_lint() {
-    let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut lint_dir = PathBuf::from(common::manifest_dir());
     lint_dir.push("tests/config_not_found");
 
     let entry_path = lint_dir.as_path().join("example.sql");
     let config_path = lint_dir.as_path().join("non_existant.cfg");
 
-    // Check if we have a virtual environment at the project root
-    let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    venv_path.push("../../.venv");
-    if !venv_path.exists() {
-        panic!(
-            "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-        );
-    }
-    // Check if sqruff script exists in the virtual environment
-    let mut sqruff_script_path = venv_path.clone();
-    sqruff_script_path.push("bin/sqruff");
-    if !sqruff_script_path.exists() {
-        panic!(
-            "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-        );
-    }
+    let sqruff_script_path = common::sqruff_path();
 
     // Set up the command with arguments
     let mut cmd = Command::new(sqruff_script_path);
@@ -40,13 +27,13 @@ fn config_not_found_lint() {
         .arg(&config_path)
         .arg(&entry_path);
     // Set the HOME environment variable to the fake home directory
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
 
     // Run the command and capture the output
     let assert = cmd.assert();
 
     // Construct the expected output file paths
-    let storage_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let storage_path = PathBuf::from(common::manifest_dir())
         .join("tests")
         .join("config_not_found")
         .join("example.sql");

--- a/crates/cli-python/tests/configure_rule.rs
+++ b/crates/cli-python/tests/configure_rule.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
@@ -8,28 +10,13 @@ fn main() {
 }
 
 fn configure_rule() {
-    let cargo_folder = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let cargo_folder = Path::new(common::manifest_dir());
 
     let sql_path = cargo_folder.join("tests/configure_rule/_example.sql");
 
-    // Check if we have a virtual environment at the project root
-    let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    venv_path.push("../../.venv");
-    if !venv_path.exists() {
-        panic!(
-            "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-        );
-    }
-    // Check if sqruff script exists in the virtual environment
-    let mut sqruff_path = venv_path.clone();
-    sqruff_path.push("bin/sqruff");
-    if !sqruff_path.exists() {
-        panic!(
-            "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-        );
-    }
+    let sqruff_path = common::sqruff_path();
 
-    let file_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/configure_rule");
+    let file_dir = PathBuf::from(common::manifest_dir()).join("tests/configure_rule");
 
     // Find all .cfg files in configure_rule folder
     // Lint with all the config files
@@ -48,6 +35,10 @@ fn configure_rule() {
         })
         .collect::<Vec<_>>();
 
+    assert!(
+        !all_config_files.is_empty(),
+        "No configuration fixtures found"
+    );
     for config in all_config_files {
         // Set up the command with arguments
         let mut cmd = Command::new(sqruff_path.clone());
@@ -60,7 +51,7 @@ fn configure_rule() {
         cmd.current_dir(cargo_folder);
 
         // Set the HOME environment variable to the fake home directory
-        cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+        cmd.env("HOME", PathBuf::from(common::manifest_dir()));
 
         // Run the command and capture the output
         let assert = cmd.assert();

--- a/crates/cli-python/tests/fix_parse_errors.rs
+++ b/crates/cli-python/tests/fix_parse_errors.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use core::str;
 use std::path::{Path, PathBuf};
 
@@ -8,27 +10,12 @@ fn main() {
 }
 
 fn parse_errors() {
-    let cargo_folder = Path::new(env!("CARGO_MANIFEST_DIR"));
-    // Check if we have a virtual environment at the project root
-    let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    venv_path.push("../../.venv");
-    if !venv_path.exists() {
-        panic!(
-            "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-        );
-    }
-    // Check if sqruff script exists in the virtual environment
-    let mut sqruff_path = venv_path.clone();
-    sqruff_path.push("bin/sqruff");
-    if !sqruff_path.exists() {
-        panic!(
-            "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-        );
-    }
+    let cargo_folder = Path::new(common::manifest_dir());
+    let sqruff_path = common::sqruff_path();
 
     // STDIN - do nothing
     let mut cmd = Command::new(sqruff_path.clone());
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
     cmd.arg("fix")
         .arg("-f")
         .arg("human")

--- a/crates/cli-python/tests/fix_return_code.rs
+++ b/crates/cli-python/tests/fix_return_code.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use core::str;
 use std::path::{Path, PathBuf};
 
@@ -18,27 +20,12 @@ fn fix_return_code() {
     // - Fix, fix everything -> 0
     // - Fix, fix some not all -> 1
 
-    let cargo_folder = Path::new(env!("CARGO_MANIFEST_DIR"));
-    // Check if we have a virtual environment at the project root
-    let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    venv_path.push("../../.venv");
-    if !venv_path.exists() {
-        panic!(
-            "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-        );
-    }
-    // Check if sqruff script exists in the virtual environment
-    let mut sqruff_path = venv_path.clone();
-    sqruff_path.push("bin/sqruff");
-    if !sqruff_path.exists() {
-        panic!(
-            "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-        );
-    }
+    let cargo_folder = Path::new(common::manifest_dir());
+    let sqruff_path = common::sqruff_path();
 
     // STDIN - do nothing
     let mut cmd = Command::new(sqruff_path.clone());
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
     cmd.arg("fix").arg("-f").arg("human").arg("-");
     cmd.current_dir(cargo_folder);
     cmd.write_stdin("SELECT foo FROM bar;\n");
@@ -57,7 +44,7 @@ fn fix_return_code() {
     // STDIN - nothing to fix
     let config_file = cargo_folder.join("tests/fix_return_code/fix_everything.cfg");
     let mut cmd = Command::new(sqruff_path.clone());
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
     cmd.arg("fix")
         .arg("-f")
         .arg("human")
@@ -76,7 +63,7 @@ fn fix_return_code() {
     assert_eq!(output.status.code().unwrap(), 0);
 
     let mut cmd = Command::new(sqruff_path.clone());
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
     cmd.arg("fix")
         .arg("-f")
         .arg("human")
@@ -95,7 +82,7 @@ fn fix_return_code() {
     // STDIN - fix everything
     let config_file = cargo_folder.join("tests/fix_return_code/fix_everything.cfg");
     let mut cmd = Command::new(sqruff_path.clone());
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
     cmd.arg("fix")
         .arg("-f")
         .arg("human")
@@ -119,7 +106,7 @@ fn fix_return_code() {
     // STDIN - fix some not all
     let config_file = cargo_folder.join("tests/fix_return_code/fix_some.cfg");
     let mut cmd = Command::new(sqruff_path.clone());
-    cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    cmd.env("HOME", PathBuf::from(common::manifest_dir()));
     cmd.arg("fix")
         .arg("-f")
         .arg("human")

--- a/crates/cli-python/tests/library_path.rs
+++ b/crates/cli-python/tests/library_path.rs
@@ -1,14 +1,12 @@
+mod common;
+
 use std::path::Path;
 
 use assert_cmd::Command;
 
 fn main() {
-    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let sqruff_path = crate_dir.join("../../.venv/bin/sqruff");
-    assert!(
-        sqruff_path.is_file(),
-        "sqruff script not found in .venv/bin; run `maturin develop` first"
-    );
+    let crate_dir = Path::new(common::manifest_dir());
+    let sqruff_path = common::sqruff_path();
 
     let fixture_dir = crate_dir.join("tests/library_path");
     let library_path = fixture_dir.join("custom_library");

--- a/crates/cli-python/tests/ui.rs
+++ b/crates/cli-python/tests/ui.rs
@@ -1,22 +1,16 @@
+mod common;
+
 use std::fs;
 use std::path::PathBuf;
 
 use assert_cmd::Command;
 use expect_test::expect_file;
 
-fn sqruff_path() -> PathBuf {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../.venv/bin/sqruff");
-    assert!(
-        path.is_file(),
-        "sqruff script not found in .venv/bin; run `maturin develop` first"
-    );
-    path
-}
-
 fn main() {
-    let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut lint_dir = PathBuf::from(common::manifest_dir());
     lint_dir.push("tests/lint");
 
+    let mut cases = 0;
     // Iterate over each test file in the directory
     for entry in fs::read_dir(&lint_dir).unwrap() {
         let entry = entry.unwrap();
@@ -28,8 +22,9 @@ fn main() {
             .and_then(|e| e.to_str())
             .is_some_and(|ext| ext == "sql" || ext == "hql")
         {
+            cases += 1;
             // Set up the command with arguments
-            let mut cmd = Command::new(sqruff_path());
+            let mut cmd = Command::new(common::sqruff_path());
             cmd.arg("lint").arg("-f").arg("human").arg(&path);
 
             let config_path = path.with_extension("cfg");
@@ -37,7 +32,7 @@ fn main() {
                 cmd.arg("--config").arg(config_path);
             }
             // Set the HOME environment variable to the fake home directory
-            cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+            cmd.env("HOME", PathBuf::from(common::manifest_dir()));
 
             // Run the command and capture the output
             let assert = cmd.assert();
@@ -72,9 +67,9 @@ fn main() {
         let sql_input = "SELECT * FROM users;";
 
         // Set up the command with arguments
-        let mut cmd = Command::new(sqruff_path());
+        let mut cmd = Command::new(common::sqruff_path());
         cmd.arg("lint").arg("-f").arg("human").arg("-"); // Use '-' to indicate stdin
-        cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+        cmd.env("HOME", PathBuf::from(common::manifest_dir()));
 
         // Provide input via stdin
         cmd.write_stdin(sql_input);
@@ -102,4 +97,6 @@ fn main() {
         expect_file![expected_output_path_stdout].assert_eq(stdout_str);
         expect_file![expected_output_path_exitcode].assert_eq(&exit_code_str);
     }
+    assert!(cases > 0, "No SQL fixtures executed");
+    println!("Ran {cases} SQL fixtures");
 }

--- a/crates/cli-python/tests/ui_github.rs
+++ b/crates/cli-python/tests/ui_github.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::PathBuf;
 
@@ -5,9 +7,10 @@ use assert_cmd::Command;
 use expect_test::expect_file;
 
 fn main() {
-    let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut lint_dir = PathBuf::from(common::manifest_dir());
     lint_dir.push("tests/github");
 
+    let mut cases = 0;
     // Iterate over each test file in the directory
     for entry in fs::read_dir(&lint_dir).unwrap() {
         let entry = entry.unwrap();
@@ -19,22 +22,8 @@ fn main() {
             .and_then(|e| e.to_str())
             .is_some_and(|ext| ext == "sql" || ext == "hql")
         {
-            // Check if we have a virtual environment at the project root
-            let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            venv_path.push("../../.venv");
-            if !venv_path.exists() {
-                panic!(
-                    "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-                );
-            }
-            // Check if sqruff script exists in the virtual environment
-            let mut sqruff_path = venv_path.clone();
-            sqruff_path.push("bin/sqruff");
-            if !sqruff_path.exists() {
-                panic!(
-                    "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-                );
-            }
+            cases += 1;
+            let sqruff_path = common::sqruff_path();
             // Set up the command with arguments
             let mut cmd = Command::new(sqruff_path);
 
@@ -45,7 +34,7 @@ fn main() {
                 cmd.arg("--config").arg(config_path);
             }
             // Set the HOME environment variable to the fake home directory
-            cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+            cmd.env("HOME", PathBuf::from(common::manifest_dir()));
             cmd.env("GITHUB_ACTIONS", "true");
 
             // Run the command and capture the output
@@ -74,4 +63,6 @@ fn main() {
             expect_file![expected_output_path_exitcode].assert_eq(&exit_code_str);
         }
     }
+    assert!(cases > 0, "No SQL fixtures executed");
+    println!("Ran {cases} SQL fixtures");
 }

--- a/crates/cli-python/tests/ui_json.rs
+++ b/crates/cli-python/tests/ui_json.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::PathBuf;
 
@@ -5,9 +7,10 @@ use assert_cmd::Command;
 use expect_test::expect_file;
 
 fn main() {
-    let mut lint_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut lint_dir = PathBuf::from(common::manifest_dir());
     lint_dir.push("tests/json");
 
+    let mut cases = 0;
     // Iterate over each test file in the directory
     for entry in fs::read_dir(&lint_dir).unwrap() {
         let entry = entry.unwrap();
@@ -19,22 +22,8 @@ fn main() {
             .and_then(|e| e.to_str())
             .is_some_and(|ext| ext == "sql" || ext == "hql")
         {
-            // Check if we have a virtual environment at the project root
-            let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            venv_path.push("../../.venv");
-            if !venv_path.exists() {
-                panic!(
-                    "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-                );
-            }
-            // Check if sqruff script exists in the virtual environment
-            let mut sqruff_path = venv_path.clone();
-            sqruff_path.push("bin/sqruff");
-            if !sqruff_path.exists() {
-                panic!(
-                    "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-                );
-            }
+            cases += 1;
+            let sqruff_path = common::sqruff_path();
             // Set up the command with arguments
             let mut cmd = Command::new(sqruff_path);
 
@@ -47,7 +36,7 @@ fn main() {
                 cmd.arg("--config").arg(config_path);
             }
             // Set the HOME environment variable to the fake home directory
-            cmd.env("HOME", PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+            cmd.env("HOME", PathBuf::from(common::manifest_dir()));
 
             // Run the command and capture the output
             let assert = cmd.assert();
@@ -75,4 +64,6 @@ fn main() {
             expect_file![expected_output_path_exitcode].assert_eq(&exit_code_str);
         }
     }
+    assert!(cases > 0, "No SQL fixtures executed");
+    println!("Ran {cases} SQL fixtures");
 }

--- a/crates/cli-python/tests/ui_with_dbt.rs
+++ b/crates/cli-python/tests/ui_with_dbt.rs
@@ -1,35 +1,22 @@
+mod common;
+
 use std::path::PathBuf;
 
 use assert_cmd::Command;
 use expect_test::expect_file;
 
 fn main() {
-    let sample_dbt_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let sample_dbt_dir = PathBuf::from(common::manifest_dir())
         .parent()
         .unwrap()
         .parent()
         .unwrap()
         .join("crates/cli-python/tests/dbt_sample/");
-    let output_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/dbt");
+    let output_dir = PathBuf::from(common::manifest_dir()).join("tests/dbt");
     // Create the output directory
     std::fs::create_dir_all(&output_dir).unwrap();
 
-    // Check if we have a virtual environment at the project root
-    let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    venv_path.push("../../.venv");
-    if !venv_path.exists() {
-        panic!(
-            "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-        );
-    }
-    // Check if sqruff script exists in the virtual environment
-    let mut sqruff_path = venv_path.clone();
-    sqruff_path.push("bin/sqruff");
-    if !sqruff_path.exists() {
-        panic!(
-            "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-        );
-    }
+    let sqruff_path = common::sqruff_path();
 
     let mut cmd = Command::new(sqruff_path);
     cmd.current_dir(&sample_dbt_dir);

--- a/crates/cli-python/tests/ui_with_jinja.rs
+++ b/crates/cli-python/tests/ui_with_jinja.rs
@@ -1,27 +1,15 @@
+mod common;
+
 use std::path::PathBuf;
 
 use assert_cmd::Command;
 use expect_test::expect_file;
 
 fn main() {
-    let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut test_dir = PathBuf::from(common::manifest_dir());
     test_dir.push("tests/jinja");
 
-    let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    venv_path.push("../../.venv");
-    if !venv_path.exists() {
-        panic!(
-            "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-        );
-    }
-    // Check if sqruff script exists in the virtual environment
-    let mut sqruff_path = venv_path.clone();
-    sqruff_path.push("bin/sqruff");
-    if !sqruff_path.exists() {
-        panic!(
-            "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-        );
-    }
+    let sqruff_path = common::sqruff_path();
     // Set up the command with arguments
     let mut cmd = Command::new(sqruff_path);
     cmd.arg("lint")
@@ -37,16 +25,16 @@ fn main() {
     }
 
     // Set the HOME environment variable to the fake home directory
-    let home_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let home_path = PathBuf::from(common::manifest_dir());
     cmd.env("HOME", home_path);
 
     // Run the command and capture the output
     let assert = cmd.assert();
 
     // Construct the expected output file path
-    let mut expected_output_path_stderr = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut expected_output_path_stderr = PathBuf::from(common::manifest_dir());
     expected_output_path_stderr.push("tests/jinja/expected_output.stderr");
-    let mut expected_output_path_stdout = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut expected_output_path_stdout = PathBuf::from(common::manifest_dir());
     expected_output_path_stdout.push("tests/jinja/expected_output.stdout");
 
     // Read the expected output

--- a/crates/cli-python/tests/ui_with_python.rs
+++ b/crates/cli-python/tests/ui_with_python.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::PathBuf;
 
@@ -5,9 +7,10 @@ use assert_cmd::Command;
 use expect_test::expect_file;
 
 fn main() {
-    let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut test_dir = PathBuf::from(common::manifest_dir());
     test_dir.push("tests/python");
 
+    let mut cases = 0;
     // Iterate over each test file in the directory
     for entry in fs::read_dir(&test_dir).unwrap() {
         let entry = entry.unwrap();
@@ -19,22 +22,8 @@ fn main() {
             .and_then(|e| e.to_str())
             .is_some_and(|ext| ext == "sql" || ext == "hql")
         {
-            // Check if we have a virtual environment at the project root
-            let mut venv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            venv_path.push("../../.venv");
-            if !venv_path.exists() {
-                panic!(
-                    "Virtual environment not found at project root. Please create a .venv directory and run 'maturin develop'"
-                );
-            }
-            // Check if sqruff script exists in the virtual environment
-            let mut sqruff_path = venv_path.clone();
-            sqruff_path.push("bin/sqruff");
-            if !sqruff_path.exists() {
-                panic!(
-                    "sqruff script not found in .venv/bin/sqruff. Please run 'maturin develop' in the virtual environment"
-                );
-            }
+            cases += 1;
+            let sqruff_path = common::sqruff_path();
             // Set up the command with arguments
             let mut cmd = Command::new(sqruff_path);
             cmd.arg("lint")
@@ -44,7 +33,7 @@ fn main() {
                 .arg("tests/python/.sqruff")
                 .arg(&path);
             // Set the HOME environment variable to the fake home directory
-            let home_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let home_path = PathBuf::from(common::manifest_dir());
             cmd.env("HOME", home_path);
 
             // Run the command and capture the output
@@ -71,4 +60,6 @@ fn main() {
             expect_file![expected_output_path_stdout].assert_eq(&stdout_normalized);
         }
     }
+    assert!(cases > 0, "No SQL fixtures executed");
+    println!("Ran {cases} SQL fixtures");
 }

--- a/crates/lib/BUILD.bazel
+++ b/crates/lib/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//:clippy.bzl", "cargo_lints", "clippy_config")
+load("//:python_tests.bzl", "python_rust_test")
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
 
@@ -107,3 +108,34 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+python_rust_test(
+    name = "sqruff-lib-test",
+    crate = ":sqruff-lib-python",
+    crate_features = ALL_FEATURES + ["python", "serde_yaml"],
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+    deps = all_crate_deps(normal = True, normal_dev = True) + [
+        ":sqruff-lib-python",
+        "@rules_python//python/cc:current_py_cc_libs",
+    ],
+    fixtures = [
+        ":test_fixtures",
+        "//crates/lib-dialects:test/fixtures/dialects/ansi/sqlfluff/select_in_multiline_comment.sql",
+    ],
+)
+
+[
+    python_rust_test(
+        name = test + "_test",
+        srcs = ["tests/" + test + ".rs"],
+        crate_root = "tests/" + test + ".rs",
+        use_libtest_harness = False,
+        deps = all_crate_deps(normal = True, normal_dev = True) + [
+            ":sqruff-lib-python",
+            "//crates/lib-core:sqruff-lib-core",
+            "@rules_python//python/cc:current_py_cc_libs",
+        ],
+        proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+        fixtures = glob(["test/fixtures/" + test + "/**"]),
+    )
+    for test in ["rules", "templaters"]
+]

--- a/crates/lib/tests/rules.rs
+++ b/crates/lib/tests/rules.rs
@@ -70,6 +70,8 @@ fn main() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     paths.sort();
+    assert!(!paths.is_empty(), "No rule fixtures matched {pattern}");
+    println!("Running {} rule fixture files", paths.len());
 
     let verbose = std::env::var_os("SQRUFF_RULE_TEST_VERBOSE").is_some();
     paths

--- a/crates/lib/tests/templaters.rs
+++ b/crates/lib/tests/templaters.rs
@@ -21,6 +21,11 @@ fn main() {
         })
         .collect::<HashSet<std::path::PathBuf>>();
 
+    assert!(
+        !templaters_folders.is_empty(),
+        "No templater fixtures found"
+    );
+    let mut cases = 0;
     for templater_setup in &templaters_folders {
         println!("{:?}", templater_setup);
         let config_path = templater_setup.join(".sqruff");
@@ -30,6 +35,10 @@ fn main() {
         let templater = match Linter::get_templater(&config) {
             Ok(t) => t,
             Err(e) => {
+                assert!(
+                    std::env::var_os("SQRUFF_REQUIRE_PYTHON").is_none(),
+                    "Required templater unavailable: {e}"
+                );
                 println!(
                     "Skipping templater test for {:?}: {}",
                     templater_setup.file_name().unwrap(),
@@ -42,6 +51,7 @@ fn main() {
         // for every sql file in that folder
         for sql_file in glob(&format!("{}/*.sql", templater_setup.to_str().unwrap())).unwrap() {
             let sql_file = sql_file.unwrap();
+            cases += 1;
             let yaml_file = sql_file.with_extension("yml");
             let yaml_file = std::path::absolute(yaml_file).unwrap();
 
@@ -73,4 +83,8 @@ fn main() {
             expect_file![yaml_file].assert_eq(&actual);
         }
     }
+    if cfg!(feature = "python") || std::env::var_os("SQRUFF_REQUIRE_PYTHON").is_some() {
+        assert!(cases > 0, "No templater SQL cases executed");
+    }
+    println!("Ran {cases} templater SQL cases");
 }

--- a/python_tests.bzl
+++ b/python_tests.bzl
@@ -1,0 +1,34 @@
+"""Native Rust test compilation with an isolated Python runtime at execution."""
+
+load("@rules_rust//rust:defs.bzl", "rust_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+def python_rust_test(name, fixtures = [], extension = False, **kwargs):
+    """Build once with rules_rust; stage only runtime files for each test."""
+    rust_test(
+        name = name + "_binary",
+        tags = ["manual"],
+        visibility = ["//visibility:private"],
+        **kwargs
+    )
+    data = fixtures + [
+        ":" + name + "_binary",
+        "//:native_test_python",
+        "//crates/cli-python:python_runtime_srcs",
+    ]
+    env = {
+        "SQRUFF_NATIVE_TEST_BINARY": "$(rlocationpath :" + name + "_binary)",
+        "PYTHON_RUNTIME": "$(rlocationpath //:native_test_python)",
+        "TEST_CRATE": native.package_name(),
+    }
+    if extension:
+        data.append("//crates/cli-python:sqruff-extension")
+        env["SQRUFF_EXTENSION"] = "$(rlocationpath //crates/cli-python:sqruff-extension)"
+    sh_test(
+        name = name,
+        srcs = ["//:.hacking/scripts/python_rust_test.sh"],
+        data = data,
+        env = env,
+        size = "medium",
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
`cargo_workspace_tests` rebuilt Rust and ran maturin in a disposable directory whenever its result was invalidated. Replace it with 15 independently cached native test targets: library and CLI-library unit tests, the rules and templater harnesses, and all 11 Python CLI integration programs.

Compile the actual Python extension with the workspace's PyO3 dependency and Bazel's Python library. Tests launch the Python entry point and load that extension, preserving wrapper coverage. A shared execution wrapper uses cached Python dependencies and private fixture copies for dbt/fix writes; no compilation or dependency installation happens during native test execution.

Keep Cargo fallbacks in shared path/launcher helpers, assert nonempty fixture discovery, and require Python templaters during native runs. The `cargo_test` suite remains as a compatibility entry point. Maturin wheel CI remains unchanged; this runtime extension does not replace wheel/ABI packaging validation.

Validation on macOS:
- Full `bazelisk test //...`: 63 targets passed, including cached results.
- Final compatibility adjustment rechecked with all 15 migrated targets forced to execute: 11.7s with compilation/dependencies cached.
- Temporarily restored the former Cargo test path to verify helper compatibility: passed in 92.3s. The temporary target was removed.
- Coverage matched: 124 library tests plus one ignored, 10 CLI-library tests, 81 rule fixture files, three templater cases, and all 11 Python CLI integration programs.
- Rust formatting, shellcheck, Prettier, keep-sorted, and whitespace checks passed.

Separate observations, unchanged here:
- `loads_config_from_workspace_root` failed once during a forced LSP rerun; five immediate reruns passed. It is being investigated separately.
- Exporting `uv.lock` selects dbt-core 2.0.0b1, which lacks `dbt.mp_context`. Existing Python dependency-resolution behavior is preserved rather than introducing that unrelated breakage.

Single commit directly on main; independent of the earlier docs and benchmark PRs. Timing is a local warm-build comparison, not a clean-build or full-suite speedup claim. Linux validation is left to CI.
