### PR TITLE
fix(sparksql): parse hint function contents (6437)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-cbcbe52676af6a45cd78f3fcfa704eb59f6e2db6
+fb1be11571a152b4cb1c9c589d9c7fdcc2f2cd39

--- a/crates/lib-dialects/src/sparksql.rs
+++ b/crates/lib-dialects/src/sparksql.rs
@@ -2473,25 +2473,9 @@ pub fn raw_dialect() -> Dialect {
             NodeMatcher::new(SyntaxKind::HintFunction, |_| {
                 Sequence::new(vec![
                     Ref::new("FunctionNameSegment").to_matchable(),
-                    Bracketed::new(vec![
-                        Delimited::new(vec![
-                            AnyNumberOf::new(vec![
-                                Ref::new("SingleIdentifierGrammar").to_matchable(),
-                                Ref::new("NumericLiteralSegment").to_matchable(),
-                                Ref::new("TableReferenceSegment").to_matchable(),
-                                Ref::new("ColumnReferenceSegment").to_matchable(),
-                            ])
-                            .config(|config| {
-                                config.min_times = 1;
-                            })
-                            .to_matchable(),
-                        ])
+                    Ref::new("FunctionContentsSegment")
+                        .optional()
                         .to_matchable(),
-                    ])
-                    .config(|config| {
-                        config.optional();
-                    })
-                    .to_matchable(),
                 ])
                 .to_matchable()
             })

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/insert_overwrite_directory.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/insert_overwrite_directory.yml
@@ -236,10 +236,12 @@ file:
               - hint_function:
                 - function_name:
                   - function_name_identifier: COALESCE
-                - bracketed:
-                  - start_bracket: (
-                  - numeric_literal: '1'
-                  - end_bracket: )
+                - function_contents:
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                      - numeric_literal: '1'
+                    - end_bracket: )
               - end_hint: '*/'
           - select_clause_element:
             - wildcard_expression:

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/select_hints.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/select_hints.yml
@@ -9,10 +9,12 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: COALESCE
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '3'
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '3'
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -43,10 +45,12 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '3'
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '3'
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -77,10 +81,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: c
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -111,12 +118,16 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '3'
-              - comma: ','
-              - naked_identifier: c
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '3'
+                - comma: ','
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -147,10 +158,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION_BY_RANGE
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: c
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -181,12 +195,16 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION_BY_RANGE
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '3'
-              - comma: ','
-              - naked_identifier: c
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '3'
+                - comma: ','
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -247,10 +265,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REBALANCE
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: c
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -281,28 +302,36 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '100'
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '100'
+                - end_bracket: )
           - comma: ','
           - hint_function:
             - function_name:
               - function_name_identifier: COALESCE
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '500'
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '500'
+                - end_bracket: )
           - comma: ','
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION_BY_RANGE
-            - bracketed:
-              - start_bracket: (
-              - numeric_literal: '3'
-              - comma: ','
-              - naked_identifier: c
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - numeric_literal: '3'
+                - comma: ','
+                - expression:
+                  - column_reference:
+                    - naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -333,10 +362,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: BROADCAST
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -393,10 +425,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: BROADCASTJOIN
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -453,10 +488,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: MAPJOIN
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t2
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t2
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -513,10 +551,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: SHUFFLE_MERGE
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -573,10 +614,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: MERGEJOIN
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t2
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t2
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -633,10 +677,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: MERGE
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -693,10 +740,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: SHUFFLE_HASH
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -753,10 +803,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: SHUFFLE_REPLICATE_NL
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -813,20 +866,28 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: BROADCAST
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - end_bracket: )
           - comma: ','
           - hint_function:
             - function_name:
               - function_name_identifier: MERGE
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - comma: ','
-              - naked_identifier: t2
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t1
+                - comma: ','
+                - expression:
+                  - column_reference:
+                    - naked_identifier: t2
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -883,13 +944,15 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: BROADCAST
-            - bracketed:
-              - start_bracket: (
-              - table_reference:
-                - naked_identifier: db
-                - dot: .
-                - naked_identifier: t1
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: db
+                    - dot: .
+                    - naked_identifier: t1
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:

--- a/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/select_sort_by.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/sparksql/sqlfluff/select_sort_by.yml
@@ -9,10 +9,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: zip_code
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: zip_code
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -76,10 +79,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: zip_code
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: zip_code
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -141,10 +147,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: zip_code
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: zip_code
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -212,10 +221,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: zip_code
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: zip_code
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -281,10 +293,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: zip_code
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: zip_code
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:
@@ -354,10 +369,13 @@ file:
           - hint_function:
             - function_name:
               - function_name_identifier: REPARTITION
-            - bracketed:
-              - start_bracket: (
-              - naked_identifier: zip_code
-              - end_bracket: )
+            - function_contents:
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                    - naked_identifier: zip_code
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
         - column_reference:

--- a/crates/lib/test/fixtures/rules/std_rule_cases/LT01-functions.yml
+++ b/crates/lib/test/fixtures/rules/std_rule_cases/LT01-functions.yml
@@ -26,3 +26,14 @@ test_pass_drop_function_go:
   configs:
     core:
       dialect: tsql
+
+test_pass_select_hint:
+  pass_str: |
+    select /*+ repartition(200) */
+        one,
+        two
+    from
+        mytable
+  configs:
+    core:
+      dialect: sparksql


### PR DESCRIPTION
## Summary
- advance the SQLFluff cursor from cbcbe52676af6a45cd78f3fcfa704eb59f6e2db6 to fb1be11571a152b4cb1c9c589d9c7fdcc2f2cd39
- reuse FunctionContentsSegment for SparkSQL hint functions so spacing is parsed consistently
- regenerate the affected SparkSQL parse fixtures and add the upstream LT01 regression case

## Validation
- exact first-parent cursor guard
- focused SparkSQL dialect fixture suite (127 files)
- LT01 rule fixture exercised through the Bazel workspace test
- cargo fmt --all -- --check
- git diff --check
- bazelisk test //... --test_output=errors (49/49 tests passed; three load-sensitive UI targets passed in isolation before the cached clean run)