### PR TITLE
perf: cache Cargo-hack checks by package with a feature matrix guard

### DIFF
--- a/.hacking/scripts/prepare_cargo_hack.py
+++ b/.hacking/scripts/prepare_cargo_hack.py
@@ -1,0 +1,164 @@
+"""Guard Cargo-hack's exact matrix and stage independently cached package inputs."""
+
+import collections
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Preserve the existing check policy, including its intentional docs exclusion.
+CHECK = [
+    "check",
+    "--each-feature",
+    "--exclude-features=codegen-docs",
+    "--locked",
+    "--offline",
+]
+
+
+def commands(output):
+    result = collections.Counter()
+    for line in output.splitlines():
+        command = tuple(shlex.split(line))
+        if command[:2] != ("cargo", "check") or "--manifest-path" not in command:
+            raise ValueError(f"Unexpected Cargo-hack command: {line}")
+        result[command] += 1
+    if not result:
+        raise ValueError("Cargo-hack did not discover any checks")
+    return result
+
+
+def verify_matrix(expected, actual):
+    missing, extra = expected - actual, actual - expected
+    if missing or extra:
+        raise ValueError(
+            f"Cargo-hack coverage drift: missing {dict(missing)}, extra {dict(extra)}"
+        )
+
+
+def dependency_closure(packages, root):
+    by_path = {str(Path(p["manifest_path"]).parent.resolve()): p for p in packages}
+    seen, pending = set(), [root]
+    while pending:
+        path = pending.pop()
+        if path in seen:
+            continue
+        seen.add(path)
+        for dependency in by_path[path]["dependencies"]:
+            if "path" in dependency:
+                dependency_path = str(Path(dependency["path"]).resolve())
+                if dependency_path not in by_path:
+                    raise ValueError(
+                        f"Unrepresented local Cargo dependency: {dependency_path}"
+                    )
+                pending.append(dependency_path)
+    return seen
+
+
+def prepare(specification, cargo, rustc, hack):
+    outputs = {
+        package: Path(path).resolve()
+        for package, path in specification["packages"].items()
+    }
+    with tempfile.TemporaryDirectory(prefix="cargo-hack-matrix-") as directory:
+        workspace = Path(directory).resolve()
+        for source in specification["sources"]:
+            destination = workspace / source
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+        environment = dict(
+            os.environ, CARGO_HOME=str(workspace / ".cargo"), RUSTC=rustc, CARGO=cargo
+        )
+
+        def run(argv):
+            result = subprocess.run(
+                argv,
+                cwd=workspace,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode:
+                raise ValueError(f"{shlex.join(argv)} failed:\n{result.stderr}")
+            return result.stdout
+
+        metadata = json.loads(
+            run(
+                [
+                    cargo,
+                    "metadata",
+                    "--format-version=1",
+                    "--no-deps",
+                    "--all-features",
+                    "--locked",
+                    "--offline",
+                ]
+            )
+        )
+        packages = metadata["packages"]
+        by_directory = {
+            str(Path(p["manifest_path"]).parent.relative_to(workspace)): p
+            for p in packages
+        }
+        if set(by_directory) != set(outputs):
+            raise ValueError(
+                f"Cargo package coverage drift: discovered {sorted(by_directory)}, Bazel has {sorted(outputs)}"
+            )
+        expected = commands(run([hack, "hack", *CHECK, "--print-command-list"]))
+        actual = collections.Counter()
+        plans = {}
+        for package, output in outputs.items():
+            argv = ["cargo", "hack", *CHECK, "--package", by_directory[package]["name"]]
+            # Check the exact same command that will run in this package's test.
+            actual.update(commands(run([hack, *argv[1:], "--print-command-list"])))
+            plans[package] = argv
+        verify_matrix(expected, actual)
+
+        for package, output in outputs.items():
+            closure = dependency_closure(packages, str(workspace / package))
+            output.mkdir(parents=True, exist_ok=True)
+            for source in specification["sources"]:
+                path = workspace / source
+                if (
+                    Path(source).parent == Path(".")
+                    or Path(source).name == "Cargo.toml"
+                    or any(path.is_relative_to(root) for root in closure)
+                ):
+                    destination = output / source
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(path, destination)
+            # Cargo parses every workspace manifest, even outside the dependency
+            # closure. Preserve its discovered target inventory with empty roots.
+            for item in packages:
+                for target in item["targets"]:
+                    destination = output / Path(target["src_path"]).relative_to(
+                        workspace
+                    )
+                    if not destination.exists():
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        destination.write_text("")
+            (output / "run_hack.sh").write_text(
+                "#!/bin/bash\nset -euo pipefail\nexec "
+                + shlex.join(plans[package])
+                + "\n"
+            )
+        print(
+            f"Verified {sum(expected.values())} Cargo-hack combinations across {len(outputs)} package tests"
+        )
+
+
+def main():
+    specification, cargo, rustc, hack = sys.argv[1:]
+    prepare(
+        json.loads(Path(specification).read_text()),
+        *(str(Path(tool).resolve()) for tool in [cargo, rustc, hack]),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.hacking/scripts/prepare_cargo_hack_test.py
+++ b/.hacking/scripts/prepare_cargo_hack_test.py
@@ -1,0 +1,58 @@
+import collections
+import unittest
+
+from prepare_cargo_hack import commands, dependency_closure, verify_matrix
+
+
+class CargoHackCoverageTest(unittest.TestCase):
+    def test_matrix_rejects_missing_extra_and_duplicate_combinations(self):
+        matrix = commands(
+            "cargo check --manifest-path crates/a/Cargo.toml --no-default-features\ncargo check --manifest-path crates/a/Cargo.toml --features new\n"
+        )
+        verify_matrix(matrix, matrix.copy())
+        for command in matrix:
+            missing = matrix.copy()
+            missing[command] -= 1
+            with self.assertRaisesRegex(ValueError, "coverage drift"):
+                verify_matrix(matrix, missing)
+            duplicate = matrix.copy()
+            duplicate[command] += 1
+            with self.assertRaisesRegex(ValueError, "coverage drift"):
+                verify_matrix(matrix, duplicate)
+        extra = matrix + collections.Counter(
+            {("cargo", "check", "--features", "unexpected"): 1}
+        )
+        with self.assertRaisesRegex(ValueError, "coverage drift"):
+            verify_matrix(matrix, extra)
+
+    def test_empty_or_unrecognized_command_output_fails_closed(self):
+        for output in [
+            "",
+            "cargo test --manifest-path crates/a/Cargo.toml",
+            "unrecognized output",
+        ]:
+            with self.assertRaises(ValueError):
+                commands(output)
+
+    def test_closure_includes_optional_dev_and_transitive_dependencies(self):
+        packages = [
+            {
+                "manifest_path": "/a/Cargo.toml",
+                "dependencies": [
+                    {"path": "/b", "optional": True},
+                    {"path": "/c", "kind": "dev"},
+                ],
+            },
+            {"manifest_path": "/b/Cargo.toml", "dependencies": [{"path": "/d"}]},
+            {"manifest_path": "/c/Cargo.toml", "dependencies": []},
+            {"manifest_path": "/d/Cargo.toml", "dependencies": [{"path": "/a"}]},
+            {"manifest_path": "/unrelated/Cargo.toml", "dependencies": []},
+        ]
+        self.assertEqual(dependency_closure(packages, "/a"), {"/a", "/b", "/c", "/d"})
+        packages[1]["dependencies"] = [{"path": "/missing"}]
+        with self.assertRaisesRegex(ValueError, "Unrepresented local Cargo dependency"):
+            dependency_closure(packages, "/a")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,8 +8,9 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_shellcheck//:def.bzl", "shellcheck_test")
 load(":clippy.bzl", "clippy_feature_flag", "clippy_targets", "workspace_clippy")
-load(":cargo_build.bzl", "cargo_test", "cargo_vendor", "cargo_vendor_provider", "python_venv_provider", "uv_python_install", "uv_python_venv")
+load(":cargo_build.bzl", "cargo_vendor", "cargo_vendor_provider", "python_venv_provider", "uv_python_install", "uv_python_venv")
 load(":compiler.bzl", "workspace_compile")
+load(":cargo_hack.bzl", "cargo_hack_packages")
 load(":linters.bzl", "keep_sorted_test")
 load(":rustfmt.bzl", "rustfmt_sources_test")
 
@@ -414,25 +415,20 @@ sh_test(
     },
 )
 
-# Cargo retains manifest/feature compatibility checks with a shared target
-# directory. Native compiler_check and clippy_check cover compilation/linting.
-cargo_test(
+# Each package retains Cargo's feature-resolution checks with independent caching.
+cargo_hack_packages(
     name = "cargo_compile_checks",
-    python_venv = ":python_runtime",
-    size = "enormous",
-    srcs = [":cargo_srcs"],
-    tools = ["@cargo_hack//:cargo-hack"],
-    vendor = ":cargo_deps",
-    script = """
-# These disposable compiler checks need neither debugger information nor
-# incremental state. Cargo still reuses completed artifacts between commands.
-export CARGO_PROFILE_DEV_DEBUG=0
-export CARGO_INCREMENTAL=0
+    packages = subpackages(include = ["crates/*"]),
+    srcs = [":cargo_srcs"] + [
+        "//" + package + ":compiler_sources" for package in subpackages(include = ["crates/*"])
+    ] + glob(["crates/**/*.rs", "crates/**/Cargo.toml"], exclude = ["**/target/**"], allow_empty = True),
+)
 
-echo "::group::Cargo hack"
-cargo hack check --each-feature --exclude-features=codegen-docs --locked --offline
-echo "::endgroup::"
-""",
+py_binary(
+    name = "prepare_cargo_hack",
+    srcs = [".hacking/scripts/prepare_cargo_hack.py"],
+    main = ".hacking/scripts/prepare_cargo_hack.py",
+    tags = ["manual"],
 )
 
 # Exercise the benchmark once against a tiny, clean fixture in the test suite.
@@ -660,5 +656,16 @@ py_test(
         ".hacking/scripts/check_cargo_targets_test.py",
     ],
     main = ".hacking/scripts/check_cargo_targets_test.py",
+    imports = [".hacking/scripts"],
+)
+
+py_test(
+    name = "prepare_cargo_hack_test",
+    size = "small",
+    srcs = [
+        ".hacking/scripts/prepare_cargo_hack.py",
+        ".hacking/scripts/prepare_cargo_hack_test.py",
+    ],
+    main = ".hacking/scripts/prepare_cargo_hack_test.py",
     imports = [".hacking/scripts"],
 )

--- a/cargo_hack.bzl
+++ b/cargo_hack.bzl
@@ -1,0 +1,67 @@
+"""Package-level Cargo-hack checks with a checked, automatically discovered matrix."""
+
+load(":cargo_build.bzl", "cargo_test")
+
+def _inputs_impl(ctx):
+    trees = [ctx.actions.declare_directory(ctx.label.name + "/" + package) for package in ctx.attr.packages]
+    specification = ctx.actions.declare_file(ctx.label.name + ".json")
+    ctx.actions.write(specification, json.encode({
+        "sources": [file.path for file in ctx.files.srcs],
+        "packages": dict(zip(ctx.attr.packages, [tree.path for tree in trees])),
+    }))
+    rust = ctx.toolchains["@rules_rust//rust:toolchain_type"]
+    args = ctx.actions.args()
+    args.add_all([specification, rust.cargo, rust.rustc, ctx.file.hack])
+    ctx.actions.run(
+        executable = ctx.executable._prepare,
+        arguments = [args],
+        inputs = ctx.files.srcs + [specification],
+        tools = [rust.all_files, ctx.file.hack],
+        outputs = trees,
+        mnemonic = "CargoHackCoverage",
+        progress_message = "Checking Cargo-hack matrix and preparing package sources",
+    )
+    return [
+        DefaultInfo(files = depset(trees)),
+        OutputGroupInfo(**{package: depset([tree]) for package, tree in zip(ctx.attr.packages, trees)}),
+    ]
+
+_inputs = rule(
+    implementation = _inputs_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "packages": attr.string_list(),
+        "hack": attr.label(default = "@cargo_hack//:cargo-hack", allow_single_file = True),
+        "_prepare": attr.label(default = "//:prepare_cargo_hack", executable = True, cfg = "exec"),
+    },
+    toolchains = ["@rules_rust//rust:toolchain_type"],
+)
+
+def cargo_hack_packages(name, packages, srcs):
+    """Generate one real test per discovered package; the matrix lives in Cargo."""
+    inputs = name + "_inputs"
+    _inputs(name = inputs, packages = packages, srcs = srcs)
+    tests = []
+    for package in packages:
+        suffix = package.removeprefix("crates/")
+        source = name + "_sources_" + suffix
+        native.filegroup(name = source, srcs = [":" + inputs], output_group = package)
+        test = "cargo_hack_" + suffix
+        cargo_test(
+            name = test,
+            size = "large",
+            srcs = [":" + source],
+            vendor = ":cargo_deps",
+            python_venv = ":python_runtime",
+            tools = ["@cargo_hack//:cargo-hack"],
+            script = """
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_INCREMENTAL=0
+# Bound each independent Cargo invocation to avoid multiplying host concurrency.
+export CARGO_BUILD_JOBS=2
+cd %s/%s
+bash run_hack.sh
+""" % (inputs, package),
+        )
+        tests.append(":" + test)
+    native.test_suite(name = name, tests = tests)


### PR DESCRIPTION
Split the opaque workspace Cargo-hack test into ten independently cached package tests. Each test receives its package sources and transitive local dependencies, including optional and development dependencies. Unrelated source edits leave its inputs unchanged. Cargo compilation is limited to two jobs per package.

A guard compares the union of package command lists with the pinned Cargo-hack tool's workspace command list before producing test inputs. It rejects missing, extra or duplicate combinations and missing packages. The same checked commands generate the scripts executed by the tests. New features are discovered automatically; the existing `--each-feature --exclude-features=codegen-docs --locked --offline` policy is preserved. This covers the existing per-feature matrix, not a feature powerset.

Stacked on #3979; merge that PR first. This PR contains one commit.

Validation on macOS arm64:
- All ten package tests passed, covering the same 46 Cargo-hack combinations.
- Guard regression tests, Ruff and keep-sorted passed; final run reported 13 passing targets, including cached results.
- A temporary new feature expanded the matrix to 47 commands. Deliberately omitting no-default-feature checks or adding a Cargo-only package failed the guard. All probes were restored.
- A temporary `sqlinference` source edit reran only its package test: nine stayed cached, and the command finished in 14.8 seconds.

The initial split run took 95.8 seconds, roughly matching the previous 96.4-second monolithic test locally. The benefit is incremental caching; full runs duplicate dependency compilation and may cost more CPU. These are local observations, not a CI speedup claim. The full workspace suite was not rerun; Linux validation remains for CI.
