### PR TITLE
feat(mysql): support EVENT statements (6646)

### DIFF
--- a/.sqlfluff-sha
+++ b/.sqlfluff-sha
@@ -1,1 +1,1 @@
-b50ebd1eaec32d5f3b91dfe50877e119c0fdbda6
+e230b7c7a2fdbd752fc3d191e47a87db6807ddd1

--- a/crates/lib-dialects/src/mysql.rs
+++ b/crates/lib-dialects/src/mysql.rs
@@ -1145,8 +1145,15 @@ pub fn raw_dialect() -> Dialect {
         "IntervalExpressionSegment",
         Sequence::new(vec![
             Ref::keyword("INTERVAL").to_matchable(),
-            Ref::new("ExpressionSegment").to_matchable(),
-            Ref::new("DatetimeUnitSegment").to_matchable(),
+            one_of(vec![
+                Ref::new("DatetimeUnitSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::new("ExpressionSegment").to_matchable(),
+                    Ref::new("DatetimeUnitSegment").to_matchable(),
+                ])
+                .to_matchable(),
+            ])
+            .to_matchable(),
         ])
         .to_matchable(),
     );
@@ -3637,6 +3644,169 @@ pub fn raw_dialect() -> Dialect {
         .into(),
     )]);
 
+    // CREATE EVENT statement.
+    // https://dev.mysql.com/doc/refman/9.2/en/create-event.html
+    mysql.add([(
+        "CreateEventStatementSegment".into(),
+        NodeMatcher::new(SyntaxKind::CreateEventStatement, |_| {
+            Sequence::new(vec![
+                Ref::keyword("CREATE").to_matchable(),
+                Ref::new("DefinerSegment").optional().to_matchable(),
+                Ref::keyword("EVENT").to_matchable(),
+                Ref::new("IfNotExistsGrammar").optional().to_matchable(),
+                Ref::new("ObjectReferenceSegment").to_matchable(),
+                Ref::keyword("ON").to_matchable(),
+                Ref::keyword("SCHEDULE").to_matchable(),
+                one_of(vec![
+                    Ref::keyword("AT").to_matchable(),
+                    Ref::keyword("EVERY").to_matchable(),
+                ])
+                .to_matchable(),
+                Ref::new("ExpressionSegment").to_matchable(),
+                Ref::new("DatetimeUnitSegment").optional().to_matchable(),
+                AnyNumberOf::new(vec![
+                    Sequence::new(vec![
+                        one_of(vec![
+                            Ref::keyword("STARTS").to_matchable(),
+                            Ref::keyword("ENDS").to_matchable(),
+                        ])
+                        .to_matchable(),
+                        Ref::new("ExpressionSegment").to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("COMPLETION").to_matchable(),
+                    Ref::keyword("NOT").optional().to_matchable(),
+                    Ref::keyword("PRESERVE").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                one_of(vec![
+                    Ref::keyword("ENABLE").to_matchable(),
+                    Ref::keyword("DISABLE").to_matchable(),
+                    Sequence::new(vec![
+                        Ref::keyword("DISABLE").to_matchable(),
+                        Ref::keyword("ON").to_matchable(),
+                        one_of(vec![
+                            Ref::keyword("REPLICA").to_matchable(),
+                            Ref::keyword("SLAVE").to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Ref::new("CommentClauseSegment").optional().to_matchable(),
+                Ref::keyword("DO").to_matchable(),
+                Ref::new("StatementSegment").to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    // ALTER EVENT statement.
+    // https://dev.mysql.com/doc/refman/9.2/en/alter-event.html
+    mysql.add([(
+        "AlterEventStatementSegment".into(),
+        NodeMatcher::new(SyntaxKind::AlterEventStatement, |_| {
+            Sequence::new(vec![
+                Ref::keyword("ALTER").to_matchable(),
+                Ref::new("DefinerSegment").optional().to_matchable(),
+                Ref::keyword("EVENT").to_matchable(),
+                Ref::new("ObjectReferenceSegment").to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("SCHEDULE").to_matchable(),
+                    one_of(vec![
+                        Ref::keyword("AT").to_matchable(),
+                        Ref::keyword("EVERY").to_matchable(),
+                    ])
+                    .to_matchable(),
+                    Ref::new("ExpressionSegment").to_matchable(),
+                    Ref::new("DatetimeUnitSegment").optional().to_matchable(),
+                    AnyNumberOf::new(vec![
+                        Sequence::new(vec![
+                            one_of(vec![
+                                Ref::keyword("STARTS").to_matchable(),
+                                Ref::keyword("ENDS").to_matchable(),
+                            ])
+                            .to_matchable(),
+                            Ref::new("ExpressionSegment").to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("ON").to_matchable(),
+                    Ref::keyword("COMPLETION").to_matchable(),
+                    Ref::keyword("NOT").optional().to_matchable(),
+                    Ref::keyword("PRESERVE").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("RENAME").to_matchable(),
+                    Ref::keyword("TO").to_matchable(),
+                    Ref::new("ObjectReferenceSegment").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                one_of(vec![
+                    Ref::keyword("ENABLE").to_matchable(),
+                    Ref::keyword("DISABLE").to_matchable(),
+                    Sequence::new(vec![
+                        Ref::keyword("DISABLE").to_matchable(),
+                        Ref::keyword("ON").to_matchable(),
+                        one_of(vec![
+                            Ref::keyword("REPLICA").to_matchable(),
+                            Ref::keyword("SLAVE").to_matchable(),
+                        ])
+                        .to_matchable(),
+                    ])
+                    .to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+                Ref::new("CommentClauseSegment").optional().to_matchable(),
+                Sequence::new(vec![
+                    Ref::keyword("DO").to_matchable(),
+                    Ref::new("StatementSegment").to_matchable(),
+                ])
+                .config(|this| this.optional())
+                .to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
+    // DROP EVENT statement.
+    // https://dev.mysql.com/doc/refman/9.2/en/drop-event.html
+    mysql.add([(
+        "DropEventStatementSegment".into(),
+        NodeMatcher::new(SyntaxKind::DropEventStatement, |_| {
+            Sequence::new(vec![
+                Ref::keyword("DROP").to_matchable(),
+                Ref::keyword("EVENT").to_matchable(),
+                Ref::new("IfExistsGrammar").optional().to_matchable(),
+                Ref::new("ObjectReferenceSegment").to_matchable(),
+            ])
+            .to_matchable()
+        })
+        .to_matchable()
+        .into(),
+    )]);
+
     // StatementSegment - override to add MySQL-specific statements
     // ============================================================
 
@@ -3683,6 +3853,9 @@ pub fn raw_dialect() -> Dialect {
                 Ref::new("AlterDatabaseStatementSegment").to_matchable(),
                 Ref::new("ReturnStatementSegment").to_matchable(),
                 Ref::new("SetNamesStatementSegment").to_matchable(),
+                Ref::new("CreateEventStatementSegment").to_matchable(),
+                Ref::new("AlterEventStatementSegment").to_matchable(),
+                Ref::new("DropEventStatementSegment").to_matchable(),
             ]),
             None,
             None,

--- a/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/alter_event.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/alter_event.sql
@@ -1,0 +1,23 @@
+ALTER EVENT no_such_event
+    ON SCHEDULE
+        EVERY '2:3' DAY_HOUR;
+
+ALTER EVENT myevent
+    ON SCHEDULE
+      EVERY 12 HOUR
+    STARTS CURRENT_TIMESTAMP + INTERVAL 4 HOUR;
+
+ALTER EVENT myevent
+    ON SCHEDULE
+      AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+    DO
+      TRUNCATE TABLE myschema.mytable;
+
+ALTER EVENT myevent
+    DISABLE;
+
+ALTER EVENT myevent
+    RENAME TO yourevent;
+
+ALTER EVENT olddb.myevent
+    RENAME TO newdb.myevent;

--- a/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/alter_event.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/alter_event.yml
@@ -1,0 +1,97 @@
+file:
+- statement:
+  - alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: no_such_event
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+      - quoted_literal: '''2:3'''
+    - date_part: DAY_HOUR
+- statement_terminator: ;
+- statement:
+  - alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: myevent
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+      - numeric_literal: '12'
+    - date_part: HOUR
+    - keyword: STARTS
+    - expression:
+      - bare_function: CURRENT_TIMESTAMP
+      - binary_operator: +
+      - interval_expression:
+        - keyword: INTERVAL
+        - expression:
+          - numeric_literal: '4'
+        - date_part: HOUR
+- statement_terminator: ;
+- statement:
+  - alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: myevent
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+      - bare_function: CURRENT_TIMESTAMP
+      - binary_operator: +
+      - interval_expression:
+        - keyword: INTERVAL
+        - expression:
+          - numeric_literal: '1'
+        - date_part: DAY
+    - keyword: DO
+    - statement:
+      - truncate_statement:
+        - keyword: TRUNCATE
+        - keyword: TABLE
+        - table_reference:
+          - naked_identifier: myschema
+          - dot: .
+          - naked_identifier: mytable
+- statement_terminator: ;
+- statement:
+  - alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: myevent
+    - keyword: DISABLE
+- statement_terminator: ;
+- statement:
+  - alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: myevent
+    - keyword: RENAME
+    - keyword: TO
+    - object_reference:
+      - naked_identifier: yourevent
+- statement_terminator: ;
+- statement:
+  - alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: olddb
+      - dot: .
+      - naked_identifier: myevent
+    - keyword: RENAME
+    - keyword: TO
+    - object_reference:
+      - naked_identifier: newdb
+      - dot: .
+      - naked_identifier: myevent
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/create_event.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/create_event.sql
@@ -1,0 +1,40 @@
+CREATE EVENT myevent
+    ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR
+    DO
+      UPDATE myschema.mytable SET mycol = mycol + 1;
+
+CREATE EVENT e_totals
+    ON SCHEDULE AT '2006-02-10 23:59:00'
+    DO INSERT INTO test.totals VALUES (NOW());
+
+CREATE EVENT e_hourly
+    ON SCHEDULE
+      EVERY 1 HOUR
+    COMMENT 'Clears out sessions table each hour.'
+    DO
+      DELETE FROM site_activity.sessions;
+
+CREATE EVENT e_daily
+    ON SCHEDULE
+      EVERY 1 DAY
+    COMMENT 'Saves total number of sessions then clears the table each day'
+    DO
+      BEGIN
+        INSERT INTO site_activity.totals (time, total)
+          SELECT CURRENT_TIMESTAMP, COUNT(*)
+            FROM site_activity.sessions;
+        DELETE FROM site_activity.sessions;
+      END;
+
+CREATE EVENT e_call_myproc
+    ON SCHEDULE
+      AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+    DO CALL myproc(5, 27);
+
+CREATE EVENT e
+  ON SCHEDULE EVERY interval SECOND
+  STARTS CURRENT_TIMESTAMP + INTERVAL 10 SECOND
+  ENDS CURRENT_TIMESTAMP + INTERVAL 2 MINUTE
+  ON COMPLETION PRESERVE
+  DO
+    INSERT INTO d.t1 VALUES ROW(NULL, NOW(), FLOOR(RAND()*100));

--- a/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/create_event.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/create_event.yml
@@ -1,0 +1,292 @@
+file:
+- statement:
+  - create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: myevent
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+      - bare_function: CURRENT_TIMESTAMP
+      - binary_operator: +
+      - interval_expression:
+        - keyword: INTERVAL
+        - expression:
+          - numeric_literal: '1'
+        - date_part: HOUR
+    - keyword: DO
+    - statement:
+      - update_statement:
+        - keyword: UPDATE
+        - table_reference:
+          - naked_identifier: myschema
+          - dot: .
+          - naked_identifier: mytable
+        - set_clause_list:
+          - keyword: SET
+          - set_clause:
+            - column_reference:
+              - naked_identifier: mycol
+            - comparison_operator:
+              - raw_comparison_operator: =
+            - expression:
+              - column_reference:
+                - naked_identifier: mycol
+              - binary_operator: +
+              - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+  - create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: e_totals
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+      - quoted_literal: '''2006-02-10 23:59:00'''
+    - keyword: DO
+    - statement:
+      - insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: totals
+        - values_clause:
+          - keyword: VALUES
+          - bracketed:
+            - start_bracket: (
+            - expression:
+              - function:
+                - function_name:
+                  - function_name_identifier: NOW
+                - function_contents:
+                  - bracketed:
+                    - start_bracket: (
+                    - end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: e_hourly
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+      - numeric_literal: '1'
+    - date_part: HOUR
+    - comment_clause:
+      - keyword: COMMENT
+      - quoted_literal: '''Clears out sessions table each hour.'''
+    - keyword: DO
+    - statement:
+      - delete_statement:
+        - keyword: DELETE
+        - from_clause:
+          - keyword: FROM
+          - from_expression:
+            - from_expression_element:
+              - table_expression:
+                - table_reference:
+                  - naked_identifier: site_activity
+                  - dot: .
+                  - naked_identifier: sessions
+- statement_terminator: ;
+- statement:
+  - create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: e_daily
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+      - numeric_literal: '1'
+    - date_part: DAY
+    - comment_clause:
+      - keyword: COMMENT
+      - quoted_literal: '''Saves total number of sessions then clears the table each day'''
+    - keyword: DO
+    - statement:
+      - transaction_statement:
+        - keyword: BEGIN
+        - statement:
+          - insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+              - naked_identifier: site_activity
+              - dot: .
+              - naked_identifier: totals
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                - naked_identifier: time
+              - comma: ','
+              - column_reference:
+                - naked_identifier: total
+              - end_bracket: )
+            - select_statement:
+              - select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                  - bare_function: CURRENT_TIMESTAMP
+                - comma: ','
+                - select_clause_element:
+                  - function:
+                    - function_name:
+                      - function_name_identifier: COUNT
+                    - function_contents:
+                      - bracketed:
+                        - start_bracket: (
+                        - star: '*'
+                        - end_bracket: )
+              - from_clause:
+                - keyword: FROM
+                - from_expression:
+                  - from_expression_element:
+                    - table_expression:
+                      - table_reference:
+                        - naked_identifier: site_activity
+                        - dot: .
+                        - naked_identifier: sessions
+- statement_terminator: ;
+- statement:
+  - delete_statement:
+    - keyword: DELETE
+    - from_clause:
+      - keyword: FROM
+      - from_expression:
+        - from_expression_element:
+          - table_expression:
+            - table_reference:
+              - naked_identifier: site_activity
+              - dot: .
+              - naked_identifier: sessions
+- statement_terminator: ;
+- statement:
+  - transaction_statement:
+    - keyword: END
+- statement_terminator: ;
+- statement:
+  - create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: e_call_myproc
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+      - bare_function: CURRENT_TIMESTAMP
+      - binary_operator: +
+      - interval_expression:
+        - keyword: INTERVAL
+        - expression:
+          - numeric_literal: '1'
+        - date_part: DAY
+    - keyword: DO
+    - statement:
+      - call_statement:
+        - keyword: CALL
+        - function:
+          - function_name:
+            - function_name_identifier: myproc
+          - function_contents:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                - numeric_literal: '5'
+              - comma: ','
+              - expression:
+                - numeric_literal: '27'
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+  - create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: e
+    - keyword: ON
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+      - interval_expression:
+        - keyword: interval
+        - date_part: SECOND
+    - keyword: STARTS
+    - expression:
+      - bare_function: CURRENT_TIMESTAMP
+      - binary_operator: +
+      - interval_expression:
+        - keyword: INTERVAL
+        - expression:
+          - numeric_literal: '10'
+        - date_part: SECOND
+    - keyword: ENDS
+    - expression:
+      - bare_function: CURRENT_TIMESTAMP
+      - binary_operator: +
+      - interval_expression:
+        - keyword: INTERVAL
+        - expression:
+          - numeric_literal: '2'
+        - date_part: MINUTE
+    - keyword: ON
+    - keyword: COMPLETION
+    - keyword: PRESERVE
+    - keyword: DO
+    - statement:
+      - insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+          - naked_identifier: d
+          - dot: .
+          - naked_identifier: t1
+        - values_clause:
+          - keyword: VALUES
+          - keyword: ROW
+          - bracketed:
+            - start_bracket: (
+            - null_literal: 'NULL'
+            - comma: ','
+            - expression:
+              - function:
+                - function_name:
+                  - function_name_identifier: NOW
+                - function_contents:
+                  - bracketed:
+                    - start_bracket: (
+                    - end_bracket: )
+            - comma: ','
+            - expression:
+              - function:
+                - function_name:
+                  - function_name_identifier: FLOOR
+                - function_contents:
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                      - function:
+                        - function_name:
+                          - function_name_identifier: RAND
+                        - function_contents:
+                          - bracketed:
+                            - start_bracket: (
+                            - end_bracket: )
+                      - binary_operator: '*'
+                      - numeric_literal: '100'
+                    - end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;

--- a/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/drop_event.sql
+++ b/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/drop_event.sql
@@ -1,0 +1,3 @@
+DROP EVENT test;
+
+DROP EVENT IF EXISTS test;

--- a/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/drop_event.yml
+++ b/crates/lib-dialects/test/fixtures/dialects/mysql/sqlfluff/drop_event.yml
@@ -1,0 +1,17 @@
+file:
+- statement:
+  - drop_event_statement:
+    - keyword: DROP
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: test
+- statement_terminator: ;
+- statement:
+  - drop_event_statement:
+    - keyword: DROP
+    - keyword: EVENT
+    - keyword: IF
+    - keyword: EXISTS
+    - object_reference:
+      - naked_identifier: test
+- statement_terminator: ;


### PR DESCRIPTION
> Stacked on sqruff #4077. Merge #4077 first.
> https://github.com/quarylabs/sqruff/pull/4077

## Summary
## Summary

- parse MySQL `CREATE EVENT`, `ALTER EVENT`, and `DROP EVENT` statements
- support unit-only interval expressions used by event schedules
- port the upstream event fixtures and generated parse expectations

## Testing

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `bazel test //...`

Ported from SQLFluff e230b7c7a2fdbd752fc3d191e47a87db6807ddd1
https://github.com/sqlfluff/sqlfluff/pull/6646
https://github.com/sqlfluff/sqlfluff/commit/e230b7c7a2fdbd752fc3d191e47a87db6807ddd1

## Validation
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `bazel test //...`
