### PR TITLE
chore: add optimized SQLFluff port workflow

### DIFF
--- a/.claude/commands/next-sqlfluff-optimized.md
+++ b/.claude/commands/next-sqlfluff-optimized.md
@@ -1,0 +1,140 @@
+Port exactly one next SQLFluff commit using the checkpointed helper below. This
+is an alternative to `next-sqlfluff.md`; do not run both workflows in one turn.
+
+## Boundaries
+
+- At most one PR per invocation, extending the active stack in upstream
+  first-parent order. Stop after publishing, finding a duplicate, reaching
+  upstream main, or encountering a blocker. A background goal may start another
+  invocation on its next continuation.
+- Default to at most fifty open SQLFluff port PRs. Preserve explicit session/goal
+  overrides: use `--limit 0` only when the user has already removed that cap.
+- Preserve unrelated work, stashes, and lockfiles. Do not merge PRs or force-push.
+  Only one porting invocation may own this worktree at a time. If another goal is
+  using it, stop or use a separately authorized isolated checkout.
+- The scripts automate bookkeeping, not the assessment of Rust behavior or
+  fixtures. Keep all required Cargo and Bazel checks, including SHA-only ports.
+
+## 1. Preflight once
+
+Choose a unique checkpoint path outside the checkout, and retain its exact path
+in the goal's continuation summary. Invoke from the sqruff root:
+
+```bash
+python3 .hacking/scripts/sqlfluff_port.py preflight --state /private/tmp/sqlfluff-port-<run-id>.json
+```
+
+The helper checks the clean worktree, fetches refs, paginates open PRs, identifies
+the active stack tip (including older forks), verifies the first-parent watermark,
+finds the next commit, and checks exact duplicates in open and historical PRs.
+It fetches SQLFluff without changing its checkout. Its JSON result is the baseline
+for this invocation; do not repeat the same queries individually.
+
+- `ready`: continue using the returned `base_sha`, `base_branch`, `branch`,
+  `next_sha`, upstream PR, and merge chain.
+- `caught_up` or `duplicate`: report the result and stop.
+- Nonzero exit / `blocked`: resolve the stated issue without bypassing the check.
+  Unknown/divergent watermarks and tied tips require explicit reconciliation.
+
+On interruption, read the existing checkpoint rather than creating another one.
+Inspect the current worktree, then use `recheck --state <path>` when resuming a
+prepared port. If nothing relevant changed, reuse completed analysis and tests.
+For `publishing` or `pushed`, inspect remote branch and PR state before retrying:
+timeouts are ambiguous successes. For `published`, finish stack linking/audit and
+stop; never create another PR from that checkpoint.
+
+## 2. Inspect and implement
+
+Create the returned branch from the exact base SHA; never overwrite an existing
+branch. Read the subject and **first-parent diff**, including merge commits:
+
+```bash
+git switch -c <branch> <base_sha>
+git -C sqlfluff show -s --format=fuller <next_sha>
+git -C sqlfluff diff <next_sha>^1 <next_sha>
+```
+
+Port equivalent Rust behavior and tests, following actual repository layout:
+
+- SQLFluff dialects → `crates/lib-dialects/src/`.
+- Rules → `crates/lib/src/rules/`.
+- Core/parser/templaters → corresponding modules under `crates/lib-core/`.
+- Dialect fixtures →
+  `crates/lib-dialects/test/fixtures/dialects/<dialect>/sqlfluff/`.
+
+Read applicable repository instructions and upstream context as needed. Docs,
+release, CI, or Python-specific changes may justify a SHA-only port. Already
+present code is a no-op only if equivalent fixtures exist too. Record the reason.
+
+Use focused tests while developing. Review actual changed code and generated
+fixtures; do not regenerate unrelated fixtures. Write `.sqlfluff-sha` to the
+returned `next_sha` **before final validation**.
+
+## 3. Stage, validate, and commit
+
+Inspect the intended diff and stage explicit paths, including `.sqlfluff-sha`.
+Keep the summary Markdown outside the worktree. Do not use `git add .` to sweep
+unrelated files into a port.
+
+```bash
+python3 .hacking/scripts/sqlfluff_port.py verify --state <checkpoint-path>
+```
+
+This checks the branch, staged watermark, whitespace, and absence of unstaged or
+untracked files. It runs formatting checks, `cargo build`, `cargo test`, and
+`bazel test //...` once on the final tree and checkpoints results and timings.
+Output streams normally; use the returned process/session handle to wait for the
+same invocation. Do not restart tests merely because a tool yielded.
+
+After successful validation, commit exactly the staged port. Use the existing
+signing policy (including any user requirement for signed commits). Use a
+conventional title such as `fix(postgres): support optional SRID (6543)` and
+include the upstream SHA and PR/commit links in the commit body.
+
+Changing code, fixtures, the staged tree, or the integration base invalidates the
+result. Revalidate after such changes. A commit of the identical staged tree does
+not need another full test run. No extra post-SHA test is needed: the full suite
+already tested the updated SHA.
+
+## 4. Publish once
+
+Write a short Markdown summary file containing bullets explaining the port and
+decisions. Then invoke:
+
+```bash
+python3 .hacking/scripts/sqlfluff_port.py publish --state <checkpoint-path> --summary <summary-file>
+```
+
+The helper checks that the clean branch contains exactly one commit above the
+recorded base and matches the validated tree. It performs the one required fresh
+remote stack/capacity/duplicate check immediately before publishing, pushes
+without force, and creates the correctly based PR using `--body-file`. It adds
+base-PR links, upstream links, and the recorded test list automatically.
+
+Do not run another full remote audit immediately before calling `publish`; the
+helper does that. If it reports a changed base or an existing port, reconcile it
+and stop or prepare a new valid checkpoint. Never simply change the checkpoint's
+base/SHA/test fields to make stale work pass.
+
+Remote publication is not atomic across machines. On a failed/ambiguous request,
+inspect remote state before retrying. The helper records its phase and will not
+create a duplicate PR it can find. Do not repeatedly retry unresolved failures.
+
+## 5. Link, audit, and stop
+
+Append the returned PR to the existing GitHub stack with
+`gh stack link <stack-number> <new-pr-number>`. If no stack exists, link the
+returned merge chain bottom-to-top. Verify once with `gh stack view` and a compact
+PR inspection confirming its head SHA, base branch, and diff. Check the current
+remote tip to detect a concurrent publisher; report any fork and stop further
+writes. Record signature verification when required by the user's signing policy.
+
+Do not routinely `unstack --local`, check out the whole stack, or recreate its
+metadata after a successful link. Those are recovery operations for demonstrated
+metadata problems. If linking fails, the correctly based PR remains valid; record
+the outstanding UI repair instead of recreating the PR.
+
+Report the new PR, base, merge order, upstream watermark, tests, and decisions.
+Keep a compact continuation checkpoint: state-file path, PR/branch/SHA, stack ID,
+completed verification, and any unfinished operation. Do not repeat resolved
+historical-fork analysis unless relevant refs change. Stop this invocation.

