### PR TITLE
perf: run workspace Rust formatting directly in Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,13 +4,13 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:prettier/package_json.bzl", prettier_bin = "bin")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_shellcheck//:def.bzl", "shellcheck_test")
 load(":cargo_build.bzl", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv", "python_venv_provider", "uv_python_install", "uv_python_venv")
 load(":clippy.bzl", "clippy_feature_flag", "clippy_targets", "workspace_clippy")
 load(":linters.bzl", "keep_sorted_test")
+load(":rustfmt.bzl", "rustfmt_sources_test")
 
 # Link all npm packages into node_modules
 npm_link_all_packages(name = "node_modules")
@@ -333,10 +333,13 @@ python_venv_provider(
     venv = ":pytest_py312_python",
 )
 
-# Rust format check
-rustfmt_test(
+# Format the same Rust files as the Cargo wrapper, including tests and benches
+# that are not part of RUST_TARGETS. Only Rust sources enter the test's runfiles.
+rustfmt_sources_test(
     name = "rustfmt_check",
-    targets = RUST_TARGETS,
+    size = "small",
+    srcs = [":cargo_srcs"],
+    config = "rustfmt.toml",
 )
 
 # Lint every workspace library and binary with Cargo's all-features coverage.
@@ -490,13 +493,10 @@ sh_binary(
     ],
 )
 
-# Cargo fmt check - verify code formatting
-# Uses vendored dependencies for hermetic builds
-cargo_test(
+# Preserve the old command without running the formatting check twice.
+alias(
     name = "cargo_fmt_check",
-    srcs = [":cargo_srcs"],
-    vendor = ":cargo_deps",
-    script = "find . -type f -name '*.rs' -exec \"$RUSTFMT\" --edition 2024 --check {} +",
+    actual = ":rustfmt_check",
 )
 
 # Cargo test - run workspace tests that have not migrated to native Bazel rules.

--- a/rustfmt.bzl
+++ b/rustfmt.bzl
@@ -1,0 +1,49 @@
+"""Check Rust source filegroups without compiling crates or preparing Cargo."""
+
+_RUSTFMT_TOOLCHAIN = "@rules_rust//rust/rustfmt:toolchain_type"
+
+def _shell_quote(value):
+    return "'" + value.replace("'", "'\\''") + "'"
+
+def _rustfmt_sources_test_impl(ctx):
+    toolchain = ctx.toolchains[_RUSTFMT_TOOLCHAIN]
+    srcs = [src for src in ctx.files.srcs if src.extension == "rs"]
+    if not srcs:
+        fail("Expected at least one Rust source file")
+
+    # The project's empty config preserves the Cargo wrapper's defaults and
+    # prevents rustfmt from discovering configuration outside the sandbox.
+    config = ctx.file.config
+    args = [toolchain.rustfmt.short_path, "--edition", ctx.attr.edition, "--check", "--config-path", config.short_path]
+    args += [src.short_path for src in srcs]
+    executable = ctx.actions.declare_file(ctx.label.name + "_test.sh")
+    ctx.actions.write(
+        executable,
+        """#!/usr/bin/env bash
+set -euo pipefail
+cd "${RUNFILES_DIR:-$0.runfiles}/%s"
+exec %s
+""" % (ctx.workspace_name, " ".join([_shell_quote(arg) for arg in args])),
+        is_executable = True,
+    )
+    return [DefaultInfo(
+        executable = executable,
+        runfiles = ctx.runfiles(
+            files = srcs + [config],
+            transitive_files = toolchain.all_files,
+        ),
+    )]
+
+rustfmt_sources_test = rule(
+    implementation = _rustfmt_sources_test_impl,
+    test = True,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, mandatory = True),
+        "edition": attr.string(default = "2024"),
+        "config": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+    toolchains = [_RUSTFMT_TOOLCHAIN],
+)


### PR DESCRIPTION
The Cargo formatting wrapper copies the workspace and depends on vendored packages just to invoke rustfmt. The existing native check also repeats most of that formatting work, but misses integration tests, benchmarks and the Python binding.

Replace both with one Bazel test using the registered rustfmt toolchain and the same Rust sources from `cargo_srcs`. Preserve `cargo_fmt_check` as an alias to `rustfmt_check`, so existing commands work and `bazel test //...` runs formatting once. The test uses edition 2024 and the project's empty formatting configuration, preserving the previous default formatting settings. The standalone Zed extension's separate formatting job is unchanged.

Validation on macOS:

- Compared exact input sets: all 277 files from the Cargo wrapper are covered, including all 246 files from the previous native check.
- Injected formatting errors into temporary copies of the 31 additional files and one shared library source; both old and new checks detected all 32.
- `bazelisk test //:cargo_fmt_check //:rustfmt_check --nocache_test_results --test_output=errors` passed, executing one underlying test.
- Verified no Cargo vendor or Python environment dependency, and checked the generated script with ShellCheck.
- Local test runtime: 3.5 seconds versus 11.3 seconds for the old Cargo wrapper; the previous duplicate native check also took 3.8 seconds. These are local measurements, not CI results.
