### PR TITLE
perf: remove Cargo check covered by native Bazel compilation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -414,9 +414,8 @@ sh_test(
     },
 )
 
-# Cargo compiler checks share one writable target directory. Keeping these in a
-# single Bazel test lets Cargo reuse dependency artifacts between check
-# and the per-feature cargo-hack checks.
+# Cargo retains manifest/feature compatibility checks with a shared target
+# directory. Native compiler_check and clippy_check cover compilation/linting.
 cargo_test(
     name = "cargo_compile_checks",
     python_venv = ":python_runtime",
@@ -430,12 +429,8 @@ cargo_test(
 export CARGO_PROFILE_DEV_DEBUG=0
 export CARGO_INCREMENTAL=0
 
-echo "::group::Cargo check"
-cargo check --all --all-features --tests --benches --locked --offline
-echo "::endgroup::"
-
 echo "::group::Cargo hack"
-cargo hack check --each-feature --exclude-features=codegen-docs --offline
+cargo hack check --each-feature --exclude-features=codegen-docs --locked --offline
 echo "::endgroup::"
 """,
 )


### PR DESCRIPTION
Remove the all-features Cargo check now covered by the native compiler targets and coverage guard in #3990. Keep Cargo-hack for individual-feature compatibility checks and require `--locked --offline`.

This is the second half of the split compiler migration. It changes only the Cargo-check block in BUILD.bazel. The Python runtime-test migration is already merged through #3935.

Merge order: #3990 → this PR → #3972 (package-level Cargo-hack) → #3974 (Zed workspace migration).

Validation:
- The final source tree is identical to the previously validated compiler migration; the split only changes commit boundaries.
- Native compiler/Clippy checks and guard tests passed after rebasing onto main.
- The retained Cargo-hack command previously passed all 46 feature checks with `--locked --offline` on macOS arm64.
- Linux validation remains for CI.
