### PR TITLE
perf: parallelize action SHA checks and allow concurrent cargo-machete

### DIFF
--- a/.hacking/scripts/verify_action_shas.sh
+++ b/.hacking/scripts/verify_action_shas.sh
@@ -10,8 +10,37 @@ CHECKED=0
 SEEN_FILE=$(mktemp)
 trap 'rm -f "$SEEN_FILE"' EXIT
 
+PIDS=()
+
+wait_for_checks() {
+    local pid
+    for pid in "${PIDS[@]}"; do
+        if ! wait "$pid"; then
+            FAILED=1
+        fi
+    done
+    PIDS=()
+}
+
+verify_sha() {
+    local file="$1" repo="$2" sha="$3" status
+    # Treat transport errors as failures too, without stopping other checks.
+    if ! status=$(curl -s -o /dev/null -w "%{http_code}" \
+        ${GITHUB_TOKEN:+-H "Authorization: token $GITHUB_TOKEN"} \
+        "https://api.github.com/repos/${repo}/git/commits/${sha}"); then
+        echo "ERROR: ${file}: Could not verify ${repo}@${sha} (request failed)"
+        return 1
+    fi
+    if [ "$status" != "200" ]; then
+        echo "ERROR: ${file}: ${repo}@${sha} does not exist (HTTP ${status})"
+        return 1
+    fi
+}
+
 for file in .github/workflows/*.yml; do
     # Extract owner/repo@sha patterns from uses: directives
+    # verify_sha uses the file argument only as an error label, never writes it.
+    # shellcheck disable=SC2094
     while IFS= read -r line; do
         action=$(echo "$line" | grep -oE '[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+@[0-9a-f]{40}' || true)
         if [ -z "$action" ]; then
@@ -29,17 +58,18 @@ for file in .github/workflows/*.yml; do
         echo "$key" >> "$SEEN_FILE"
 
         CHECKED=$((CHECKED + 1))
-        # Use GitHub API to check if the commit exists
-        status=$(curl -s -o /dev/null -w "%{http_code}" \
-            ${GITHUB_TOKEN:+-H "Authorization: token $GITHUB_TOKEN"} \
-            "https://api.github.com/repos/${repo}/git/commits/${sha}")
-
-        if [ "$status" != "200" ]; then
-            echo "ERROR: ${file}: ${repo}@${sha} does not exist (HTTP ${status})"
-            FAILED=1
+        # Check batches of four refs, keeping API concurrency bounded.
+        verify_sha "$file" "$repo" "$sha" &
+        PIDS+=("$!")
+        if [ "${#PIDS[@]}" -eq 4 ]; then
+            wait_for_checks
         fi
     done < "$file"
 done
+
+if [ "${#PIDS[@]}" -gt 0 ]; then
+    wait_for_checks
+fi
 
 if [ "$CHECKED" -eq 0 ]; then
     echo "ERROR: No action SHAs found to verify"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -386,7 +386,6 @@ sh_test(
         "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
         "MACHETE": "$(rlocationpath @cargo_machete//:cargo-machete)",
     },
-    tags = ["exclusive"],
 )
 
 # Cargo compiler checks share one writable target directory. Keeping these in a


### PR DESCRIPTION
GitHub Action SHA verification currently makes serial API requests, and `cargo_machete` forces an exclusive test phase. Verify unique action refs in batches of at most four requests and let `cargo_machete` run alongside other tests.

Existing repository/SHA deduplication is preserved. SHA verification collects HTTP and transport failures across batches and still fails if no refs are found.

Validation: `bazelisk test //:cargo_machete //:shellcheck //:verify_action_shas --test_output=errors` passed on macOS. Mock API checks verified deduplication, the four-request concurrency limit, HTTP/transport failure handling, and empty input.