--- a/.hacking/scripts/sqlfluff_port.py
+++ b/.hacking/scripts/sqlfluff_port.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Small, checkpointed helpers for next-sqlfluff-optimized.md (stdlib only)."""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO = "quarylabs/sqruff"
+UPSTREAM = "https://github.com/sqlfluff/sqlfluff"
+
+
+class PortError(Exception):
+    pass
+
+
+def run(*args, cwd=None, timeout=120):
+    """No shell interpolation; never automatically retry a remote mutation."""
+    try:
+        result = subprocess.run(
+            args, cwd=cwd, text=True, capture_output=True, timeout=timeout, check=False
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise PortError(
+            f"Timed out after {timeout}s: {args[0:3]}. "
+            "A remote write may have succeeded; inspect remote state before retrying."
+        ) from exc
+    if result.returncode:
+        raise PortError(f"Command failed: {args[0:3]}\n{result.stderr[-4000:]}")
+    return result.stdout.strip()
+
+
+def git(root, *args):
+    return run("git", *args, cwd=root)
+
+
+def save(path, state):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, delete=False) as out:
+        json.dump(state, out, indent=2)
+        out.write("\n")
+        temporary = Path(out.name)
+    temporary.replace(path)
+
+
+def pages(endpoint):
+    return json.loads(run("gh", "api", "--paginate", "--slurp", endpoint))
+
+
+def open_ports():
+    prs = [
+        pr
+        for page in pages(f"repos/{REPO}/pulls?state=open&per_page=100")
+        for pr in page
+    ]
+    return [
+        pr
+        for pr in prs
+        if pr["head"]["ref"].startswith("port/sqlfluff-")
+        or re.search(
+            r"sqlfluff", pr["title"] + "\n" + (pr.get("body") or ""), re.IGNORECASE
+        )
+    ]
+
+
+def select_tip(prs, cursor, history):
+    """Select only a tip on upstream first-parent history; reject tied forks."""
+    if not prs:
+        return None
+    bases = {pr["base"]["ref"] for pr in prs}
+    tips = [pr for pr in prs if pr["head"]["ref"] not in bases]
+    if not tips:
+        raise PortError("Port PR graph has no tip; reconcile the stack.")
+    ranked = []
+    for pr in tips:
+        sha = cursor(pr)
+        if sha not in history:
+            raise PortError(
+                f"PR #{pr['number']} watermark is not on upstream first-parent history."
+            )
+        ranked.append((history[sha], pr))
+    ranked.sort(key=lambda item: item[0])  # newest-first history
+    if len(ranked) > 1 and ranked[0][0] == ranked[1][0]:
+        raise PortError(
+            "Multiple stack tips have the same upstream watermark; reconcile them."
+        )
+    return ranked[0][1]
+
+
+def exact_port(pr, state):
+    head = pr.get("head", {}).get("ref", pr.get("headRefName", ""))
+    text = pr.get("title", "") + "\n" + (pr.get("body") or "")
+    if head == state["branch"] or re.search(
+        rf"(?<![0-9a-f]){state['next_sha']}(?![0-9a-f])", text
+    ):
+        return True
+    number = state["upstream_pr"]
+    return bool(
+        number
+        and (
+            re.search(rf"github\.com/sqlfluff/sqlfluff/pull/{number}(?!\d)", text)
+            or re.search(rf"\(#{number}\)|\({number}\)", pr.get("title", ""))
+        )
+    )
+
+
+def duplicates(state):
+    queries = [state["next_sha"]]
+    if state["upstream_pr"]:
+        queries.append(str(state["upstream_pr"]))
+
+    def search(query):
+        # Search has a 1000-result ceiling; never treat truncated results as complete.
+        from urllib.parse import urlencode
+
+        endpoint = "search/issues?" + urlencode(
+            {"q": f"repo:{REPO} is:pr {query} in:title,body", "per_page": 100}
+        )
+        result = pages(endpoint)
+        if any(p.get("incomplete_results") or p["total_count"] > 1000 for p in result):
+            raise PortError("Duplicate search incomplete; resolve before proceeding.")
+        return [pr for page in result for pr in page["items"]]
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        found = [pr for result in pool.map(search, queries) for pr in result]
+    found.extend(
+        pr
+        for page in pages(
+            f"repos/{REPO}/pulls?state=all&head=quarylabs:{state['branch']}&per_page=100"
+        )
+        for pr in page
+    )
+    return sorted({pr["html_url"] for pr in found if exact_port(pr, state)})
+
+
+def snapshot(root, limit):
+    git(root, "fetch", "origin", "--prune")
+    prs = open_ports()
+    if limit and len(prs) >= limit:
+        raise PortError(f"Capacity exhausted: {len(prs)} open ports, limit {limit}.")
+    upstream = root / "sqlfluff"
+    if not upstream.exists():
+        run("git", "clone", f"{UPSTREAM}.git", str(upstream), timeout=300)
+    git(upstream, "fetch", "origin", "main")
+    upstream_tip = git(upstream, "rev-parse", "origin/main")
+    commits = git(upstream, "rev-list", "--first-parent", upstream_tip).splitlines()
+    history = {sha: index for index, sha in enumerate(commits)}
+    tip = select_tip(
+        prs, lambda pr: git(root, "show", f"{pr['head']['sha']}:.sqlfluff-sha"), history
+    )
+    base_branch = tip["head"]["ref"] if tip else "main"
+    base_sha = tip["head"]["sha"] if tip else git(root, "rev-parse", "origin/main")
+    if git(root, "rev-parse", f"origin/{base_branch}") != base_sha:
+        raise PortError("PR listing and fetched branch disagree; rerun preflight.")
+    cursor = git(root, "show", f"{base_sha}:.sqlfluff-sha")
+    if cursor not in history:
+        raise PortError("Selected watermark is not on upstream first-parent history.")
+    index = history[cursor]
+    next_sha = commits[index - 1] if index else None
+    chain = []
+    node = tip
+    heads = {pr["head"]["ref"]: pr for pr in prs}
+    seen = set()
+    while node:
+        if node["number"] in seen:
+            raise PortError("Cycle in port PR stack.")
+        seen.add(node["number"])
+        chain.append(node["number"])
+        node = heads.get(node["base"]["ref"])
+    return {
+        "root": str(root),
+        "limit": limit,
+        "base_branch": base_branch,
+        "base_sha": base_sha,
+        "base_pr": tip["number"] if tip else None,
+        "cursor": cursor,
+        "next_sha": next_sha,
+        "upstream_tip": upstream_tip,
+        "remaining": index,
+        "open_ports": len(prs),
+        "chain": chain[::-1],
+        "other_ports": sorted(pr["number"] for pr in prs if pr["number"] not in seen),
+    }
+
+
+def preflight(args):
+    root = Path(git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    if git(root, "status", "--porcelain"):
+        raise PortError("Worktree is dirty; preserve it and stop.")
+    if Path(args.state).exists():
+        raise PortError("Checkpoint exists. Inspect/resume it or choose a new path.")
+    state = snapshot(root, args.limit)
+    state["status"] = "caught_up"
+    if state["next_sha"]:
+        subject = git(root / "sqlfluff", "show", "-s", "--format=%s", state["next_sha"])
+        match = re.search(r"\(#(\d+)\)", subject)
+        number = int(match[1]) if match else None
+        state.update(
+            subject=subject,
+            upstream_pr=number,
+            branch=f"port/sqlfluff-{number or state['next_sha'][:12]}",
+        )
+        state["duplicates"] = duplicates(state)
+        state["status"] = "duplicate" if state["duplicates"] else "ready"
+    save(args.state, state)
+    return state
+
+
+def recheck(state):
+    fresh = snapshot(Path(state["root"]), state["limit"])
+    found = duplicates(state)
+    if found:
+        raise PortError(
+            f"Exact port already exists: {found}. Do not create another PR."
+        )
+    for key in ("base_sha", "base_branch", "cursor", "next_sha"):
+        if fresh[key] != state[key]:
+            raise PortError(
+                f"Stack changed ({key}); reconcile/rebase and revalidate before publication."
+            )
+    return fresh
+
+
+def staged_tree(state):
+    root = Path(state["root"])
+    if git(root, "branch", "--show-current") != state["branch"]:
+        raise PortError("Not on the planned port branch.")
+    if git(root, "diff") or git(root, "ls-files", "--others", "--exclude-standard"):
+        raise PortError(
+            "Stage the exact intended files; unstaged/untracked work exists."
+        )
+    if git(root, "show", ":.sqlfluff-sha") != state["next_sha"]:
+        raise PortError("Staged watermark does not match the planned next commit.")
+    git(root, "diff", "--cached", "--check")
+    return git(root, "write-tree")
+
+
+def verify(args, state):
+    tree = staged_tree(state)
+    root = Path(state["root"])
+    state.pop("validated_tree", None)
+    state["status"] = "testing"
+    state["tests"] = []
+    save(args.state, state)
+    for command in [
+        ["cargo", "fmt", "--all", "--", "--check"],
+        ["cargo", "build"],
+        ["cargo", "test"],
+        ["bazel", "test", "//..."],
+    ]:
+        start = time.monotonic()
+        print("Running " + " ".join(command), file=sys.stderr, flush=True)
+        # Stream output to stderr; stdout remains one compact machine-readable result.
+        result = subprocess.run(
+            command, cwd=root, stdout=sys.stderr, stderr=sys.stderr, check=False
+        )
+        state["tests"].append(
+            {
+                "command": command,
+                "seconds": round(time.monotonic() - start, 2),
+                "exit_code": result.returncode,
+            }
+        )
+        save(args.state, state)
+        if result.returncode:
+            raise PortError("Validation failed; fix the failure and rerun verify.")
+    if staged_tree(state) != tree:
+        raise PortError("Tree changed during validation; rerun verify.")
+    state.update(validated_tree=tree, status="validated")
+    save(args.state, state)
+    return {"status": state["status"], "tree": tree, "tests": state["tests"]}
+
+
+def publish(args, state):
+    root = Path(state["root"])
+    if git(root, "status", "--porcelain"):
+        raise PortError(
+            "Commit the validated changes before publishing; worktree must be clean."
+        )
+    if staged_tree(state) != state.get("validated_tree"):
+        raise PortError("Current tree was not validated.")
+    if git(root, "rev-list", "--parents", "-n", "1", "HEAD").split()[1:] != [
+        state["base_sha"]
+    ]:
+        raise PortError("Expected exactly one commit directly above the recorded base.")
+    # Read body as data, never as shell code. Freeze it before performing remote writes.
+    summary = Path(args.summary).read_text().strip()
+    if not summary:
+        raise PortError("Summary file is empty.")
+    title = git(root, "show", "-s", "--format=%s", "HEAD")
+    head = git(root, "rev-parse", "HEAD")
+    fresh = recheck(state)
+    remote = git(
+        root, "ls-remote", "--heads", "origin", f"refs/heads/{state['branch']}"
+    )
+    if remote and not (
+        remote.split()[0] == head
+        and state.get("commit") == head
+        and state["status"] in ("publishing", "pushed")
+    ):
+        raise PortError(
+            "Remote branch already exists outside this checkpoint; reconcile it."
+        )
+    state["chain"] = fresh["chain"]
+    state.update(status="publishing", commit=head)
+    save(args.state, state)
+    prefix = ""
+    if state["base_pr"]:
+        number = state["base_pr"]
+        prefix = f"> Stacked on sqruff #{number}. Merge #{number} first.\n> https://github.com/{REPO}/pull/{number}\n\n"
+    body = (
+        prefix
+        + "## Summary\n"
+        + summary
+        + f"\n\nPorted from SQLFluff {state['next_sha']}\n"
+    )
+    if state["upstream_pr"]:
+        body += f"{UPSTREAM}/pull/{state['upstream_pr']}\n"
+    body += f"{UPSTREAM}/commit/{state['next_sha']}\n\n## Validation\n"
+    body += (
+        "\n".join("- `" + " ".join(test["command"]) + "`" for test in state["tests"])
+        + "\n"
+    )
+    state["body_sha256"] = hashlib.sha256(body.encode()).hexdigest()
+    save(args.state, state)
+    run("git", "push", "-u", "origin", state["branch"], cwd=root)
+    state["status"] = "pushed"
+    save(args.state, state)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md") as file:
+        file.write(body)
+        file.flush()
+        url = run(
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            REPO,
+            "--base",
+            state["base_branch"],
+            "--head",
+            state["branch"],
+            "--title",
+            title,
+            "--body-file",
+            file.name,
+            cwd=root,
+        )
+    state.update(status="published", pr_url=url)
+    save(args.state, state)
+    return {
+        "status": "published",
+        "pr_url": url,
+        "base_pr": state["base_pr"],
+        "chain": state["chain"] + [int(url.rsplit("/", 1)[1])],
+        "next_step": "Link and verify GitHub stack UI once; do not recreate this PR.",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("preflight", "recheck", "verify", "publish"):
+        command = sub.add_parser(name)
+        command.add_argument(
+            "--state", required=True, help="Checkpoint path outside the worktree"
+        )
+        if name == "preflight":
+            command.add_argument(
+                "--limit",
+                type=int,
+                default=50,
+                help="Open-port limit; 0 only for an existing explicit user override",
+            )
+        if name == "publish":
+            command.add_argument(
+                "--summary", required=True, help="Markdown summary file"
+            )
+    args = parser.parse_args()
+    try:
+        root = Path(git(Path.cwd(), "rev-parse", "--show-toplevel")).resolve()
+        if Path(args.state).resolve().is_relative_to(root):
+            raise PortError(
+                "Keep the checkpoint outside the worktree (for example /private/tmp)."
+            )
+        if args.command == "preflight":
+            if args.limit < 0:
+                raise PortError("Limit must be nonnegative.")
+            result = preflight(args)
+        else:
+            state = json.loads(Path(args.state).read_text())
+            if Path(state["root"]).resolve() != root:
+                raise PortError("Checkpoint belongs to a different worktree.")
+            if state.get("status") in ("caught_up", "duplicate", "published"):
+                raise PortError(
+                    f"Checkpoint is {state['status']}; do not publish another port."
+                )
+            if args.command == "recheck":
+                fresh = recheck(state)
+                result = {
+                    "status": "unchanged",
+                    "base_sha": fresh["base_sha"],
+                    "open_ports": fresh["open_ports"],
+                }
+            else:
+                result = globals()[args.command](args, state)
+        print(json.dumps(result, indent=2))
+    except (PortError, OSError, ValueError, KeyError) as exc:
+        print(json.dumps({"status": "blocked", "reason": str(exc)}), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.hacking/scripts/sqlfluff_port_test.py
+++ b/.hacking/scripts/sqlfluff_port_test.py
@@ -1,0 +1,276 @@
+"""Offline regression tests: real temporary Git repos, mocked network/build tools."""
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location(
+    "sqlfluff_port", Path(__file__).with_name("sqlfluff_port.py")
+)
+port = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(port)
+
+
+def pr(number, head, base="main", body="", title="SQLFluff port"):
+    return {
+        "number": number,
+        "head": {"ref": head},
+        "base": {"ref": base},
+        "body": body,
+        "title": title,
+        "html_url": f"https://github.com/quarylabs/sqruff/pull/{number}",
+    }
+
+
+class GraphTests(unittest.TestCase):
+    def test_selects_tip_not_parent_and_prefers_advanced_fork(self):
+        prs = [pr(1, "a"), pr(2, "b", "a"), pr(3, "old")]
+        cursors = {2: "new", 3: "old"}
+        self.assertEqual(
+            port.select_tip(prs, lambda p: cursors[p["number"]], {"new": 0, "old": 5})[
+                "number"
+            ],
+            2,
+        )
+
+    def test_tied_and_unknown_watermarks_fail_closed(self):
+        prs = [pr(1, "a"), pr(2, "b")]
+        for history in [{"same": 0}, {}]:
+            with self.assertRaises(port.PortError):
+                port.select_tip(prs, lambda _: "same", history)
+
+    def test_cycle_fails_closed(self):
+        with self.assertRaises(port.PortError):
+            port.select_tip(
+                [pr(1, "a", "b"), pr(2, "b", "a")], lambda _: "sha", {"sha": 0}
+            )
+
+    def test_duplicate_identity_not_numeric_prefix(self):
+        state = {
+            "branch": "port/sqlfluff-123",
+            "next_sha": "a" * 40,
+            "upstream_pr": 123,
+        }
+        self.assertTrue(
+            port.exact_port(
+                pr(1, "x", body="https://github.com/sqlfluff/sqlfluff/pull/123"), state
+            )
+        )
+        self.assertFalse(
+            port.exact_port(
+                pr(1, "x", body="https://github.com/sqlfluff/sqlfluff/pull/1234"), state
+            )
+        )
+        self.assertTrue(port.exact_port(pr(1, "port/sqlfluff-123"), state))
+        self.assertFalse(
+            port.exact_port(pr(1, "x", title="Unrelated issue 123"), state)
+        )
+
+    def test_open_ports_includes_all_pages_and_body_identification(self):
+        with patch.object(
+            port,
+            "pages",
+            return_value=[
+                [pr(1, "port/sqlfluff-1")],
+                [pr(2, "legacy", body="Ported from SQLFluff")],
+                [pr(3, "other", title="Unrelated")],
+            ],
+        ):
+            self.assertEqual([p["number"] for p in port.open_ports()], [1, 2])
+
+    def test_incomplete_duplicate_search_fails_closed(self):
+        state = {
+            "branch": "port/sqlfluff-123",
+            "next_sha": "a" * 40,
+            "upstream_pr": None,
+        }
+        with (
+            patch.object(
+                port, "pages", return_value=[{"total_count": 1001, "items": []}]
+            ),
+            self.assertRaises(port.PortError),
+        ):
+            port.duplicates(state)
+
+    def test_changed_remote_base_prevents_publication(self):
+        state = {
+            "root": "/tmp",
+            "limit": 50,
+            "base_sha": "old",
+            "base_branch": "branch",
+            "cursor": "cursor",
+            "next_sha": "next",
+        }
+        with (
+            patch.object(port, "snapshot", return_value={**state, "base_sha": "new"}),
+            patch.object(port, "duplicates", return_value=[]),
+            self.assertRaisesRegex(port.PortError, "Stack changed"),
+        ):
+            port.recheck(state)
+
+
+class WorkflowTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name) / "repo"
+        self.root.mkdir()
+        self.checkpoint = Path(self.temporary.name) / "state.json"
+        self.summary = Path(self.temporary.name) / "summary.md"
+        port.git(self.root, "init", "-q")
+        port.git(self.root, "config", "user.email", "test@example.invalid")
+        port.git(self.root, "config", "user.name", "Test")
+        port.git(self.root, "config", "commit.gpgsign", "false")
+        (self.root / ".sqlfluff-sha").write_text("a" * 40 + "\n")
+        port.git(self.root, "add", ".sqlfluff-sha")
+        port.git(self.root, "commit", "-qm", "base")
+        self.base = port.git(self.root, "rev-parse", "HEAD")
+        port.git(self.root, "switch", "-qc", "port/sqlfluff-123")
+        (self.root / ".sqlfluff-sha").write_text("b" * 40 + "\n")
+        port.git(self.root, "add", ".sqlfluff-sha")
+        self.state = {
+            "root": str(self.root),
+            "branch": "port/sqlfluff-123",
+            "next_sha": "b" * 40,
+            "base_sha": self.base,
+            "base_branch": "main",
+            "base_pr": None,
+            "limit": 50,
+            "upstream_pr": 123,
+            "chain": [],
+            "status": "ready",
+        }
+        self.args = argparse.Namespace(
+            state=str(self.checkpoint), summary=str(self.summary)
+        )
+        self.summary.write_text("- Literal `cargo test` and $(do-not-execute)\n")
+        self.real_run = subprocess.run
+
+    def builds(self, fail=None):
+        def execute(command, **kwargs):
+            if command[0] in ("cargo", "bazel"):
+                return subprocess.CompletedProcess(command, 1 if command == fail else 0)
+            return self.real_run(command, **kwargs)
+
+        return patch.object(port.subprocess, "run", side_effect=execute)
+
+    def validated_commit(self):
+        with self.builds():
+            port.verify(self.args, self.state)
+        port.git(self.root, "commit", "-qm", "chore: record upstream (123)")
+
+    def test_success_records_all_checks_and_matches_committed_tree(self):
+        self.validated_commit()
+        saved = json.loads(self.checkpoint.read_text())
+        self.assertEqual(
+            saved["validated_tree"], port.git(self.root, "rev-parse", "HEAD^{tree}")
+        )
+        self.assertEqual(
+            [t["command"] for t in saved["tests"]],
+            [
+                ["cargo", "fmt", "--all", "--", "--check"],
+                ["cargo", "build"],
+                ["cargo", "test"],
+                ["bazel", "test", "//..."],
+            ],
+        )
+
+    def test_failed_test_invalidates_previous_validation(self):
+        self.state["validated_tree"] = "stale"
+        with self.builds(["cargo", "test"]), self.assertRaises(port.PortError):
+            port.verify(self.args, self.state)
+        saved = json.loads(self.checkpoint.read_text())
+        self.assertNotIn("validated_tree", saved)
+        self.assertEqual(saved["tests"][-1]["exit_code"], 1)
+
+    def test_untracked_work_refused(self):
+        (self.root / "unrelated.txt").write_text("preserve me")
+        with self.assertRaises(port.PortError):
+            port.staged_tree(self.state)
+
+    def test_changed_tree_cannot_publish(self):
+        self.validated_commit()
+        (self.root / "extra").write_text("not tested")
+        port.git(self.root, "add", "extra")
+        port.git(self.root, "commit", "--amend", "--no-edit", "-q")
+        with (
+            patch.object(port, "recheck") as check,
+            self.assertRaisesRegex(port.PortError, "not validated"),
+        ):
+            port.publish(self.args, self.state)
+        check.assert_not_called()
+
+    def test_publish_uses_literal_body_file_and_checkpoints_success(self):
+        self.validated_commit()
+        calls = []
+        real = port.run
+
+        def execute(*args, **kwargs):
+            if args[:2] == ("git", "ls-remote"):
+                return ""
+            if args[:2] == ("git", "push"):
+                calls.append("push")
+                return ""
+            if args[:3] == ("gh", "pr", "create"):
+                calls.append("create")
+                body = Path(args[args.index("--body-file") + 1]).read_text()
+                self.assertIn("`cargo test` and $(do-not-execute)", body)
+                return "https://github.com/quarylabs/sqruff/pull/42"
+            return real(*args, **kwargs)
+
+        with (
+            patch.object(port, "recheck", return_value={"chain": []}),
+            patch.object(port, "run", side_effect=execute),
+        ):
+            result = port.publish(self.args, self.state)
+        self.assertEqual(calls, ["push", "create"])
+        self.assertEqual(result["chain"], [42])
+        self.assertEqual(json.loads(self.checkpoint.read_text())["status"], "published")
+
+    def test_existing_remote_branch_is_not_overwritten(self):
+        self.validated_commit()
+        real = port.run
+
+        def execute(*args, **kwargs):
+            if args[:2] == ("git", "ls-remote"):
+                return "c" * 40 + "\trefs/heads/port/sqlfluff-123"
+            if args[:2] == ("git", "push"):
+                self.fail("Must not push over an existing branch")
+            return real(*args, **kwargs)
+
+        with (
+            patch.object(port, "recheck", return_value={"chain": []}),
+            patch.object(port, "run", side_effect=execute),
+            self.assertRaisesRegex(port.PortError, "Remote branch already exists"),
+        ):
+            port.publish(self.args, self.state)
+
+    def test_ambiguous_create_failure_preserves_pushed_checkpoint(self):
+        self.validated_commit()
+        real = port.run
+
+        def execute(*args, **kwargs):
+            if args[:2] in [("git", "ls-remote"), ("git", "push")]:
+                return ""
+            if args[:3] == ("gh", "pr", "create"):
+                raise port.PortError("Timed out; remote may have succeeded")
+            return real(*args, **kwargs)
+
+        with (
+            patch.object(port, "recheck", return_value={"chain": []}),
+            patch.object(port, "run", side_effect=execute),
+            self.assertRaises(port.PortError),
+        ):
+            port.publish(self.args, self.state)
+        saved = json.loads(self.checkpoint.read_text())
+        self.assertEqual(saved["status"], "pushed")
+        self.assertEqual(saved["commit"], port.git(self.root, "rev-parse", "HEAD"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Sequential SQLFluff ports repeatedly rediscover the stack, rerun administrative checks, and reconstruct publication commands. Add `next-sqlfluff-optimized.md` as an opt-in alternative that calls checkpointed Python helpers for preflight, validation, and publication, while retaining the original command.

The helper checks the complete open-PR listing and exact upstream duplicates, records the selected base and next first-parent commit, and publishes only one tested commit above that unchanged base. It validates the updated watermark with the final staged tree and uses a PR body file so Markdown cannot execute shell commands. Checkpoints retain test results and publication state for recovery after interruption.

The workflow preserves Cargo/Bazel validation, the default open-port cap and explicit user overrides, and ordered PR stacking. Stack UI linking remains an explicit final step.

## Validation

- 14 offline regression tests using temporary Git repositories and mocked build/network commands.
- Ruff lint and formatting checks for both Python files.
- Prettier check for the new command.
- `git diff --check`.

Live pushes, PR creation, and full Cargo/Bazel builds are not exercised by the regression tests. The implementation makes no changes to the original port command or Rust code.
