### PR TITLE
perf: replace Cargo check with native Bazel compilation and coverage guards

### DIFF
--- a/.hacking/scripts/check_cargo_targets.py
+++ b/.hacking/scripts/check_cargo_targets.py
@@ -1,0 +1,131 @@
+"""Compare native Bazel compilation with Cargo's discovered workspace targets."""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import tomllib
+
+
+def target_modes(target, manifest):
+    """Return compilation modes, including unit/benchmark harnesses on libraries."""
+    kind = target["kind"][0]
+    if kind in ("lib", "rlib", "cdylib", "staticlib", "dylib", "proc-macro"):
+        settings = manifest.get("lib", {})
+        modes = [(False, False)]
+    elif kind == "bin":
+        settings = next(
+            (
+                item
+                for item in manifest.get("bin", [])
+                if item["name"] == target["name"]
+            ),
+            {},
+        )
+        modes = [(False, False)]
+    elif kind in ("test", "bench", "example"):
+        settings = next(
+            (item for item in manifest.get(kind, []) if item["name"] == target["name"]),
+            {},
+        )
+        if kind == "example" and not target["test"]:
+            return [(False, False)]
+        return [(True, settings.get("harness", True))]
+    else:
+        raise ValueError(
+            f"Cargo target kind {kind!r} needs explicit native coverage support"
+        )
+    if target["test"] or settings.get("bench", True):
+        modes.append((True, settings.get("harness", True)))
+    return modes
+
+
+def check_coverage(metadata, entries, workspace):
+    errors = []
+    checked = 0
+    for package in metadata["packages"]:
+        manifest_path = Path(package["manifest_path"])
+        manifest = tomllib.loads(manifest_path.read_text())
+        features = set(package["features"])
+        for target in package["targets"]:
+            root = str(Path(target["src_path"]).relative_to(workspace))
+            try:
+                modes = target_modes(target, manifest)
+            except ValueError as error:
+                errors.append(f"{package['name']}/{target['name']}: {error}")
+                continue
+            for test_mode, harness in modes:
+                checked += 1
+                candidates = [
+                    entry
+                    for entry in entries
+                    if entry["root"] == root and entry["test"] == test_mode
+                ]
+                description = f"{package['name']}/{target['name']} ({'test' if test_mode else 'normal'} mode, {root})"
+                if not candidates:
+                    errors.append(f"Missing Bazel compiler target for {description}")
+                elif not any(
+                    set(entry["features"]) == features
+                    and entry["edition"] == target["edition"]
+                    and entry["compilation_mode"] == "fastbuild"
+                    and entry["lint_config"]
+                    and (not test_mode or entry["harness"] == harness)
+                    for entry in candidates
+                ):
+                    errors.append(
+                        f"Bazel features, edition or harness differ for {description} "
+                        "(requires fastbuild and Cargo lint policy): "
+                        f"expected features {sorted(features)}, edition {target['edition']}, harness {harness}; "
+                        f"got {candidates}"
+                    )
+    if not checked:
+        errors.append("Cargo did not discover any compiler targets")
+    return errors, checked
+
+
+def main():
+    inventory, sources, marker, cargo, rustc = sys.argv[1:]
+    entries = json.loads(Path(inventory).read_text())
+    cargo, rustc = str(Path(cargo).resolve()), str(Path(rustc).resolve())
+    with tempfile.TemporaryDirectory(prefix="cargo-target-coverage-") as directory:
+        workspace = Path(directory).resolve()
+        for path in json.loads(Path(sources).read_text()):
+            destination = workspace / path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(path, destination)
+        environment = dict(
+            os.environ, CARGO_HOME=str(workspace / ".cargo"), RUSTC=rustc
+        )
+        result = subprocess.run(
+            [
+                cargo,
+                "metadata",
+                "--format-version=1",
+                "--no-deps",
+                "--all-features",
+                "--locked",
+                "--offline",
+            ],
+            cwd=workspace,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode:
+            sys.exit(result.stderr)
+        errors, checked = check_coverage(json.loads(result.stdout), entries, workspace)
+        if errors:
+            sys.exit(
+                "\n".join(errors)
+                + "\nAdd or update native compiler targets before removing Cargo coverage."
+            )
+    Path(marker).write_text(f"Verified {checked} Cargo target/mode combinations\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.hacking/scripts/check_cargo_targets_test.py
+++ b/.hacking/scripts/check_cargo_targets_test.py
@@ -1,0 +1,77 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_cargo_targets import check_coverage, target_modes
+
+
+class CargoCoverageTest(unittest.TestCase):
+    def test_library_unit_and_benchmark_modes(self):
+        target = {"kind": ["rlib"], "name": "example", "test": True}
+        self.assertEqual(target_modes(target, {}), [(False, False), (True, True)])
+        target["test"] = False
+        self.assertEqual(target_modes(target, {}), [(False, False), (True, True)])
+        self.assertEqual(
+            target_modes(target, {"lib": {"bench": False}}), [(False, False)]
+        )
+
+    def test_criterion_benchmark_is_compiled_in_test_mode_without_harness(self):
+        target = {"kind": ["bench"], "name": "speed", "test": False}
+        manifest = {"bench": [{"name": "speed", "harness": False}]}
+        self.assertEqual(target_modes(target, manifest), [(True, False)])
+
+    def test_new_build_script_requires_coverage(self):
+        with self.assertRaises(ValueError):
+            target_modes({"kind": ["custom-build"]}, {})
+
+    def test_new_test_benchmark_and_example_are_not_silently_skipped(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            manifest = workspace / "Cargo.toml"
+            manifest.write_text('[package]\nname = "example"\nversion = "0.1.0"\n')
+            for kind in ["test", "bench", "example"]:
+                target = {
+                    "name": "new_target",
+                    "kind": [kind],
+                    "test": kind == "test",
+                    "src_path": str(workspace / "new.rs"),
+                    "edition": "2024",
+                }
+                metadata = {
+                    "packages": [
+                        {
+                            "name": "example",
+                            "manifest_path": str(manifest),
+                            "features": {"new": []},
+                            "targets": [target],
+                        }
+                    ]
+                }
+                errors, count = check_coverage(metadata, [], workspace)
+                self.assertEqual(count, 1)
+                self.assertIn("Missing Bazel compiler target", errors[0])
+                entry = {
+                    "root": "new.rs",
+                    "compilation_mode": "fastbuild",
+                    "lint_config": True,
+                    "test": kind != "example",
+                    "harness": True,
+                    "edition": "2024",
+                    "features": ["new"],
+                }
+                self.assertEqual(check_coverage(metadata, [entry], workspace)[0], [])
+                entry["features"] = []
+                self.assertIn(
+                    "features, edition or harness differ",
+                    check_coverage(metadata, [entry], workspace)[0][0],
+                )
+                entry["features"] = ["new"]
+                entry["edition"] = "2021"
+                self.assertTrue(check_coverage(metadata, [entry], workspace)[0])
+
+    def test_empty_inventory_fails(self):
+        self.assertTrue(check_coverage({"packages": []}, [], Path("."))[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_shellcheck//:def.bzl", "shellcheck_test")
 load(":clippy.bzl", "clippy_feature_flag", "clippy_targets", "workspace_clippy")
 load(":cargo_build.bzl", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv_provider", "uv_python_install", "uv_python_venv")
+load(":compiler.bzl", "workspace_compile")
 load(":linters.bzl", "keep_sorted_test")
 load(":rustfmt.bzl", "rustfmt_sources_test")
 
@@ -413,9 +414,8 @@ sh_test(
     },
 )
 
-# Cargo compiler checks share one writable target directory. Keeping these in a
-# single Bazel test lets Cargo reuse dependency artifacts between check
-# and the per-feature cargo-hack checks.
+# Cargo retains manifest/feature compatibility checks with a shared target
+# directory. Native compiler_check and clippy_check cover compilation/linting.
 cargo_test(
     name = "cargo_compile_checks",
     python_venv = ":python_runtime",
@@ -429,12 +429,8 @@ cargo_test(
 export CARGO_PROFILE_DEV_DEBUG=0
 export CARGO_INCREMENTAL=0
 
-echo "::group::Cargo check"
-cargo check --all --all-features --tests --benches --locked --offline
-echo "::endgroup::"
-
 echo "::group::Cargo hack"
-cargo hack check --each-feature --exclude-features=codegen-docs --offline
+cargo hack check --each-feature --exclude-features=codegen-docs --locked --offline
 echo "::endgroup::"
 """,
 )
@@ -634,4 +630,35 @@ filegroup(
     name = "native_test_python",
     srcs = [":pytest_py312_venv"],
     visibility = ["//visibility:public"],
+)
+
+# Discover Bazel crate packages automatically. A new Cargo-only package is also
+# staged below, so Cargo discovery reports its missing Bazel compiler coverage.
+_COMPILER_PACKAGES = subpackages(include = ["crates/*"])
+
+workspace_compile(
+    name = "compiler_check",
+    testonly = True,
+    targets = ["//" + package + ":compiler_targets" for package in _COMPILER_PACKAGES],
+    srcs = ["Cargo.toml", "Cargo.lock"] + [
+        "//" + package + ":compiler_sources" for package in _COMPILER_PACKAGES
+    ] + glob(["crates/**/*.rs", "crates/**/Cargo.toml"], exclude = ["**/target/**"], allow_empty = True),
+)
+
+py_binary(
+    name = "check_cargo_targets",
+    srcs = [".hacking/scripts/check_cargo_targets.py"],
+    main = ".hacking/scripts/check_cargo_targets.py",
+    tags = ["manual"],
+)
+
+py_test(
+    name = "check_cargo_targets_test",
+    size = "small",
+    srcs = [
+        ".hacking/scripts/check_cargo_targets.py",
+        ".hacking/scripts/check_cargo_targets_test.py",
+    ],
+    main = ".hacking/scripts/check_cargo_targets_test.py",
+    imports = [".hacking/scripts"],
 )

--- a/clippy.bzl
+++ b/clippy.bzl
@@ -1,4 +1,4 @@
-"""Cargo lint policy and an all-features configuration for native Clippy."""
+"""Cargo lint policy and a shared all-features compiler/lint configuration."""
 
 load("@rules_rust//cargo:defs.bzl", "extract_cargo_lints")
 load("@rules_rust//rust:defs.bzl", "rust_clippy_aspect")
@@ -37,7 +37,7 @@ def cargo_lints():
     )
 
 def clippy_config(normal, all_features):
-    """Select attributes for the all-features lint configuration only."""
+    """Select attributes for the all-features compiler/lint configuration."""
     return select({
         "//:clippy_all_features_enabled": all_features,
         "//conditions:default": normal,

--- a/compiler.bzl
+++ b/compiler.bzl
@@ -1,0 +1,105 @@
+"""Compile Cargo's target inventory with native Bazel rules and check coverage."""
+
+load("@rules_rust//rust:defs.bzl", "rust_common")
+
+def _compiler_configuration(_settings, _attr):
+    # Cargo check uses the dev profile: opt-level 0 and debug assertions enabled.
+    # fastbuild also omits debug information, matching CARGO_PROFILE_DEV_DEBUG=0.
+    return {
+        "//:clippy_all_features": True,
+        "//command_line_option:compilation_mode": "fastbuild",
+    }
+
+_compiler_transition = transition(
+    implementation = _compiler_configuration,
+    inputs = [],
+    outputs = ["//:clippy_all_features", "//command_line_option:compilation_mode"],
+)
+
+_Compilation = provider(fields = ["entries"])
+
+def _inventory_impl(target, ctx):
+    if rust_common.crate_info in target:
+        crate = target[rust_common.crate_info]
+    else:
+        crate = target[rust_common.test_crate_info].crate
+    return [_Compilation(entries = [{
+        "target": str(target.label),
+        "root": crate.root.short_path,
+        "test": crate.is_test,
+        "harness": getattr(ctx.rule.attr, "use_libtest_harness", False),
+        "edition": crate.edition,
+        "features": ctx.rule.attr.crate_features,
+        "compilation_mode": ctx.var["COMPILATION_MODE"],
+        "lint_config": bool(getattr(ctx.rule.attr, "lint_config", None)),
+    }])]
+
+_inventory = aspect(implementation = _inventory_impl)
+
+def _targets_impl(ctx):
+    return [
+        DefaultInfo(files = depset(transitive = [dep[DefaultInfo].files for dep in ctx.attr.deps])),
+        _Compilation(entries = [entry for dep in ctx.attr.deps for entry in dep[_Compilation].entries]),
+    ]
+
+_targets = rule(
+    implementation = _targets_impl,
+    attrs = {"deps": attr.label_list(aspects = [_inventory])},
+)
+
+def compiler_targets(libraries):
+    """Include all declared Rust tests, even compile-only benchmarks tagged manual."""
+    _targets(
+        name = "compiler_targets",
+        testonly = True,
+        deps = libraries + [
+            ":" + name
+            for name, rule in native.existing_rules().items()
+            if rule["kind"] == "rust_test"
+        ],
+        visibility = ["//visibility:public"],
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "compiler_sources",
+        srcs = ["Cargo.toml"] + native.glob(["**/*.rs"], exclude = ["**/target/**"]),
+        visibility = ["//visibility:public"],
+    )
+
+def _workspace_compile_impl(ctx):
+    inventory = ctx.actions.declare_file(ctx.label.name + ".targets.json")
+    ctx.actions.write(inventory, json.encode([
+        entry for target in ctx.attr.targets for entry in target[_Compilation].entries
+    ]))
+    sources = ctx.actions.declare_file(ctx.label.name + ".sources.json")
+    ctx.actions.write(sources, json.encode([file.path for file in ctx.files.srcs]))
+    marker = ctx.actions.declare_file(ctx.label.name + ".coverage.ok")
+    toolchain = ctx.toolchains["@rules_rust//rust:toolchain_type"]
+    args = ctx.actions.args()
+    args.add_all([inventory, sources, marker, toolchain.cargo, toolchain.rustc])
+    ctx.actions.run(
+        executable = ctx.executable._guard,
+        arguments = [args],
+        inputs = ctx.files.srcs + [inventory, sources],
+        tools = [toolchain.all_files],
+        outputs = [marker],
+        mnemonic = "CargoTargetCoverage",
+        progress_message = "Checking native compiler coverage against Cargo targets",
+    )
+    return [DefaultInfo(files = depset(
+        [marker],
+        transitive = [target[DefaultInfo].files for target in ctx.attr.targets],
+    ))]
+
+workspace_compile = rule(
+    implementation = _workspace_compile_impl,
+    attrs = {
+        "targets": attr.label_list(cfg = _compiler_transition),
+        "srcs": attr.label_list(allow_files = True),
+        "_guard": attr.label(default = "//:check_cargo_targets", executable = True, cfg = "exec"),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    toolchains = ["@rules_rust//rust:toolchain_type"],
+)

--- a/crates/cli-lib/BUILD.bazel
+++ b/crates/cli-lib/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints", "clippy_config")
 load("//:python_tests.bzl", "python_rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
@@ -5,17 +6,20 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 
 exports_files(["Cargo.toml"])
 
+_CARGO_FEATURES = [
+    "clap-markdown",
+    "codegen-docs",
+    "minijinja",
+    "parser",
+    "pyo3",
+    "python",
+]
+
+
 rust_library(
     name = "sqruff-cli-lib",
     lint_config = ":cargo_lints",
-    crate_features = clippy_config([], [
-        "clap-markdown",
-        "codegen-docs",
-        "minijinja",
-        "parser",
-        "pyo3",
-        "python",
-    ]),
+    crate_features = clippy_config([], _CARGO_FEATURES),
     compile_data = clippy_config([], glob(["src/docs/*.md"])),
     srcs = glob(["src/**/*.rs"]),
     proc_macro_deps = all_crate_deps(proc_macro = True),
@@ -74,14 +78,16 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
 rust_library(
     name = "sqruff-cli-lib-python",
     srcs = glob(["src/**/*.rs"]),
     crate_name = "sqruff_cli_lib",
-    crate_features = ["python", "parser"],
+    crate_features = clippy_config(["python", "parser"], _CARGO_FEATURES),
+    compile_data = clippy_config([], glob(["src/docs/*.md"])),
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
-    deps = all_crate_deps(normal = True) + [
+    deps = all_crate_deps(normal = True) + clippy_config([], ["@crates//:clap-markdown", "@crates//:minijinja"]) + [
         "//crates/lib:sqruff-lib-python",
         "//crates/lib-core:sqruff-lib-core",
         "//crates/lib-dialects:sqruff-lib-dialects",
@@ -91,10 +97,13 @@ rust_library(
 
 python_rust_test(
     name = "sqruff-cli-lib-test",
+    lint_config = ":cargo_lints",
     crate = ":sqruff-cli-lib-python",
-    crate_features = ["python", "parser", "codegen-docs"],
+    crate_features = clippy_config(["python", "parser", "codegen-docs"], _CARGO_FEATURES),
     compile_data = glob(["src/docs/*.md"]),
     deps = all_crate_deps(normal_dev = True) + [
         "@rules_python//python/cc:current_py_cc_libs",
     ],
 )
+
+compiler_targets(libraries = [":sqruff-cli-lib"])

--- a/crates/cli-python/BUILD.bazel
+++ b/crates/cli-python/BUILD.bazel
@@ -1,7 +1,8 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints")
 load("//:python_tests.bzl", "python_rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
+load("@rules_rust//rust:defs.bzl", "rust_test", "rust_library", "rust_shared_library")
 
 exports_files([
     "Cargo.toml",
@@ -76,7 +77,8 @@ _INTEGRATION_FIXTURES = {
 
 [
     python_rust_test(
-        name = "integration_" + test,
+        lint_config = ":cargo_lints",
+            name = "integration_" + test,
         srcs = ["tests/" + test + ".rs"] + glob(["tests/common/**/*.rs"]),
         crate_root = "tests/" + test + ".rs",
         use_libtest_harness = False,
@@ -115,3 +117,12 @@ rust_library(
     visibility = ["//visibility:public"],
     tags = ["manual"],
 )
+
+rust_test(
+    name = "sqruff-python-clippy-compile-test",
+    lint_config = ":cargo_lints",
+    crate = ":sqruff-python-clippy",
+    tags = ["manual"],
+)
+
+compiler_targets(libraries = [":sqruff-python-clippy"])

--- a/crates/cli/BUILD.bazel
+++ b/crates/cli/BUILD.bazel
@@ -1,6 +1,7 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints", "clippy_config")
 load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test_suite")
+load("@rules_rust//rust:defs.bzl", "rust_test", "rust_binary", "rust_test_suite")
 
 exports_files(["Cargo.toml"])
 
@@ -40,6 +41,8 @@ rust_binary(
 # Cargo and Bazel both discover the integration tests from tests/*.rs.
 rust_test_suite(
     name = "cli_tests",
+    lint_config = ":cargo_lints",
+    crate_features = clippy_config([], _CLIPPY_FEATURES),
     srcs = glob(["tests/*.rs"]),
     shared_srcs = glob(["tests/common/**/*.rs"]),
     data = [
@@ -92,3 +95,21 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+rust_test(
+    name = "sqruff-compile-test",
+    lint_config = ":cargo_lints",
+    crate = ":sqruff",
+    crate_features = clippy_config([], _CLIPPY_FEATURES),
+    tags = ["manual"],
+)
+
+rust_test(
+    name = "bench-compile-test",
+    lint_config = ":cargo_lints",
+    crate = ":bench",
+    crate_features = clippy_config([], _CLIPPY_FEATURES),
+    tags = ["manual"],
+)
+
+compiler_targets(libraries = [":sqruff", ":bench"])

--- a/crates/lib-core/BUILD.bazel
+++ b/crates/lib-core/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints")
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
@@ -21,6 +22,7 @@ rust_library(
 
 rust_test(
     name = "sqruff-lib-core-test",
+    lint_config = ":cargo_lints",
     crate = ":sqruff-lib-core",
     crate_features = ALL_FEATURES,
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
@@ -42,3 +44,5 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+compiler_targets(libraries = [":sqruff-lib-core"])

--- a/crates/lib-dialects/BUILD.bazel
+++ b/crates/lib-dialects/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints", "clippy_config")
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite")
@@ -48,16 +49,18 @@ rust_library(
 
 rust_test(
     name = "sqruff-lib-dialects-test",
+    lint_config = ":cargo_lints",
     crate = ":sqruff-lib-dialects",
-    crate_features = ALL_FEATURES,
+    crate_features = clippy_config(ALL_FEATURES, ALL_FEATURES + ["default"]),
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal_dev = True),
 )
 
 rust_test_suite(
     name = "dialect_tests",
+    lint_config = ":cargo_lints",
     srcs = ["tests/dialects.rs"],
-    crate_features = ALL_FEATURES,
+    crate_features = clippy_config(ALL_FEATURES, ALL_FEATURES + ["default"]),
     data = [
         ":test_fixtures",
         "Cargo.toml",
@@ -104,3 +107,5 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+compiler_targets(libraries = [":sqruff-lib-dialects"])

--- a/crates/lib-wasm/BUILD.bazel
+++ b/crates/lib-wasm/BUILD.bazel
@@ -1,6 +1,7 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints")
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
+load("@rules_rust//rust:defs.bzl", "rust_test", "rust_library", "rust_shared_library")
 load("@rules_rust_wasm_bindgen//:defs.bzl", "rust_wasm_bindgen")
 
 exports_files(["Cargo.toml"])
@@ -71,3 +72,12 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+rust_test(
+    name = "sqruff-wasm-compile-test",
+    lint_config = ":cargo_lints",
+    crate = ":sqruff-wasm",
+    tags = ["manual"],
+)
+
+compiler_targets(libraries = [":sqruff-wasm"])

--- a/crates/lib/BUILD.bazel
+++ b/crates/lib/BUILD.bazel
@@ -1,9 +1,18 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints", "clippy_config")
 load("//:python_tests.bzl", "python_rust_test")
-load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library")
+load("@crates//:defs.bzl", "aliases", "all_crate_deps", "crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_test", "rust_library", "rust_shared_library")
 
 exports_files(["Cargo.toml"])
+
+_CARGO_FEATURES = [
+    "parser",
+    "pyo3",
+    "python",
+    "serde_yaml",
+]
+
 
 ALL_FEATURES = [
     "parser",
@@ -14,7 +23,7 @@ rust_library(
     lint_config = ":cargo_lints",
     srcs = glob(["src/**/*.rs"]),
     compile_data = glob(["src/**/*.cfg"]),
-    crate_features = clippy_config(ALL_FEATURES, ALL_FEATURES + ["python", "serde_yaml", "pyo3"]),
+    crate_features = clippy_config(ALL_FEATURES, _CARGO_FEATURES),
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True) + clippy_config([], ["@rules_python//python/cc:current_py_cc_libs"]) + [
@@ -29,7 +38,7 @@ rust_library(
     lint_config = ":cargo_lints",
     srcs = glob(["src/**/*.rs"]),
     compile_data = glob(["src/**/*.cfg"]),
-    crate_features = clippy_config(ALL_FEATURES + ["python"], ALL_FEATURES + ["python", "serde_yaml", "pyo3"]),
+    crate_features = clippy_config(ALL_FEATURES + ["python"], _CARGO_FEATURES),
     crate_name = "sqruff_lib",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
@@ -108,10 +117,12 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
 python_rust_test(
     name = "sqruff-lib-test",
+    lint_config = ":cargo_lints",
     crate = ":sqruff-lib-python",
-    crate_features = ALL_FEATURES + ["python", "serde_yaml"],
+    crate_features = clippy_config(ALL_FEATURES + ["python", "serde_yaml"], _CARGO_FEATURES),
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal = True, normal_dev = True) + [
         ":sqruff-lib-python",
@@ -126,6 +137,8 @@ python_rust_test(
 [
     python_rust_test(
         name = test + "_test",
+        lint_config = ":cargo_lints",
+        crate_features = clippy_config([], _CARGO_FEATURES),
         srcs = ["tests/" + test + ".rs"],
         crate_root = "tests/" + test + ".rs",
         use_libtest_harness = False,
@@ -139,3 +152,25 @@ python_rust_test(
     )
     for test in ["rules", "templaters"]
 ]
+
+# Compile the Criterion programs with cfg(test), without running benchmarks.
+[
+    rust_test(
+        name = "benchmark_" + benchmark,
+        lint_config = ":cargo_lints",
+        aliases = aliases(normal_dev = True),
+        srcs = ["benches/" + benchmark + ".rs", "benches/shims/global_alloc_overwrite.rs"],
+        crate_root = "benches/" + benchmark + ".rs",
+        crate_features = clippy_config([], _CARGO_FEATURES),
+        use_libtest_harness = False,
+        deps = all_crate_deps(normal_dev = True) + [
+            ":sqruff-lib",
+            "//crates/lib-core:sqruff-lib-core",
+            "@rules_python//python/cc:current_py_cc_libs",
+        ],
+        tags = ["manual"],
+    )
+    for benchmark in ["depth_map", "fix", "parsing"]
+]
+
+compiler_targets(libraries = [":sqruff-lib"])

--- a/crates/lineage/BUILD.bazel
+++ b/crates/lineage/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints")
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
@@ -18,6 +19,7 @@ rust_library(
 
 rust_test(
     name = "lineage-test",
+    lint_config = ":cargo_lints",
     crate = ":lineage",
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal_dev = True),
@@ -38,3 +40,5 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+compiler_targets(libraries = [":lineage"])

--- a/crates/lsp/BUILD.bazel
+++ b/crates/lsp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints")
 load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_shared_library", "rust_test")
@@ -19,6 +20,7 @@ rust_library(
 
 rust_test(
     name = "sqruff-lsp-test",
+    lint_config = ":cargo_lints",
     crate = ":sqruff-lsp",
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal_dev = True),
@@ -90,3 +92,5 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+compiler_targets(libraries = [":sqruff-lsp"])

--- a/crates/sqlinference/BUILD.bazel
+++ b/crates/sqlinference/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:compiler.bzl", "compiler_targets")
 load("//:clippy.bzl", "cargo_lints")
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
@@ -17,6 +18,7 @@ rust_library(
 
 rust_test(
     name = "sqruff-sqlinference-test",
+    lint_config = ":cargo_lints",
     crate = ":sqruff-sqlinference",
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
     deps = all_crate_deps(normal_dev = True) + [
@@ -39,3 +41,5 @@ filegroup(
 
 # Keep Rust and Clippy lint levels inherited from Cargo.toml.
 cargo_lints()
+
+compiler_targets(libraries = [":sqruff-sqlinference"])


### PR DESCRIPTION
Stacked on #3935; merge that PR first. This PR contains one compiler-check commit.

Replace the all-features `cargo check` invocation with `//:compiler_check`, which compiles native Bazel libraries, binaries, test harnesses and all three Criterion benchmarks. The compiler configuration enables every Cargo feature and preserves the dev profile's debug assertions and inherited Cargo lint policy. Benchmarks compile without running; Cargo-hack remains for individual-feature compatibility checks, with `--locked --offline`.

A guard uses the pinned Cargo toolchain's offline metadata to compare discovered workspace targets against actual Bazel Rust providers. It currently verifies 50 target/mode combinations and fails for missing targets or mismatched features, editions, harnesses, compiler mode or missing lint configuration. New Cargo packages, tests, examples and benchmarks must gain native coverage before the check passes.

Validation on macOS arm64:
- After rebasing: native compiler and Clippy checks plus both guard suites, Rust formatting, core unit tests, CLI integration tests and all 15 migrated Python runtime targets passed (30 test targets).
- Temporary benchmark, integration-test, example and Cargo-only package additions were each rejected by the coverage guard.
- A deliberate benchmark type error under `#[cfg(debug_assertions)]` failed compilation, confirming debug-only benchmark paths are checked.
- Retained Cargo-hack passed all 46 feature checks with `--locked --offline`; Ruff and keep-sorted checks also passed.
- The full workspace suite was not rerun after this rebase. Linux validation remains for CI.
