### PR TITLE
test: prevent LSP fixture directory collisions

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -627,14 +627,21 @@ mod tests {
 
     impl TempRoot {
         fn new() -> Self {
-            let suffix = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            let path = std::env::temp_dir()
-                .join(format!("sqruff-lsp-test-{}-{suffix}", std::process::id()));
-            fs::create_dir_all(&path).unwrap();
-            Self { path }
+            loop {
+                let suffix = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos();
+                let path = std::env::temp_dir()
+                    .join(format!("sqruff-lsp-test-{}-{suffix}", std::process::id()));
+                // Parallel tests can observe the same clock tick. Claim the
+                // directory exclusively so they never share or delete fixtures.
+                match fs::create_dir(&path) {
+                    Ok(()) => return Self { path },
+                    Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(err) => panic!("Failed to create test directory {}: {err}", path.display()),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Parallel LSP tests can observe the same clock tick and generate the same PID/timestamp temporary-directory name. `create_dir_all` silently allowed them to share that directory, so one test could overwrite another's `.sqruff` or remove its fixtures. This caused `loads_config_from_workspace_root` to intermittently load ANSI instead of PostgreSQL.

Create the directory exclusively with `create_dir` and retry on `AlreadyExists`. Each test now owns its fixture directory and cleanup. Only the test helper changes; production LSP behavior is unchanged.

Validation on macOS:
- Reproduced the original failure twice in 500 runs of the nine-test LSP binary.
- Temporary instrumentation using exclusive creation without retries caught 11 directory collisions in 1,000 runs. That instrumentation is not included in this PR.
- With the fix: zero failures in 5,000 runs, with eight test processes running concurrently.
- `bazelisk test //crates/lsp:sqruff-lsp-test //:rustfmt_check` passed.
- `git diff --check` passed.

Single commit directly on main, independent of the native test migration in #3935.
